### PR TITLE
Add `MasterHandle::get_decode_log_level`.

### DIFF
--- a/dnp3/examples/master-main.rs
+++ b/dnp3/examples/master-main.rs
@@ -44,8 +44,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .as_str()
         {
             "x" => return Ok(()),
-            "dln" => runtime.block_on(master.set_decode_log_level(DecodeLogLevel::Nothing)),
-            "dlv" => runtime.block_on(master.set_decode_log_level(DecodeLogLevel::ObjectValues)),
+            "dln" => {
+                runtime
+                    .block_on(master.set_decode_log_level(DecodeLogLevel::Nothing))
+                    .ok();
+            }
+            "dlv" => {
+                runtime
+                    .block_on(master.set_decode_log_level(DecodeLogLevel::ObjectValues))
+                    .ok();
+            }
             "cmd" => {
                 if let Err(err) = runtime.block_on(association.operate(
                     CommandMode::SelectBeforeOperate,

--- a/dnp3/examples/master-tokio-main.rs
+++ b/dnp3/examples/master-tokio-main.rs
@@ -40,11 +40,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         match reader.next().await.unwrap()?.as_str() {
             "x" => return Ok(()),
-            "dln" => master.set_decode_log_level(DecodeLogLevel::Nothing).await,
+            "dln" => {
+                master
+                    .set_decode_log_level(DecodeLogLevel::Nothing)
+                    .await
+                    .ok();
+            }
             "dlv" => {
                 master
                     .set_decode_log_level(DecodeLogLevel::ObjectValues)
                     .await
+                    .ok();
             }
             "rao" => {
                 if let Err(err) = association

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -9,8 +9,9 @@ use std::error::Error;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::oneshot::error::RecvError;
 
-/// Indicates that a task has shutdown
-pub(crate) struct Shutdown;
+/// Indicates that the master task has shutdown
+#[derive(Copy, Clone, Debug)]
+pub struct Shutdown;
 
 /// Errors that can occur when adding an association
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -304,6 +305,12 @@ impl From<TaskError> for TimeSyncError {
     }
 }
 
+impl From<RecvError> for Shutdown {
+    fn from(_: RecvError) -> Self {
+        Shutdown
+    }
+}
+
 impl From<RecvError> for AssociationError {
     fn from(_: RecvError) -> Self {
         AssociationError::Shutdown
@@ -325,6 +332,12 @@ impl From<RecvError> for CommandError {
 impl From<RecvError> for TimeSyncError {
     fn from(_: RecvError) -> Self {
         TimeSyncError::Task(TaskError::Shutdown)
+    }
+}
+
+impl<T> From<SendError<T>> for Shutdown {
+    fn from(_: SendError<T>) -> Self {
+        Shutdown
     }
 }
 

--- a/dnp3/src/master/runner.rs
+++ b/dnp3/src/master/runner.rs
@@ -183,6 +183,9 @@ impl Runner {
             MasterMsg::SetDecodeLogLevel(level) => {
                 self.level = level;
             }
+            MasterMsg::GetDecodeLogLevel(promise) => {
+                promise.complete(Ok(self.level));
+            }
         }
     }
 

--- a/ffi/dnp3-ffi/src/logging.rs
+++ b/ffi/dnp3-ffi/src/logging.rs
@@ -55,3 +55,14 @@ impl From<ffi::DecodeLogLevel> for DecodeLogLevel {
         }
     }
 }
+
+impl From<DecodeLogLevel> for ffi::DecodeLogLevel {
+    fn from(from: DecodeLogLevel) -> Self {
+        match from {
+            DecodeLogLevel::Nothing => ffi::DecodeLogLevel::Nothing,
+            DecodeLogLevel::Header => ffi::DecodeLogLevel::Header,
+            DecodeLogLevel::ObjectHeaders => ffi::DecodeLogLevel::ObjectHeaders,
+            DecodeLogLevel::ObjectValues => ffi::DecodeLogLevel::ObjectValues,
+        }
+    }
+}

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -68,6 +68,23 @@ pub unsafe fn master_set_decode_log_level(master: *mut Master, level: ffi::Decod
     }
 }
 
+pub unsafe fn master_get_decode_log_level(master: *mut Master) -> ffi::DecodeLogLevel {
+    if tokio::runtime::Handle::try_current().is_err() {
+        if let Some(master) = master.as_mut() {
+            if let Ok(level) = master
+                .runtime
+                .block_on(master.handle.get_decode_log_level())
+            {
+                return level.into();
+            }
+        }
+    } else {
+        log::warn!("Tried calling 'master_get_decode_log_level' from within a tokio thread");
+    }
+
+    ffi::DecodeLogLevel::Nothing
+}
+
 fn convert_event_classes(config: &ffi::EventClasses) -> EventClasses {
     EventClasses::new(config.class1, config.class2, config.class3)
 }

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -121,17 +121,35 @@ pub fn define(
         )?
         .param(
             "level",
-            Type::Enum(decode_log_level_enum),
+            Type::Enum(decode_log_level_enum.clone()),
             "Decode log level",
         )?
         .return_type(ReturnType::void())?
         .doc("Set the master decoding level for log messages")?
         .build()?;
 
+    let get_decode_log_level_fn = lib
+        .declare_native_function("master_get_decode_log_level")?
+        .param(
+            "master",
+            Type::ClassRef(master_class.clone()),
+            "Master to modify",
+        )?
+        .return_type(ReturnType::new(
+            Type::Enum(decode_log_level_enum),
+            "Decode log level",
+        ))?
+        .doc(
+            doc("Get the master decoding level for log messages")
+                .warning("This cannot be called from within a callback."),
+        )?
+        .build()?;
+
     lib.define_class(&master_class)?
         .destructor(&destroy_fn)?
         .method("AddAssociation", &add_association_fn)?
         .method("SetDecodeLogLevel", &set_decode_log_level_fn)?
+        .method("GetDecodeLogLevel", &get_decode_log_level_fn)?
         .doc(
             doc("Master channel of communication")
             .details("To communicate with a particular outstation, you need to add an association with {class:Master.AddAssociation()}.")


### PR DESCRIPTION
Fix #18.

Also done in this PR:
- Removed all the `on_send_failure` from messages, since we don't use them anymore.
- Added a return type of `Result<(), Shutdown>` to all the methods that didn't have a return type.