### PR TITLE
Fix numerous issues with time sync task + optional system time value

### DIFF
--- a/dnp3/src/app/format/write.rs
+++ b/dnp3/src/app/format/write.rs
@@ -1,5 +1,7 @@
 use crate::app::enums::{FunctionCode, QualifierCode};
-use crate::app::header::{Control, RequestHeader};
+use crate::app::header::{Control, RequestHeader, ResponseFunction, ResponseHeader, IIN};
+#[cfg(test)]
+use crate::app::parse::parser::{DecodeSettings, ParsedFragment};
 use crate::app::parse::traits::{FixedSizeVariation, Index};
 use crate::app::sequence::Sequence;
 use crate::app::variations::Variation;
@@ -19,7 +21,22 @@ pub(crate) fn start_request<'a, 'b>(
     Ok(HeaderWriter { cursor })
 }
 
+pub(crate) fn start_response<'a, 'b>(
+    control: Control,
+    function: ResponseFunction,
+    iin: IIN,
+    cursor: &'b mut WriteCursor<'a>,
+) -> Result<HeaderWriter<'a, 'b>, WriteError> {
+    let header = ResponseHeader::new(control, function, iin);
+    header.write(cursor)?;
+    Ok(HeaderWriter { cursor })
+}
+
 impl<'a, 'b> HeaderWriter<'a, 'b> {
+    pub(crate) fn inner(self) -> &'b mut WriteCursor<'a> {
+        self.cursor
+    }
+
     pub(crate) fn write_class1230(&mut self) -> Result<(), WriteError> {
         self.write_all_objects_header(Variation::Group60Var2)?;
         self.write_all_objects_header(Variation::Group60Var3)?;
@@ -91,6 +108,11 @@ impl<'a, 'b> HeaderWriter<'a, 'b> {
         self.cursor.write_u8(1)?;
         item.write(self.cursor)?;
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn to_parsed(&'a self) -> ParsedFragment<'a> {
+        ParsedFragment::parse(DecodeSettings::none(), self.cursor.written()).unwrap()
     }
 }
 

--- a/dnp3/src/app/header.rs
+++ b/dnp3/src/app/header.rs
@@ -51,6 +51,26 @@ impl Control {
         }
     }
 
+    pub(crate) fn response(seq: Sequence) -> Self {
+        Self {
+            fir: true,
+            fin: true,
+            con: false,
+            uns: false,
+            seq,
+        }
+    }
+
+    pub(crate) fn response_with_confirmation(seq: Sequence) -> Self {
+        Self {
+            fir: true,
+            fin: true,
+            con: true,
+            uns: false,
+            seq,
+        }
+    }
+
     pub(crate) fn unsolicited(seq: Sequence) -> Self {
         Self {
             fir: true,
@@ -315,13 +335,11 @@ impl IIN {
             || self.iin2.get_parameter_error()
     }
 
-    /*
-        pub(crate) fn write(self, cursor: &mut WriteCursor) -> Result<(), WriteError> {
-            cursor.write_u8(self.iin1.value)?;
-            cursor.write_u8(self.iin2.value)?;
-            Ok(())
-        }
-    */
+    pub(crate) fn write(self, cursor: &mut WriteCursor) -> Result<(), WriteError> {
+        cursor.write_u8(self.iin1.value)?;
+        cursor.write_u8(self.iin2.value)?;
+        Ok(())
+    }
 }
 
 impl Default for IIN {
@@ -381,6 +399,15 @@ impl ResponseFunction {
     }
 }
 
+impl From<ResponseFunction> for FunctionCode {
+    fn from(from: ResponseFunction) -> Self {
+        match from {
+            ResponseFunction::Response => FunctionCode::Response,
+            ResponseFunction::UnsolicitedResponse => FunctionCode::UnsolicitedResponse,
+        }
+    }
+}
+
 impl RequestHeader {
     pub(crate) fn new(control: Control, function: FunctionCode) -> Self {
         Self { control, function }
@@ -402,13 +429,8 @@ impl ResponseHeader {
         }
     }
 
-    /*
     pub(crate) fn function(self) -> FunctionCode {
-        if self.unsolicited {
-            FunctionCode::UnsolicitedResponse
-        } else {
-            FunctionCode::Response
-        }
+        self.function.into()
     }
 
     pub(crate) fn write(self, cursor: &mut WriteCursor) -> Result<(), WriteError> {
@@ -417,5 +439,4 @@ impl ResponseHeader {
         self.iin.write(cursor)?;
         Ok(())
     }
-    */
 }

--- a/dnp3/src/app/measurement.rs
+++ b/dnp3/src/app/measurement.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::app::flags::Flags;
 use crate::app::types::{DoubleBit, Timestamp};
 use crate::util::bit::bits::*;
@@ -49,11 +51,11 @@ impl From<Option<Time>> for Timestamp {
 impl Time {
     pub(crate) fn checked_add(self, x: u16) -> Option<Self> {
         match self {
-            Time::Synchronized(ts) => match ts.checked_add(x) {
+            Time::Synchronized(ts) => match ts.checked_add(Duration::from_millis(x as u64)) {
                 Some(x) => Some(Time::Synchronized(x)),
                 None => None,
             },
-            Time::NotSynchronized(ts) => match ts.checked_add(x) {
+            Time::NotSynchronized(ts) => match ts.checked_add(Duration::from_millis(x as u64)) {
                 Some(x) => Some(Time::NotSynchronized(x)),
                 None => None,
             },

--- a/dnp3/src/app/parse/parser.rs
+++ b/dnp3/src/app/parse/parser.rs
@@ -19,6 +19,15 @@ pub(crate) struct DecodeSettings {
     level: DecodeLogLevel,
 }
 
+impl DecodeSettings {
+    pub(crate) fn none() -> Self {
+        DecodeSettings {
+            is_transmit: false,
+            level: DecodeLogLevel::Nothing,
+        }
+    }
+}
+
 impl DecodeLogLevel {
     pub(crate) fn transmit(self) -> DecodeSettings {
         DecodeSettings {
@@ -398,6 +407,14 @@ impl HeaderDetails<'_> {
             HeaderDetails::TwoByteCount(_, _) => QualifierCode::Count16,
             HeaderDetails::OneByteCountAndPrefix(_, _) => QualifierCode::CountAndPrefix8,
             HeaderDetails::TwoByteCountAndPrefix(_, _) => QualifierCode::CountAndPrefix16,
+        }
+    }
+
+    pub(crate) fn count(&self) -> Option<&CountVariation> {
+        match self {
+            HeaderDetails::OneByteCount(_, objects) => Some(objects),
+            HeaderDetails::TwoByteCount(_, objects) => Some(objects),
+            _ => None,
         }
     }
 }

--- a/dnp3/src/master/association.rs
+++ b/dnp3/src/master/association.rs
@@ -1,7 +1,7 @@
 use crate::app::header::{ResponseHeader, IIN};
 use crate::app::parse::parser::HeaderCollection;
 use crate::app::sequence::Sequence;
-use crate::master::error::{AssociationError, TaskError};
+use crate::master::error::{AssociationError, TaskError, TimeSyncError};
 use crate::master::extract::extract_measurements;
 use crate::master::handle::{AssociationHandler, Promise};
 use crate::master::messages::AssociationMsgType;
@@ -233,17 +233,12 @@ impl Association {
         self.auto_tasks.clear_restart_iin = AutoTaskState::Failed;
     }
 
-    pub(crate) fn on_time_sync_iin_response(&mut self, iin: IIN) {
-        self.auto_tasks.time_sync = if iin.iin1.get_need_time() {
-            log::warn!("device failed to clear NEED_TIME IIN bit");
-            AutoTaskState::Failed
-        } else {
-            AutoTaskState::Idle
-        }
+    pub(crate) fn on_time_sync_success(&mut self) {
+        self.auto_tasks.time_sync = AutoTaskState::Idle;
     }
 
-    pub(crate) fn on_time_sync_iin_failure(&mut self) {
-        log::warn!("auto time sync failed");
+    pub(crate) fn on_time_sync_failure(&mut self, err: TimeSyncError) {
+        log::warn!("auto time sync failed: {}", err);
         self.auto_tasks.time_sync = AutoTaskState::Failed;
     }
 
@@ -310,7 +305,7 @@ impl Association {
         if self.auto_tasks.time_sync.is_pending() {
             if let Some(procedure) = self.config.auto_time_sync {
                 return Next::Now(
-                    TimeSync(TimeSyncTask::get_procedure(procedure, true, Promise::None)).wrap(),
+                    TimeSync(TimeSyncTask::get_procedure(procedure, Promise::None)).wrap(),
                 );
             }
         }

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -85,6 +85,7 @@ pub enum TimeSyncError {
     BadOutstationTimeDelay(u16),
     Overflow,
     StillNeedsTime,
+    SystemTimeNotAvailable,
     IINError(IIN2),
 }
 
@@ -215,6 +216,7 @@ impl std::fmt::Display for TimeSyncError {
             TimeSyncError::Overflow => f.write_str("overflow in calculation"),
             TimeSyncError::ClockRollback => f.write_str("detected a clock rollback"),
             TimeSyncError::StillNeedsTime => f.write_str("outstation did not clear NEED_TIME bit"),
+            TimeSyncError::SystemTimeNotAvailable => f.write_str("system time not available"),
             TimeSyncError::IINError(iin2) => write!(f, "outstation indicated an error: {}", iin2),
         }
     }

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -133,7 +133,7 @@ impl AssociationHandle {
         procedure: TimeSyncProcedure,
     ) -> Result<(), TimeSyncError> {
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), TimeSyncError>>();
-        let task = TimeSyncTask::get_procedure(procedure, false, Promise::OneShot(tx));
+        let task = TimeSyncTask::get_procedure(procedure, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?
     }

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -3,6 +3,7 @@ use crate::app::header::ResponseHeader;
 use crate::app::measurement::*;
 use crate::app::parse::bytes::Bytes;
 use crate::app::parse::DecodeLogLevel;
+use crate::app::types::Timestamp;
 use crate::app::variations::Variation;
 use crate::master::association::{Association, Configuration};
 use crate::master::error::{AssociationError, CommandError, PollError, TaskError, TimeSyncError};
@@ -204,8 +205,8 @@ impl<T> Listener<T> {
 /// callbacks associated with a single master to outstation association
 pub trait AssociationHandler: Send {
     /// Retrieve the system time used for time synchronization
-    fn get_system_time(&self) -> SystemTime {
-        SystemTime::now()
+    fn get_system_time(&self) -> Option<Timestamp> {
+        Timestamp::try_from_system_time(SystemTime::now())
     }
 
     /// retrieve a handler used to process integrity polls

--- a/dnp3/src/master/tasks/time.rs
+++ b/dnp3/src/master/tasks/time.rs
@@ -10,14 +10,13 @@ use crate::master::handle::Promise;
 use crate::master::request::TimeSyncProcedure;
 use crate::master::tasks::NonReadTask;
 use crate::util::cursor::WriteError;
-use std::convert::TryFrom;
-use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+use std::time::Duration;
 use tokio::time::Instant;
 
 enum State {
-    MeasureDelay,
+    MeasureDelay(Option<Instant>),
     WriteAbsoluteTime(Timestamp),
-    RecordCurrentTime(Option<SystemTime>),
+    RecordCurrentTime(Option<Timestamp>),
     WriteLastRecordedTime(Timestamp),
 }
 
@@ -30,7 +29,7 @@ impl TimeSyncProcedure {
     fn get_start_state(&self) -> State {
         match self {
             TimeSyncProcedure::LAN => State::RecordCurrentTime(None),
-            TimeSyncProcedure::NonLAN => State::MeasureDelay,
+            TimeSyncProcedure::NonLAN => State::MeasureDelay(None),
         }
     }
 }
@@ -55,28 +54,50 @@ impl TimeSyncTask {
         NonReadTask::TimeSync(self)
     }
 
+    pub(crate) fn start(mut self, association: &mut Association) -> Option<Self> {
+        match &mut self.state {
+            State::MeasureDelay(time) => {
+                time.replace(Instant::now());
+
+                match association.get_system_time() {
+                    Some(_) => Some(self),
+                    None => {
+                        self.report_error(association, TimeSyncError::SystemTimeNotAvailable);
+                        None
+                    }
+                }
+            }
+            State::WriteAbsoluteTime(_) => Some(self),
+            State::RecordCurrentTime(time) => {
+                *time = association.get_system_time();
+
+                match time {
+                    Some(_) => Some(self),
+                    None => {
+                        self.report_error(association, TimeSyncError::SystemTimeNotAvailable);
+                        None
+                    }
+                }
+            }
+            State::WriteLastRecordedTime(_) => Some(self),
+        }
+    }
+
     pub(crate) fn function(&self) -> FunctionCode {
         match self.state {
-            State::MeasureDelay => FunctionCode::DelayMeasure,
+            State::MeasureDelay(_) => FunctionCode::DelayMeasure,
             State::WriteAbsoluteTime(_) => FunctionCode::Write,
             State::RecordCurrentTime(_) => FunctionCode::RecordCurrentTime,
             State::WriteLastRecordedTime(_) => FunctionCode::Write,
         }
     }
 
-    pub(crate) fn write(
-        &mut self,
-        writer: &mut HeaderWriter,
-        association: &Association,
-    ) -> Result<(), WriteError> {
-        match &mut self.state {
-            State::MeasureDelay => Ok(()),
-            State::WriteAbsoluteTime(x) => writer.write_count_of_one(Group50Var1 { time: *x }),
-            State::RecordCurrentTime(time) => {
-                time.replace(association.get_system_time());
-                Ok(())
-            }
-            State::WriteLastRecordedTime(x) => writer.write_count_of_one(Group50Var3 { time: *x }),
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+        match self.state {
+            State::MeasureDelay(_) => Ok(()),
+            State::WriteAbsoluteTime(x) => writer.write_count_of_one(Group50Var1 { time: x }),
+            State::RecordCurrentTime(_) => Ok(()),
+            State::WriteLastRecordedTime(x) => writer.write_count_of_one(Group50Var3 { time: x }),
         }
     }
 
@@ -94,11 +115,10 @@ impl TimeSyncTask {
     pub(crate) fn handle(
         self,
         association: &mut Association,
-        request_tx: Instant,
         response: Response,
     ) -> Option<NonReadTask> {
         match self.state {
-            State::MeasureDelay => self.handle_delay_measure(association, request_tx, response),
+            State::MeasureDelay(time) => self.handle_delay_measure(association, time, response),
             State::WriteAbsoluteTime(_) => self.handle_write_absolute_time(association, response),
             State::RecordCurrentTime(time) => {
                 self.handle_record_current_time(association, time, response)
@@ -112,9 +132,10 @@ impl TimeSyncTask {
     fn handle_delay_measure(
         self,
         association: &mut Association,
-        request_tx: Instant,
+        request_tx: Option<Instant>,
         response: Response,
     ) -> Option<NonReadTask> {
+        let request_tx = request_tx.unwrap_or_else(Instant::now);
         let now = Instant::now();
 
         let interval = match now.checked_duration_since(request_tx) {
@@ -166,13 +187,13 @@ impl TimeSyncTask {
                 }
             };
 
-        let time = match association.get_system_time().duration_since(UNIX_EPOCH) {
-            Err(err) => {
-                log::error!("{}", err);
-                self.report_error(association, TimeSyncError::SystemTimeNotUnix);
+        let time = match association.get_system_time() {
+            Some(time) => time,
+            None => {
+                log::warn!("system time not available");
+                self.report_error(association, TimeSyncError::SystemTimeNotAvailable);
                 return None;
             }
-            Ok(x) => x,
         };
 
         let timestamp = match Self::get_timestamp(time, propagation_delay) {
@@ -215,7 +236,7 @@ impl TimeSyncTask {
     fn handle_record_current_time(
         self,
         association: &mut Association,
-        recorded_time: Option<SystemTime>,
+        recorded_time: Option<Timestamp>,
         response: Response,
     ) -> Option<NonReadTask> {
         if !response.raw_objects.is_empty() {
@@ -226,17 +247,11 @@ impl TimeSyncTask {
             return None;
         }
 
-        let recorded_time = recorded_time.unwrap_or_else(|| association.get_system_time());
-        match Self::convert_to_timestamp(recorded_time) {
-            Ok(timestamp) => Some(
-                self.change_state(State::WriteLastRecordedTime(timestamp))
-                    .wrap(),
-            ),
-            Err(err) => {
-                self.report_error(association, err);
-                None
-            }
-        }
+        let recorded_time = recorded_time.expect("Recorded time should be set by the start method");
+        Some(
+            self.change_state(State::WriteLastRecordedTime(recorded_time))
+                .wrap(),
+        )
     }
 
     fn handle_write_last_recorded_time(
@@ -261,18 +276,12 @@ impl TimeSyncTask {
         None
     }
 
-    fn convert_to_timestamp(time: SystemTime) -> Result<Timestamp, TimeSyncError> {
-        Ok(Timestamp::new(u64::try_from(
-            time.duration_since(UNIX_EPOCH)?.as_millis(),
-        )?))
-    }
-
     fn get_timestamp(
-        now: Duration,
+        now: Timestamp,
         propagation_delay: Duration,
     ) -> Result<Timestamp, TimeSyncError> {
         match now.checked_add(propagation_delay) {
-            Some(x) => Ok(Timestamp::new(u64::try_from(x.as_millis())?)),
+            Some(x) => Ok(x),
             None => Err(TimeSyncError::Overflow),
         }
     }
@@ -298,12 +307,6 @@ impl From<std::num::TryFromIntError> for TimeSyncError {
     }
 }
 
-impl From<SystemTimeError> for TimeSyncError {
-    fn from(_: SystemTimeError) -> Self {
-        TimeSyncError::Overflow
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,30 +320,64 @@ mod tests {
     use crate::util::cursor::WriteCursor;
     use std::cell::Cell;
     use std::future::Future;
+    use std::time::SystemTime;
+
+    struct SingleTimestampTestHandler {
+        time: Cell<Option<Timestamp>>,
+        handler: NullHandler,
+    }
+
+    impl SingleTimestampTestHandler {
+        fn new(time: Timestamp) -> Self {
+            Self {
+                time: Cell::new(Some(time)),
+                handler: NullHandler,
+            }
+        }
+    }
+
+    impl AssociationHandler for SingleTimestampTestHandler {
+        fn get_system_time(&self) -> Option<Timestamp> {
+            self.time.take()
+        }
+
+        fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
+            &mut self.handler
+        }
+
+        fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
+            &mut self.handler
+        }
+
+        fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+            &mut self.handler
+        }
+    }
 
     mod non_lan {
+
         use super::*;
         const OUTSTATION_DELAY_MS: u16 = 100;
         const TOTAL_DELAY_MS: u16 = 200;
         const PROPAGATION_DELAY_MS: u16 = (TOTAL_DELAY_MS - OUTSTATION_DELAY_MS) / 2;
 
         struct TestHandler {
-            time: SystemTime,
+            time: Timestamp,
             handler: NullHandler,
         }
 
         impl TestHandler {
-            fn new(time: SystemTime) -> Self {
+            fn new(time: Timestamp) -> Self {
                 Self {
-                    time,
+                    time: time,
                     handler: NullHandler,
                 }
             }
         }
 
         impl AssociationHandler for TestHandler {
-            fn get_system_time(&self) -> SystemTime {
-                self.time
+            fn get_system_time(&self) -> Option<Timestamp> {
+                Some(self.time)
             }
 
             fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
@@ -358,145 +395,185 @@ mod tests {
 
         #[tokio::test]
         async fn success() {
-            run_nonlan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_measure_delay_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
-                    let mut task =
-                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    send_write_response(task, request_tx, &mut association);
-                    assert!(rx.await.unwrap().is_ok());
-                },
-            )
+            run_nonlan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_measure_delay_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                let task = send_measure_delay_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                send_write_response(task, &mut association);
+                assert!(rx.await.unwrap().is_ok());
+            })
             .await;
         }
 
         #[tokio::test]
         async fn with_16bit_count() {
-            run_nonlan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_measure_delay_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+            run_nonlan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_measure_delay_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
 
-                    let mut task = {
-                        let mut buffer = [0; 20];
-                        let mut cursor = WriteCursor::new(&mut buffer);
-                        let writer = start_response(
-                            Control::response(Sequence::default()),
-                            ResponseFunction::Response,
-                            IIN::default(),
-                            &mut cursor,
-                        )
-                        .unwrap();
-                        {
-                            let cursor = writer.inner();
-                            Group52Var2::VARIATION.write(cursor).unwrap();
-                            QualifierCode::Count16.write(cursor).unwrap();
-                            cursor.write_u16_le(1).unwrap();
-                            Group52Var2 {
-                                time: OUTSTATION_DELAY_MS,
-                            }
-                            .write(cursor)
-                            .unwrap();
-                        }
-                        let response =
-                            ParsedFragment::parse(DecodeSettings::none(), cursor.written())
-                                .unwrap()
-                                .to_response()
-                                .unwrap();
-
-                        task.handle(request_tx, &mut association, response)
-                    }
+                let task = {
+                    let mut buffer = [0; 20];
+                    let mut cursor = WriteCursor::new(&mut buffer);
+                    let writer = start_response(
+                        Control::response(Sequence::default()),
+                        ResponseFunction::Response,
+                        IIN::default(),
+                        &mut cursor,
+                    )
                     .unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    send_write_response(task, request_tx, &mut association);
-                    assert!(rx.await.unwrap().is_ok());
-                },
-            )
+                    {
+                        let cursor = writer.inner();
+                        Group52Var2::VARIATION.write(cursor).unwrap();
+                        QualifierCode::Count16.write(cursor).unwrap();
+                        cursor.write_u16_le(1).unwrap();
+                        Group52Var2 {
+                            time: OUTSTATION_DELAY_MS,
+                        }
+                        .write(cursor)
+                        .unwrap();
+                    }
+                    let response = ParsedFragment::parse(DecodeSettings::none(), cursor.written())
+                        .unwrap()
+                        .to_response()
+                        .unwrap();
+
+                    task.handle(&mut association, response)
+                }
+                .unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                send_write_response(task, &mut association);
+                assert!(rx.await.unwrap().is_ok());
+            })
             .await;
         }
 
         #[tokio::test]
         async fn delay_reported_by_outstation_greater_than_actual_delay() {
-            run_nonlan_timesync_test(
-                |mut task, _system_time, request_tx, mut association, rx| async move {
-                    check_measure_delay_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(1)).await; // This delay is less than the reported delay of the outstation
-                    assert!(
-                        send_measure_delay_response(task, request_tx, &mut association).is_none()
-                    );
-                    assert_eq!(
-                        Err(TimeSyncError::BadOutstationTimeDelay(OUTSTATION_DELAY_MS)),
-                        rx.await.unwrap()
-                    );
-                },
-            )
+            run_nonlan_timesync_test(|task, _system_time, mut association, rx| async move {
+                let task = check_measure_delay_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(1)).await; // This delay is less than the reported delay of the outstation
+                assert!(send_measure_delay_response(task, &mut association).is_none());
+                assert_eq!(
+                    Err(TimeSyncError::BadOutstationTimeDelay(OUTSTATION_DELAY_MS)),
+                    rx.await.unwrap()
+                );
+            })
             .await;
         }
 
         #[tokio::test]
         async fn empty_measure_delay_response() {
-            run_nonlan_timesync_test(
-                |mut task, _system_time, request_tx, mut association, rx| async move {
-                    check_measure_delay_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
-                    {
-                        let mut buffer = [0; 20];
-                        let mut cursor = WriteCursor::new(&mut buffer);
-                        let writer = start_response(
-                            Control::response(Sequence::default()),
-                            ResponseFunction::Response,
-                            IIN::default(),
-                            &mut cursor,
-                        )
-                        .unwrap();
+            run_nonlan_timesync_test(|task, _system_time, mut association, rx| async move {
+                let task = check_measure_delay_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                {
+                    let mut buffer = [0; 20];
+                    let mut cursor = WriteCursor::new(&mut buffer);
+                    let writer = start_response(
+                        Control::response(Sequence::default()),
+                        ResponseFunction::Response,
+                        IIN::default(),
+                        &mut cursor,
+                    )
+                    .unwrap();
 
-                        let response = writer.to_parsed().to_response().unwrap();
+                    let response = writer.to_parsed().to_response().unwrap();
 
-                        assert!(task
-                            .handle(request_tx, &mut association, response)
-                            .is_none());
-                    }
-                    assert_eq!(
-                        rx.await.unwrap(),
-                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
-                    );
-                },
-            )
+                    assert!(task.handle(&mut association, response).is_none());
+                }
+                assert_eq!(
+                    rx.await.unwrap(),
+                    Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                );
+            })
             .await;
         }
 
         #[tokio::test]
         async fn non_empty_write_response() {
-            run_nonlan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_measure_delay_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
-                    let mut task =
-                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    {
-                        let mut buffer = [0; 20];
-                        let mut cursor = WriteCursor::new(&mut buffer);
-                        let mut writer = start_response(
-                            Control::response(Sequence::default()),
-                            ResponseFunction::Response,
-                            IIN::default(),
-                            &mut cursor,
-                        )
-                        .unwrap();
-                        writer.write_class1230().unwrap();
+            run_nonlan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_measure_delay_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                let task = send_measure_delay_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                {
+                    let mut buffer = [0; 20];
+                    let mut cursor = WriteCursor::new(&mut buffer);
+                    let mut writer = start_response(
+                        Control::response(Sequence::default()),
+                        ResponseFunction::Response,
+                        IIN::default(),
+                        &mut cursor,
+                    )
+                    .unwrap();
+                    writer.write_class1230().unwrap();
 
-                        let response = writer.to_parsed().to_response().unwrap();
+                    let response = writer.to_parsed().to_response().unwrap();
 
-                        assert!(task
-                            .handle(request_tx, &mut association, response)
-                            .is_none());
-                    }
-                    assert_matches!(
+                    assert!(task.handle(&mut association, response).is_none());
+                }
+                assert_matches!(
+                    rx.await.unwrap(),
+                    Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                );
+            })
+            .await;
+        }
+
+        #[tokio::test]
+        async fn iin_bit_not_reset() {
+            run_nonlan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_measure_delay_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                let task = send_measure_delay_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                {
+                    let mut buffer = [0; 20];
+                    let mut cursor = WriteCursor::new(&mut buffer);
+                    let writer = start_response(
+                        Control::response(Sequence::default()),
+                        ResponseFunction::Response,
+                        IIN::new(IIN1::new(0x10), IIN2::new(0x00)),
+                        &mut cursor,
+                    )
+                    .unwrap();
+
+                    let response = writer.to_parsed().to_response().unwrap();
+
+                    assert!(task.handle(&mut association, response).is_none());
+                }
+                assert_matches!(rx.await.unwrap(), Err(TimeSyncError::StillNeedsTime));
+            })
+            .await;
+        }
+
+        #[tokio::test]
+        async fn error_response() {
+            run_nonlan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_measure_delay_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                let task = send_measure_delay_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                task.on_task_error(Some(&mut association), TaskError::ResponseTimeout);
+                assert_eq!(
+                    rx.await.unwrap(),
+                    Err(TimeSyncError::Task(TaskError::ResponseTimeout))
+                );
+            })
+            .await;
+        }
+
+        #[tokio::test]
+        async fn no_system_time_at_start() {
+            run_nonlan_timesync_single_timestamp_test(
+                |task, _system_time, mut association, rx| async move {
+                    association.get_system_time(); // Empty the time
+
+                    assert!(task.start(&mut association).is_none());
+                    assert_eq!(
                         rx.await.unwrap(),
-                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                        Err(TimeSyncError::SystemTimeNotAvailable)
                     );
                 },
             )
@@ -504,50 +581,15 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn iin_bit_not_reset() {
-            run_nonlan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_measure_delay_request(&mut task, &association);
+        async fn no_system_time_at_delay() {
+            run_nonlan_timesync_single_timestamp_test(
+                |task, _system_time, mut association, rx| async move {
+                    let task = check_measure_delay_request(task, &mut association);
                     tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
-                    let mut task =
-                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    {
-                        let mut buffer = [0; 20];
-                        let mut cursor = WriteCursor::new(&mut buffer);
-                        let writer = start_response(
-                            Control::response(Sequence::default()),
-                            ResponseFunction::Response,
-                            IIN::new(IIN1::new(0x10), IIN2::new(0x00)),
-                            &mut cursor,
-                        )
-                        .unwrap();
-
-                        let response = writer.to_parsed().to_response().unwrap();
-
-                        assert!(task
-                            .handle(request_tx, &mut association, response)
-                            .is_none());
-                    }
-                    assert_matches!(rx.await.unwrap(), Err(TimeSyncError::StillNeedsTime));
-                },
-            )
-            .await;
-        }
-
-        #[tokio::test]
-        async fn error_response() {
-            run_nonlan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_measure_delay_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
-                    let mut task =
-                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    task.on_task_error(Some(&mut association), TaskError::ResponseTimeout);
+                    assert!(send_measure_delay_response(task, &mut association).is_none());
                     assert_eq!(
                         rx.await.unwrap(),
-                        Err(TimeSyncError::Task(TaskError::ResponseTimeout))
+                        Err(TimeSyncError::SystemTimeNotAvailable)
                     );
                 },
             )
@@ -557,14 +599,13 @@ mod tests {
         async fn run_nonlan_timesync_test<F: Future>(
             test: impl FnOnce(
                 NonReadTask,
-                SystemTime,
-                Instant,
+                Timestamp,
                 Association,
                 tokio::sync::oneshot::Receiver<Result<(), TimeSyncError>>,
             ) -> F,
         ) {
             tokio::time::pause();
-            let system_time = SystemTime::now();
+            let system_time = Timestamp::try_from_system_time(SystemTime::now()).unwrap();
             let association = Association::new(
                 1,
                 Configuration::default(),
@@ -575,30 +616,58 @@ mod tests {
                 TimeSyncProcedure::NonLAN,
                 Promise::OneShot(tx),
             ));
-            let request_tx = Instant::now();
 
-            test(task, system_time, request_tx, association, rx).await;
+            test(task, system_time, association, rx).await;
         }
 
-        fn check_measure_delay_request(task: &mut NonReadTask, association: &Association) {
+        async fn run_nonlan_timesync_single_timestamp_test<F: Future>(
+            test: impl FnOnce(
+                NonReadTask,
+                Timestamp,
+                Association,
+                tokio::sync::oneshot::Receiver<Result<(), TimeSyncError>>,
+            ) -> F,
+        ) {
+            tokio::time::pause();
+            let system_time = Timestamp::try_from_system_time(SystemTime::now()).unwrap();
+            let association = Association::new(
+                1,
+                Configuration::default(),
+                Box::new(SingleTimestampTestHandler::new(system_time)),
+            );
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let task = NonReadTask::TimeSync(TimeSyncTask::get_procedure(
+                TimeSyncProcedure::NonLAN,
+                Promise::OneShot(tx),
+            ));
+
+            test(task, system_time, association, rx).await;
+        }
+
+        fn check_measure_delay_request(
+            task: NonReadTask,
+            association: &mut Association,
+        ) -> NonReadTask {
             let mut buffer = [0; 20];
             let mut cursor = WriteCursor::new(&mut buffer);
+            let task = task.start(association).unwrap();
             let mut writer = start_request(
                 Control::request(Sequence::default()),
                 task.function(),
                 &mut cursor,
             )
             .unwrap();
-            task.write(&mut writer, association).unwrap();
+            task.write(&mut writer).unwrap();
             let request = writer.to_parsed().to_request().unwrap();
 
             assert_eq!(request.header.function, FunctionCode::DelayMeasure);
             assert!(request.raw_objects.is_empty());
+
+            task
         }
 
         fn send_measure_delay_response(
             task: NonReadTask,
-            request_tx: Instant,
             association: &mut Association,
         ) -> Option<NonReadTask> {
             let mut buffer = [0; 20];
@@ -617,23 +686,24 @@ mod tests {
                 .unwrap();
             let response = writer.to_parsed().to_response().unwrap();
 
-            task.handle(request_tx, association, response)
+            task.handle(association, response)
         }
 
         fn check_write_request(
-            task: &mut NonReadTask,
-            association: &Association,
-            system_time: SystemTime,
-        ) {
+            task: NonReadTask,
+            association: &mut Association,
+            system_time: Timestamp,
+        ) -> NonReadTask {
             let mut buffer = [0; 20];
             let mut cursor = WriteCursor::new(&mut buffer);
+            let task = task.start(association).unwrap();
             let mut writer = start_request(
                 Control::request(Sequence::default()),
                 task.function(),
                 &mut cursor,
             )
             .unwrap();
-            task.write(&mut writer, association).unwrap();
+            task.write(&mut writer).unwrap();
             let request = writer.to_parsed().to_request().unwrap();
 
             assert_eq!(request.header.function, FunctionCode::Write);
@@ -641,24 +711,19 @@ mod tests {
             match header.details.count().unwrap() {
                 CountVariation::Group50Var1(seq) => {
                     assert_eq!(
-                        seq.single().unwrap().time.raw_value(),
+                        seq.single().unwrap().time,
                         system_time
                             .checked_add(Duration::from_millis(PROPAGATION_DELAY_MS as u64))
                             .unwrap()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_millis() as u64
                     );
                 }
                 _ => panic!("wrong WRITE content"),
             }
+
+            task
         }
 
-        fn send_write_response(
-            task: NonReadTask,
-            request_tx: Instant,
-            association: &mut Association,
-        ) {
+        fn send_write_response(task: NonReadTask, association: &mut Association) {
             let mut buffer = [0; 20];
             let mut cursor = WriteCursor::new(&mut buffer);
             let writer = start_response(
@@ -670,7 +735,7 @@ mod tests {
             .unwrap();
             let response = writer.to_parsed().to_response().unwrap();
 
-            assert!(task.handle(request_tx, association, response).is_none());
+            assert!(task.handle(association, response).is_none());
         }
     }
 
@@ -679,231 +744,184 @@ mod tests {
 
         const DELAY_MS: u16 = 200;
 
-        struct TestHandler {
-            time: SystemTime,
-            handler: NullHandler,
-            get_system_time_called: Cell<bool>,
-        }
-
-        impl TestHandler {
-            fn new(time: SystemTime) -> Self {
-                Self {
-                    time,
-                    handler: NullHandler,
-                    get_system_time_called: Cell::new(false),
-                }
-            }
-        }
-
-        impl AssociationHandler for TestHandler {
-            fn get_system_time(&self) -> SystemTime {
-                if !self.get_system_time_called.get() {
-                    self.get_system_time_called.set(true);
-                    self.time
-                } else {
-                    SystemTime::UNIX_EPOCH
-                }
-            }
-
-            fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
-                &mut self.handler
-            }
-
-            fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
-                &mut self.handler
-            }
-
-            fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
-                &mut self.handler
-            }
-        }
-
         #[tokio::test]
         async fn success() {
-            run_lan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_record_current_time_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
-                    let mut task =
-                        send_record_current_time_response(task, request_tx, &mut association)
-                            .unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    send_write_response(task, request_tx, &mut association);
-                    assert!(rx.await.unwrap().is_ok());
-                },
-            )
+            run_lan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_record_current_time_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                let task = send_record_current_time_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                send_write_response(task, &mut association);
+                assert!(rx.await.unwrap().is_ok());
+            })
             .await;
         }
 
         #[tokio::test]
         async fn non_empty_record_current_time_response() {
-            run_lan_timesync_test(
-                |mut task, _system_time, request_tx, mut association, rx| async move {
-                    check_record_current_time_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
-                    {
-                        let mut buffer = [0; 20];
-                        let mut cursor = WriteCursor::new(&mut buffer);
-                        let mut writer = start_response(
-                            Control::response(Sequence::default()),
-                            ResponseFunction::Response,
-                            IIN::default(),
-                            &mut cursor,
-                        )
-                        .unwrap();
-                        writer.write_class1230().unwrap();
+            run_lan_timesync_test(|task, _system_time, mut association, rx| async move {
+                let task = check_record_current_time_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                {
+                    let mut buffer = [0; 20];
+                    let mut cursor = WriteCursor::new(&mut buffer);
+                    let mut writer = start_response(
+                        Control::response(Sequence::default()),
+                        ResponseFunction::Response,
+                        IIN::default(),
+                        &mut cursor,
+                    )
+                    .unwrap();
+                    writer.write_class1230().unwrap();
 
-                        let response = writer.to_parsed().to_response().unwrap();
+                    let response = writer.to_parsed().to_response().unwrap();
 
-                        assert!(task
-                            .handle(request_tx, &mut association, response)
-                            .is_none());
-                    }
-                    assert_eq!(
-                        rx.await.unwrap(),
-                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
-                    );
-                },
-            )
+                    assert!(task.handle(&mut association, response).is_none());
+                }
+                assert_eq!(
+                    rx.await.unwrap(),
+                    Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                );
+            })
             .await;
         }
 
         #[tokio::test]
         async fn non_empty_write_response() {
-            run_lan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_record_current_time_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
-                    let mut task =
-                        send_record_current_time_response(task, request_tx, &mut association)
-                            .unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    {
-                        let mut buffer = [0; 20];
-                        let mut cursor = WriteCursor::new(&mut buffer);
-                        let mut writer = start_response(
-                            Control::response(Sequence::default()),
-                            ResponseFunction::Response,
-                            IIN::default(),
-                            &mut cursor,
-                        )
-                        .unwrap();
-                        writer.write_class1230().unwrap();
+            run_lan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_record_current_time_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                let task = send_record_current_time_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                {
+                    let mut buffer = [0; 20];
+                    let mut cursor = WriteCursor::new(&mut buffer);
+                    let mut writer = start_response(
+                        Control::response(Sequence::default()),
+                        ResponseFunction::Response,
+                        IIN::default(),
+                        &mut cursor,
+                    )
+                    .unwrap();
+                    writer.write_class1230().unwrap();
 
-                        let response = writer.to_parsed().to_response().unwrap();
+                    let response = writer.to_parsed().to_response().unwrap();
 
-                        assert!(task
-                            .handle(request_tx, &mut association, response)
-                            .is_none());
-                    }
-                    assert_eq!(
-                        rx.await.unwrap(),
-                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
-                    );
-                },
-            )
+                    assert!(task.handle(&mut association, response).is_none());
+                }
+                assert_eq!(
+                    rx.await.unwrap(),
+                    Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                );
+            })
             .await;
         }
 
         #[tokio::test]
         async fn iin_bit_not_reset() {
-            run_lan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_record_current_time_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
-                    let mut task =
-                        send_record_current_time_response(task, request_tx, &mut association)
-                            .unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    {
-                        let mut buffer = [0; 20];
-                        let mut cursor = WriteCursor::new(&mut buffer);
-                        let writer = start_response(
-                            Control::response(Sequence::default()),
-                            ResponseFunction::Response,
-                            IIN::new(IIN1::new(0x10), IIN2::new(0x00)),
-                            &mut cursor,
-                        )
-                        .unwrap();
+            run_lan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_record_current_time_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                let task = send_record_current_time_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                {
+                    let mut buffer = [0; 20];
+                    let mut cursor = WriteCursor::new(&mut buffer);
+                    let writer = start_response(
+                        Control::response(Sequence::default()),
+                        ResponseFunction::Response,
+                        IIN::new(IIN1::new(0x10), IIN2::new(0x00)),
+                        &mut cursor,
+                    )
+                    .unwrap();
 
-                        let response = writer.to_parsed().to_response().unwrap();
+                    let response = writer.to_parsed().to_response().unwrap();
 
-                        assert!(task
-                            .handle(request_tx, &mut association, response)
-                            .is_none());
-                    }
-                    assert_matches!(rx.await.unwrap(), Err(TimeSyncError::StillNeedsTime));
-                },
-            )
+                    assert!(task.handle(&mut association, response).is_none());
+                }
+                assert_matches!(rx.await.unwrap(), Err(TimeSyncError::StillNeedsTime));
+            })
             .await;
         }
 
         #[tokio::test]
         async fn error_response() {
-            run_lan_timesync_test(
-                |mut task, system_time, request_tx, mut association, rx| async move {
-                    check_record_current_time_request(&mut task, &association);
-                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
-                    let mut task =
-                        send_record_current_time_response(task, request_tx, &mut association)
-                            .unwrap();
-                    check_write_request(&mut task, &association, system_time);
-                    task.on_task_error(Some(&mut association), TaskError::ResponseTimeout);
-                    assert_eq!(
-                        rx.await.unwrap(),
-                        Err(TimeSyncError::Task(TaskError::ResponseTimeout))
-                    );
-                },
-            )
+            run_lan_timesync_test(|task, system_time, mut association, rx| async move {
+                let task = check_record_current_time_request(task, &mut association);
+                tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                let task = send_record_current_time_response(task, &mut association).unwrap();
+                let task = check_write_request(task, &mut association, system_time);
+                task.on_task_error(Some(&mut association), TaskError::ResponseTimeout);
+                assert_eq!(
+                    rx.await.unwrap(),
+                    Err(TimeSyncError::Task(TaskError::ResponseTimeout))
+                );
+            })
+            .await;
+        }
+
+        #[tokio::test]
+        async fn no_system_time_available() {
+            run_lan_timesync_test(|task, _system_time, mut association, rx| async move {
+                association.get_system_time(); // Empty the time
+
+                assert!(task.start(&mut association).is_none());
+                assert_eq!(
+                    rx.await.unwrap(),
+                    Err(TimeSyncError::SystemTimeNotAvailable)
+                );
+            })
             .await;
         }
 
         async fn run_lan_timesync_test<F: Future>(
             test: impl FnOnce(
                 NonReadTask,
-                SystemTime,
-                Instant,
+                Timestamp,
                 Association,
                 tokio::sync::oneshot::Receiver<Result<(), TimeSyncError>>,
             ) -> F,
         ) {
             tokio::time::pause();
-            let system_time = SystemTime::now();
+            let system_time = Timestamp::try_from_system_time(SystemTime::now()).unwrap();
             let association = Association::new(
                 1,
                 Configuration::default(),
-                Box::new(TestHandler::new(system_time)),
+                Box::new(SingleTimestampTestHandler::new(system_time)),
             );
             let (tx, rx) = tokio::sync::oneshot::channel();
             let task = NonReadTask::TimeSync(TimeSyncTask::get_procedure(
                 TimeSyncProcedure::LAN,
                 Promise::OneShot(tx),
             ));
-            let request_tx = Instant::now();
 
-            test(task, system_time, request_tx, association, rx).await;
+            test(task, system_time, association, rx).await;
         }
 
-        fn check_record_current_time_request(task: &mut NonReadTask, association: &Association) {
+        fn check_record_current_time_request(
+            task: NonReadTask,
+            association: &mut Association,
+        ) -> NonReadTask {
             let mut buffer = [0; 20];
             let mut cursor = WriteCursor::new(&mut buffer);
+            let task = task.start(association).unwrap();
             let mut writer = start_request(
                 Control::request(Sequence::default()),
                 task.function(),
                 &mut cursor,
             )
             .unwrap();
-            task.write(&mut writer, association).unwrap();
+            task.write(&mut writer).unwrap();
             let request = writer.to_parsed().to_request().unwrap();
 
             assert_eq!(request.header.function, FunctionCode::RecordCurrentTime);
             assert!(request.raw_objects.is_empty());
-            assert_eq!(association.get_system_time(), SystemTime::UNIX_EPOCH);
+            assert!(association.get_system_time().is_none());
+            task
         }
 
         fn send_record_current_time_response(
             task: NonReadTask,
-            request_tx: Instant,
             association: &mut Association,
         ) -> Option<NonReadTask> {
             let mut buffer = [0; 20];
@@ -917,43 +935,39 @@ mod tests {
             .unwrap();
             let response = writer.to_parsed().to_response().unwrap();
 
-            task.handle(request_tx, association, response)
+            task.handle(association, response)
         }
 
         fn check_write_request(
-            task: &mut NonReadTask,
-            association: &Association,
-            system_time: SystemTime,
-        ) {
+            task: NonReadTask,
+            association: &mut Association,
+            system_time: Timestamp,
+        ) -> NonReadTask {
             let mut buffer = [0; 20];
             let mut cursor = WriteCursor::new(&mut buffer);
+            let task = task.start(association).unwrap();
             let mut writer = start_request(
                 Control::request(Sequence::default()),
                 task.function(),
                 &mut cursor,
             )
             .unwrap();
-            task.write(&mut writer, association).unwrap();
+            task.write(&mut writer).unwrap();
             let request = writer.to_parsed().to_request().unwrap();
 
             assert_eq!(request.header.function, FunctionCode::Write);
             let header = request.objects.unwrap().get_only_header().unwrap();
             match header.details.count().unwrap() {
                 CountVariation::Group50Var3(seq) => {
-                    assert_eq!(
-                        seq.single().unwrap().time.raw_value(),
-                        system_time.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64
-                    );
+                    assert_eq!(seq.single().unwrap().time, system_time);
                 }
                 _ => panic!("wrong WRITE content"),
             }
+
+            task
         }
 
-        fn send_write_response(
-            task: NonReadTask,
-            request_tx: Instant,
-            association: &mut Association,
-        ) {
+        fn send_write_response(task: NonReadTask, association: &mut Association) {
             let mut buffer = [0; 20];
             let mut cursor = WriteCursor::new(&mut buffer);
             let writer = start_response(
@@ -965,7 +979,7 @@ mod tests {
             .unwrap();
             let response = writer.to_parsed().to_response().unwrap();
 
-            assert!(task.handle(request_tx, association, response).is_none());
+            assert!(task.handle(association, response).is_none());
         }
     }
 }

--- a/dnp3/src/master/tasks/time.rs
+++ b/dnp3/src/master/tasks/time.rs
@@ -1,7 +1,7 @@
 use crate::app::enums::FunctionCode;
 use crate::app::format::write::HeaderWriter;
 use crate::app::gen::count::CountVariation;
-use crate::app::parse::parser::{HeaderDetails, Response};
+use crate::app::parse::parser::Response;
 use crate::app::types::Timestamp;
 use crate::app::variations::{Group50Var1, Group50Var3};
 use crate::master::association::Association;
@@ -12,16 +12,16 @@ use crate::master::tasks::NonReadTask;
 use crate::util::cursor::WriteError;
 use std::convert::TryFrom;
 use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+use tokio::time::Instant;
 
 enum State {
     MeasureDelay,
     WriteAbsoluteTime(Timestamp),
-    RecordCurrentTime,
+    RecordCurrentTime(Option<SystemTime>),
     WriteLastRecordedTime(Timestamp),
 }
 
 pub(crate) struct TimeSyncTask {
-    is_auto_task: bool,
     state: State,
     promise: Promise<Result<(), TimeSyncError>>,
 }
@@ -29,31 +29,26 @@ pub(crate) struct TimeSyncTask {
 impl TimeSyncProcedure {
     fn get_start_state(&self) -> State {
         match self {
-            TimeSyncProcedure::LAN => State::RecordCurrentTime,
+            TimeSyncProcedure::LAN => State::RecordCurrentTime(None),
             TimeSyncProcedure::NonLAN => State::MeasureDelay,
         }
     }
 }
 
 impl TimeSyncTask {
-    fn new(is_auto_task: bool, state: State, promise: Promise<Result<(), TimeSyncError>>) -> Self {
-        Self {
-            is_auto_task,
-            state,
-            promise,
-        }
+    fn new(state: State, promise: Promise<Result<(), TimeSyncError>>) -> Self {
+        Self { state, promise }
     }
 
     fn change_state(self, state: State) -> Self {
-        TimeSyncTask::new(self.is_auto_task, state, self.promise)
+        TimeSyncTask::new(state, self.promise)
     }
 
     pub(crate) fn get_procedure(
         procedure: TimeSyncProcedure,
-        is_auto_task: bool,
         promise: Promise<Result<(), TimeSyncError>>,
     ) -> Self {
-        Self::new(is_auto_task, procedure.get_start_state(), promise)
+        Self::new(procedure.get_start_state(), promise)
     }
 
     pub(crate) fn wrap(self) -> NonReadTask {
@@ -64,39 +59,50 @@ impl TimeSyncTask {
         match self.state {
             State::MeasureDelay => FunctionCode::DelayMeasure,
             State::WriteAbsoluteTime(_) => FunctionCode::Write,
-            State::RecordCurrentTime => FunctionCode::RecordCurrentTime,
+            State::RecordCurrentTime(_) => FunctionCode::RecordCurrentTime,
             State::WriteLastRecordedTime(_) => FunctionCode::Write,
         }
     }
 
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
-        match self.state {
+    pub(crate) fn write(
+        &mut self,
+        writer: &mut HeaderWriter,
+        association: &Association,
+    ) -> Result<(), WriteError> {
+        match &mut self.state {
             State::MeasureDelay => Ok(()),
-            State::WriteAbsoluteTime(x) => writer.write_count_of_one(Group50Var1 { time: x }),
-            State::RecordCurrentTime => Ok(()),
-            State::WriteLastRecordedTime(x) => writer.write_count_of_one(Group50Var3 { time: x }),
+            State::WriteAbsoluteTime(x) => writer.write_count_of_one(Group50Var1 { time: *x }),
+            State::RecordCurrentTime(time) => {
+                time.replace(association.get_system_time());
+                Ok(())
+            }
+            State::WriteLastRecordedTime(x) => writer.write_count_of_one(Group50Var3 { time: *x }),
         }
     }
 
     pub(crate) fn on_task_error(self, association: Option<&mut Association>, err: TaskError) {
-        if self.is_auto_task {
-            if let Some(association) = association {
-                association.on_time_sync_iin_failure();
+        match self.promise {
+            Promise::None => {
+                if let Some(association) = association {
+                    association.on_time_sync_failure(err.into());
+                }
             }
+            _ => self.promise.complete(Err(err.into())),
         }
-        self.promise.complete(Err(err.into()))
     }
 
     pub(crate) fn handle(
         self,
         association: &mut Association,
-        request_tx: SystemTime,
+        request_tx: Instant,
         response: Response,
     ) -> Option<NonReadTask> {
         match self.state {
             State::MeasureDelay => self.handle_delay_measure(association, request_tx, response),
             State::WriteAbsoluteTime(_) => self.handle_write_absolute_time(association, response),
-            State::RecordCurrentTime => self.handle_record_current_time(request_tx, response),
+            State::RecordCurrentTime(time) => {
+                self.handle_record_current_time(association, time, response)
+            }
             State::WriteLastRecordedTime(_) => {
                 self.handle_write_last_recorded_time(association, response)
             }
@@ -106,16 +112,17 @@ impl TimeSyncTask {
     fn handle_delay_measure(
         self,
         association: &mut Association,
-        request_tx: SystemTime,
+        request_tx: Instant,
         response: Response,
     ) -> Option<NonReadTask> {
-        let now = SystemTime::now();
+        let now = Instant::now();
 
-        let interval = match now.duration_since(request_tx) {
-            Ok(x) => x,
-            Err(_) => {
+        let interval = match now.checked_duration_since(request_tx) {
+            Some(x) => x,
+            None => {
+                // This should NEVER happen. `tokio::time::Instant` is guaranteed to be monotonic and nondecreasing.
                 log::error!("clock rollback detected while synchronizing outstation");
-                self.promise.complete(Err(TimeSyncError::ClockRollback));
+                self.report_error(association, TimeSyncError::ClockRollback);
                 return None;
             }
         };
@@ -123,28 +130,27 @@ impl TimeSyncTask {
         let objects = match response.objects {
             Ok(x) => x,
             Err(err) => {
-                self.promise
-                    .complete(Err(TaskError::MalformedResponse(err).into()));
+                self.report_error(association, TaskError::MalformedResponse(err).into());
                 return None;
             }
         };
 
-        let delay_ms: Option<u16> = objects.get_only_header().and_then(|x| match x.details {
-            HeaderDetails::OneByteCount(1, CountVariation::Group52Var2(seq)) => {
+        let delay_ms: Option<u16> = objects.get_only_header().and_then(|x| {
+            if let Some(CountVariation::Group52Var2(seq)) = x.details.count() {
                 match seq.single() {
                     Some(x) => Some(x.time),
                     None => None,
                 }
+            } else {
+                None
             }
-            _ => None,
         });
 
         let delay_ms = match delay_ms {
             Some(x) => x,
             None => {
                 log::warn!("received unexpected header(s) in response to delay measure");
-                self.promise
-                    .complete(Err(TaskError::UnexpectedResponseHeaders.into()));
+                self.report_error(association, TaskError::UnexpectedResponseHeaders.into());
                 return None;
             }
         };
@@ -155,8 +161,7 @@ impl TimeSyncTask {
                 Some(x) => (x / 2),
                 None => {
                     log::warn!("outstation time delay is larger than the response delay");
-                    self.promise
-                        .complete(Err(TimeSyncError::BadOutstationTimeDelay(delay_ms)));
+                    self.report_error(association, TimeSyncError::BadOutstationTimeDelay(delay_ms));
                     return None;
                 }
             };
@@ -164,7 +169,7 @@ impl TimeSyncTask {
         let time = match association.get_system_time().duration_since(UNIX_EPOCH) {
             Err(err) => {
                 log::error!("{}", err);
-                self.promise.complete(Err(TimeSyncError::SystemTimeNotUnix));
+                self.report_error(association, TimeSyncError::SystemTimeNotUnix);
                 return None;
             }
             Ok(x) => x,
@@ -173,7 +178,7 @@ impl TimeSyncTask {
         let timestamp = match Self::get_timestamp(time, propagation_delay) {
             Err(err) => {
                 log::error!("{}", err);
-                self.promise.complete(Err(err));
+                self.report_error(association, err);
                 return None;
             }
             Ok(x) => x,
@@ -190,31 +195,48 @@ impl TimeSyncTask {
         association: &mut Association,
         response: Response,
     ) -> Option<NonReadTask> {
-        if self.is_auto_task {
-            association.on_time_sync_iin_response(response.header.iin);
+        if !response.raw_objects.is_empty() {
+            self.report_error(
+                association,
+                TimeSyncError::Task(TaskError::UnexpectedResponseHeaders),
+            );
+            return None;
         }
-        self.promise
-            .complete(TimeSyncError::from_iin(response.header.iin));
+
+        if let Err(error) = TimeSyncError::from_iin(response.header.iin) {
+            self.report_error(association, error);
+        } else {
+            self.report_success(association);
+        }
+
         None
     }
 
     fn handle_record_current_time(
         self,
-        request_tx: SystemTime,
-        _response: Response,
+        association: &mut Association,
+        recorded_time: Option<SystemTime>,
+        response: Response,
     ) -> Option<NonReadTask> {
-        let timestamp = match Self::convert_to_timestamp(request_tx) {
-            Err(err) => {
-                self.promise.complete(Err(err));
-                return None;
-            }
-            Ok(x) => x,
-        };
+        if !response.raw_objects.is_empty() {
+            self.report_error(
+                association,
+                TimeSyncError::Task(TaskError::UnexpectedResponseHeaders),
+            );
+            return None;
+        }
 
-        Some(
-            self.change_state(State::WriteLastRecordedTime(timestamp))
-                .wrap(),
-        )
+        let recorded_time = recorded_time.unwrap_or_else(|| association.get_system_time());
+        match Self::convert_to_timestamp(recorded_time) {
+            Ok(timestamp) => Some(
+                self.change_state(State::WriteLastRecordedTime(timestamp))
+                    .wrap(),
+            ),
+            Err(err) => {
+                self.report_error(association, err);
+                None
+            }
+        }
     }
 
     fn handle_write_last_recorded_time(
@@ -222,11 +244,20 @@ impl TimeSyncTask {
         association: &mut Association,
         response: Response,
     ) -> Option<NonReadTask> {
-        if self.is_auto_task {
-            association.on_time_sync_iin_response(response.header.iin);
+        if !response.raw_objects.is_empty() {
+            self.report_error(
+                association,
+                TimeSyncError::Task(TaskError::UnexpectedResponseHeaders),
+            );
+            return None;
         }
-        self.promise
-            .complete(TimeSyncError::from_iin(response.header.iin));
+
+        if let Err(error) = TimeSyncError::from_iin(response.header.iin) {
+            self.report_error(association, error);
+        } else {
+            self.report_success(association);
+        }
+
         None
     }
 
@@ -245,6 +276,20 @@ impl TimeSyncTask {
             None => Err(TimeSyncError::Overflow),
         }
     }
+
+    fn report_success(self, association: &mut Association) {
+        match self.promise {
+            Promise::None => association.on_time_sync_success(),
+            _ => self.promise.complete(Ok(())),
+        }
+    }
+
+    fn report_error(self, association: &mut Association, error: TimeSyncError) {
+        match self.promise {
+            Promise::None => association.on_time_sync_failure(error),
+            _ => self.promise.complete(Err(error)),
+        }
+    }
 }
 
 impl From<std::num::TryFromIntError> for TimeSyncError {
@@ -256,5 +301,671 @@ impl From<std::num::TryFromIntError> for TimeSyncError {
 impl From<SystemTimeError> for TimeSyncError {
     fn from(_: SystemTimeError) -> Self {
         TimeSyncError::Overflow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::format::write::*;
+    use crate::app::header::*;
+    use crate::app::parse::parser::{DecodeSettings, ParsedFragment};
+    use crate::app::parse::traits::{FixedSize, FixedSizeVariation};
+    use crate::app::sequence::Sequence;
+    use crate::master::tasks::RequestWriter;
+    use crate::prelude::master::*;
+    use crate::util::cursor::WriteCursor;
+    use std::cell::Cell;
+    use std::future::Future;
+
+    mod non_lan {
+        use super::*;
+        const OUTSTATION_DELAY_MS: u16 = 100;
+        const TOTAL_DELAY_MS: u16 = 200;
+        const PROPAGATION_DELAY_MS: u16 = (TOTAL_DELAY_MS - OUTSTATION_DELAY_MS) / 2;
+
+        struct TestHandler {
+            time: SystemTime,
+            handler: NullHandler,
+        }
+
+        impl TestHandler {
+            fn new(time: SystemTime) -> Self {
+                Self {
+                    time,
+                    handler: NullHandler,
+                }
+            }
+        }
+
+        impl AssociationHandler for TestHandler {
+            fn get_system_time(&self) -> SystemTime {
+                self.time
+            }
+
+            fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
+                &mut self.handler
+            }
+
+            fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
+                &mut self.handler
+            }
+
+            fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+                &mut self.handler
+            }
+        }
+
+        #[tokio::test]
+        async fn success() {
+            run_nonlan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_measure_delay_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                    let mut task =
+                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    send_write_response(task, request_tx, &mut association);
+                    assert!(rx.await.unwrap().is_ok());
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn with_16bit_count() {
+            run_nonlan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_measure_delay_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+
+                    let mut task = {
+                        let mut buffer = [0; 20];
+                        let mut cursor = WriteCursor::new(&mut buffer);
+                        let writer = start_response(
+                            Control::response(Sequence::default()),
+                            ResponseFunction::Response,
+                            IIN::default(),
+                            &mut cursor,
+                        )
+                        .unwrap();
+                        {
+                            let cursor = writer.inner();
+                            Group52Var2::VARIATION.write(cursor).unwrap();
+                            QualifierCode::Count16.write(cursor).unwrap();
+                            cursor.write_u16_le(1).unwrap();
+                            Group52Var2 {
+                                time: OUTSTATION_DELAY_MS,
+                            }
+                            .write(cursor)
+                            .unwrap();
+                        }
+                        let response =
+                            ParsedFragment::parse(DecodeSettings::none(), cursor.written())
+                                .unwrap()
+                                .to_response()
+                                .unwrap();
+
+                        task.handle(request_tx, &mut association, response)
+                    }
+                    .unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    send_write_response(task, request_tx, &mut association);
+                    assert!(rx.await.unwrap().is_ok());
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn delay_reported_by_outstation_greater_than_actual_delay() {
+            run_nonlan_timesync_test(
+                |mut task, _system_time, request_tx, mut association, rx| async move {
+                    check_measure_delay_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(1)).await; // This delay is less than the reported delay of the outstation
+                    assert!(
+                        send_measure_delay_response(task, request_tx, &mut association).is_none()
+                    );
+                    assert_eq!(
+                        Err(TimeSyncError::BadOutstationTimeDelay(OUTSTATION_DELAY_MS)),
+                        rx.await.unwrap()
+                    );
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn empty_measure_delay_response() {
+            run_nonlan_timesync_test(
+                |mut task, _system_time, request_tx, mut association, rx| async move {
+                    check_measure_delay_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                    {
+                        let mut buffer = [0; 20];
+                        let mut cursor = WriteCursor::new(&mut buffer);
+                        let writer = start_response(
+                            Control::response(Sequence::default()),
+                            ResponseFunction::Response,
+                            IIN::default(),
+                            &mut cursor,
+                        )
+                        .unwrap();
+
+                        let response = writer.to_parsed().to_response().unwrap();
+
+                        assert!(task
+                            .handle(request_tx, &mut association, response)
+                            .is_none());
+                    }
+                    assert_eq!(
+                        rx.await.unwrap(),
+                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                    );
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn non_empty_write_response() {
+            run_nonlan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_measure_delay_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                    let mut task =
+                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    {
+                        let mut buffer = [0; 20];
+                        let mut cursor = WriteCursor::new(&mut buffer);
+                        let mut writer = start_response(
+                            Control::response(Sequence::default()),
+                            ResponseFunction::Response,
+                            IIN::default(),
+                            &mut cursor,
+                        )
+                        .unwrap();
+                        writer.write_class1230().unwrap();
+
+                        let response = writer.to_parsed().to_response().unwrap();
+
+                        assert!(task
+                            .handle(request_tx, &mut association, response)
+                            .is_none());
+                    }
+                    assert_matches!(
+                        rx.await.unwrap(),
+                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                    );
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn iin_bit_not_reset() {
+            run_nonlan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_measure_delay_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                    let mut task =
+                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    {
+                        let mut buffer = [0; 20];
+                        let mut cursor = WriteCursor::new(&mut buffer);
+                        let writer = start_response(
+                            Control::response(Sequence::default()),
+                            ResponseFunction::Response,
+                            IIN::new(IIN1::new(0x10), IIN2::new(0x00)),
+                            &mut cursor,
+                        )
+                        .unwrap();
+
+                        let response = writer.to_parsed().to_response().unwrap();
+
+                        assert!(task
+                            .handle(request_tx, &mut association, response)
+                            .is_none());
+                    }
+                    assert_matches!(rx.await.unwrap(), Err(TimeSyncError::StillNeedsTime));
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn error_response() {
+            run_nonlan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_measure_delay_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(TOTAL_DELAY_MS as u64)).await;
+                    let mut task =
+                        send_measure_delay_response(task, request_tx, &mut association).unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    task.on_task_error(Some(&mut association), TaskError::ResponseTimeout);
+                    assert_eq!(
+                        rx.await.unwrap(),
+                        Err(TimeSyncError::Task(TaskError::ResponseTimeout))
+                    );
+                },
+            )
+            .await;
+        }
+
+        async fn run_nonlan_timesync_test<F: Future>(
+            test: impl FnOnce(
+                NonReadTask,
+                SystemTime,
+                Instant,
+                Association,
+                tokio::sync::oneshot::Receiver<Result<(), TimeSyncError>>,
+            ) -> F,
+        ) {
+            tokio::time::pause();
+            let system_time = SystemTime::now();
+            let association = Association::new(
+                1,
+                Configuration::default(),
+                Box::new(TestHandler::new(system_time)),
+            );
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let task = NonReadTask::TimeSync(TimeSyncTask::get_procedure(
+                TimeSyncProcedure::NonLAN,
+                Promise::OneShot(tx),
+            ));
+            let request_tx = Instant::now();
+
+            test(task, system_time, request_tx, association, rx).await;
+        }
+
+        fn check_measure_delay_request(task: &mut NonReadTask, association: &Association) {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let mut writer = start_request(
+                Control::request(Sequence::default()),
+                task.function(),
+                &mut cursor,
+            )
+            .unwrap();
+            task.write(&mut writer, association).unwrap();
+            let request = writer.to_parsed().to_request().unwrap();
+
+            assert_eq!(request.header.function, FunctionCode::DelayMeasure);
+            assert!(request.raw_objects.is_empty());
+        }
+
+        fn send_measure_delay_response(
+            task: NonReadTask,
+            request_tx: Instant,
+            association: &mut Association,
+        ) -> Option<NonReadTask> {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let mut writer = start_response(
+                Control::response(Sequence::default()),
+                ResponseFunction::Response,
+                IIN::default(),
+                &mut cursor,
+            )
+            .unwrap();
+            writer
+                .write_count_of_one(Group52Var2 {
+                    time: OUTSTATION_DELAY_MS,
+                })
+                .unwrap();
+            let response = writer.to_parsed().to_response().unwrap();
+
+            task.handle(request_tx, association, response)
+        }
+
+        fn check_write_request(
+            task: &mut NonReadTask,
+            association: &Association,
+            system_time: SystemTime,
+        ) {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let mut writer = start_request(
+                Control::request(Sequence::default()),
+                task.function(),
+                &mut cursor,
+            )
+            .unwrap();
+            task.write(&mut writer, association).unwrap();
+            let request = writer.to_parsed().to_request().unwrap();
+
+            assert_eq!(request.header.function, FunctionCode::Write);
+            let header = request.objects.unwrap().get_only_header().unwrap();
+            match header.details.count().unwrap() {
+                CountVariation::Group50Var1(seq) => {
+                    assert_eq!(
+                        seq.single().unwrap().time.raw_value(),
+                        system_time
+                            .checked_add(Duration::from_millis(PROPAGATION_DELAY_MS as u64))
+                            .unwrap()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_millis() as u64
+                    );
+                }
+                _ => panic!("wrong WRITE content"),
+            }
+        }
+
+        fn send_write_response(
+            task: NonReadTask,
+            request_tx: Instant,
+            association: &mut Association,
+        ) {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let writer = start_response(
+                Control::request(Sequence::default()),
+                ResponseFunction::Response,
+                IIN::default(),
+                &mut cursor,
+            )
+            .unwrap();
+            let response = writer.to_parsed().to_response().unwrap();
+
+            assert!(task.handle(request_tx, association, response).is_none());
+        }
+    }
+
+    mod lan {
+        use super::*;
+
+        const DELAY_MS: u16 = 200;
+
+        struct TestHandler {
+            time: SystemTime,
+            handler: NullHandler,
+            get_system_time_called: Cell<bool>,
+        }
+
+        impl TestHandler {
+            fn new(time: SystemTime) -> Self {
+                Self {
+                    time,
+                    handler: NullHandler,
+                    get_system_time_called: Cell::new(false),
+                }
+            }
+        }
+
+        impl AssociationHandler for TestHandler {
+            fn get_system_time(&self) -> SystemTime {
+                if !self.get_system_time_called.get() {
+                    self.get_system_time_called.set(true);
+                    self.time
+                } else {
+                    SystemTime::UNIX_EPOCH
+                }
+            }
+
+            fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
+                &mut self.handler
+            }
+
+            fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
+                &mut self.handler
+            }
+
+            fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+                &mut self.handler
+            }
+        }
+
+        #[tokio::test]
+        async fn success() {
+            run_lan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_record_current_time_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                    let mut task =
+                        send_record_current_time_response(task, request_tx, &mut association)
+                            .unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    send_write_response(task, request_tx, &mut association);
+                    assert!(rx.await.unwrap().is_ok());
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn non_empty_record_current_time_response() {
+            run_lan_timesync_test(
+                |mut task, _system_time, request_tx, mut association, rx| async move {
+                    check_record_current_time_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                    {
+                        let mut buffer = [0; 20];
+                        let mut cursor = WriteCursor::new(&mut buffer);
+                        let mut writer = start_response(
+                            Control::response(Sequence::default()),
+                            ResponseFunction::Response,
+                            IIN::default(),
+                            &mut cursor,
+                        )
+                        .unwrap();
+                        writer.write_class1230().unwrap();
+
+                        let response = writer.to_parsed().to_response().unwrap();
+
+                        assert!(task
+                            .handle(request_tx, &mut association, response)
+                            .is_none());
+                    }
+                    assert_eq!(
+                        rx.await.unwrap(),
+                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                    );
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn non_empty_write_response() {
+            run_lan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_record_current_time_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                    let mut task =
+                        send_record_current_time_response(task, request_tx, &mut association)
+                            .unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    {
+                        let mut buffer = [0; 20];
+                        let mut cursor = WriteCursor::new(&mut buffer);
+                        let mut writer = start_response(
+                            Control::response(Sequence::default()),
+                            ResponseFunction::Response,
+                            IIN::default(),
+                            &mut cursor,
+                        )
+                        .unwrap();
+                        writer.write_class1230().unwrap();
+
+                        let response = writer.to_parsed().to_response().unwrap();
+
+                        assert!(task
+                            .handle(request_tx, &mut association, response)
+                            .is_none());
+                    }
+                    assert_eq!(
+                        rx.await.unwrap(),
+                        Err(TimeSyncError::Task(TaskError::UnexpectedResponseHeaders))
+                    );
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn iin_bit_not_reset() {
+            run_lan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_record_current_time_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                    let mut task =
+                        send_record_current_time_response(task, request_tx, &mut association)
+                            .unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    {
+                        let mut buffer = [0; 20];
+                        let mut cursor = WriteCursor::new(&mut buffer);
+                        let writer = start_response(
+                            Control::response(Sequence::default()),
+                            ResponseFunction::Response,
+                            IIN::new(IIN1::new(0x10), IIN2::new(0x00)),
+                            &mut cursor,
+                        )
+                        .unwrap();
+
+                        let response = writer.to_parsed().to_response().unwrap();
+
+                        assert!(task
+                            .handle(request_tx, &mut association, response)
+                            .is_none());
+                    }
+                    assert_matches!(rx.await.unwrap(), Err(TimeSyncError::StillNeedsTime));
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn error_response() {
+            run_lan_timesync_test(
+                |mut task, system_time, request_tx, mut association, rx| async move {
+                    check_record_current_time_request(&mut task, &association);
+                    tokio::time::advance(Duration::from_millis(DELAY_MS as u64)).await;
+                    let mut task =
+                        send_record_current_time_response(task, request_tx, &mut association)
+                            .unwrap();
+                    check_write_request(&mut task, &association, system_time);
+                    task.on_task_error(Some(&mut association), TaskError::ResponseTimeout);
+                    assert_eq!(
+                        rx.await.unwrap(),
+                        Err(TimeSyncError::Task(TaskError::ResponseTimeout))
+                    );
+                },
+            )
+            .await;
+        }
+
+        async fn run_lan_timesync_test<F: Future>(
+            test: impl FnOnce(
+                NonReadTask,
+                SystemTime,
+                Instant,
+                Association,
+                tokio::sync::oneshot::Receiver<Result<(), TimeSyncError>>,
+            ) -> F,
+        ) {
+            tokio::time::pause();
+            let system_time = SystemTime::now();
+            let association = Association::new(
+                1,
+                Configuration::default(),
+                Box::new(TestHandler::new(system_time)),
+            );
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let task = NonReadTask::TimeSync(TimeSyncTask::get_procedure(
+                TimeSyncProcedure::LAN,
+                Promise::OneShot(tx),
+            ));
+            let request_tx = Instant::now();
+
+            test(task, system_time, request_tx, association, rx).await;
+        }
+
+        fn check_record_current_time_request(task: &mut NonReadTask, association: &Association) {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let mut writer = start_request(
+                Control::request(Sequence::default()),
+                task.function(),
+                &mut cursor,
+            )
+            .unwrap();
+            task.write(&mut writer, association).unwrap();
+            let request = writer.to_parsed().to_request().unwrap();
+
+            assert_eq!(request.header.function, FunctionCode::RecordCurrentTime);
+            assert!(request.raw_objects.is_empty());
+            assert_eq!(association.get_system_time(), SystemTime::UNIX_EPOCH);
+        }
+
+        fn send_record_current_time_response(
+            task: NonReadTask,
+            request_tx: Instant,
+            association: &mut Association,
+        ) -> Option<NonReadTask> {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let writer = start_response(
+                Control::response(Sequence::default()),
+                ResponseFunction::Response,
+                IIN::default(),
+                &mut cursor,
+            )
+            .unwrap();
+            let response = writer.to_parsed().to_response().unwrap();
+
+            task.handle(request_tx, association, response)
+        }
+
+        fn check_write_request(
+            task: &mut NonReadTask,
+            association: &Association,
+            system_time: SystemTime,
+        ) {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let mut writer = start_request(
+                Control::request(Sequence::default()),
+                task.function(),
+                &mut cursor,
+            )
+            .unwrap();
+            task.write(&mut writer, association).unwrap();
+            let request = writer.to_parsed().to_request().unwrap();
+
+            assert_eq!(request.header.function, FunctionCode::Write);
+            let header = request.objects.unwrap().get_only_header().unwrap();
+            match header.details.count().unwrap() {
+                CountVariation::Group50Var3(seq) => {
+                    assert_eq!(
+                        seq.single().unwrap().time.raw_value(),
+                        system_time.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64
+                    );
+                }
+                _ => panic!("wrong WRITE content"),
+            }
+        }
+
+        fn send_write_response(
+            task: NonReadTask,
+            request_tx: Instant,
+            association: &mut Association,
+        ) {
+            let mut buffer = [0; 20];
+            let mut cursor = WriteCursor::new(&mut buffer);
+            let writer = start_response(
+                Control::request(Sequence::default()),
+                ResponseFunction::Response,
+                IIN::default(),
+                &mut cursor,
+            )
+            .unwrap();
+            let response = writer.to_parsed().to_response().unwrap();
+
+            assert!(task.handle(request_tx, association, response).is_none());
+        }
     }
 }

--- a/ffi/bindings/c/main.c
+++ b/ffi/bindings/c/main.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 void print_qualifier(qualifier_code_t qualifier)
 {
@@ -206,6 +207,14 @@ void on_timesync_complete(time_sync_result_t result, void* arg)
     printf("TimeSyncResult: %s\n", TimeSyncResult_to_string(result));
 }
 
+// Timestamp callback
+time_provider_timestamp_t get_time(void* arg)
+{
+    time_t timer = time(NULL);
+
+    return timeprovidertimestamp_valid(timer * 1000);
+}
+
 int main()
 {
     // Setup logging
@@ -282,11 +291,17 @@ int main()
         .unsolicited_handler = read_handler,
         .default_poll_handler = read_handler,
     };
+    time_provider_t time_provider =
+    {
+        .get_time = get_time,
+        .ctx = NULL,
+    };
     association_t* association = master_add_association(
         master,
         1024,
         association_config,
-        association_handlers
+        association_handlers,
+        time_provider
     );
 
     // Add an event poll

--- a/ffi/bindings/dotnet/dnp3rs.Tests/Main.cs
+++ b/ffi/bindings/dotnet/dnp3rs.Tests/Main.cs
@@ -135,6 +135,14 @@ class MainClass
         }
     }
 
+    class TestTimeProvider : ITimeProvider
+    {
+        public TimeProviderTimestamp GetTime()
+        {
+            return TimeProviderTimestamp.Valid((ulong)DateTime.UtcNow.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
+        }
+    }
+
     public static void Main(string[] args)
     {   
             MainAsync().GetAwaiter().GetResult();
@@ -184,7 +192,8 @@ class MainClass
                     IntegrityHandler = readHandler,
                     UnsolicitedHandler = readHandler,
                     DefaultPollHandler = readHandler,
-                }
+                },
+                new TestTimeProvider()
             );
 
             var pollRequest = Request.ClassRequest(false, true, true, true);

--- a/ffi/bindings/java/dnp3rs-tests/src/main/java/io/stepfunc/dnp3rs_tests/Main.java
+++ b/ffi/bindings/java/dnp3rs-tests/src/main/java/io/stepfunc/dnp3rs_tests/Main.java
@@ -129,6 +129,14 @@ class TestReadHandler implements ReadHandler {
     }
 }
 
+class TestTimeProvider implements TimeProvider
+{
+    @Override
+    public TimeProviderTimestamp getTime() {
+        return TimeProviderTimestamp.valid(ulong(System.currentTimeMillis()));
+    }
+}
+
 public class Main {
     public static void main(String[] args) {
         // Setup logging
@@ -171,7 +179,8 @@ public class Main {
             Association association = master.addAssociation(
                     ushort(1024),
                     associationConfiguration,
-                    associationHandlers
+                    associationHandlers,
+                    new TestTimeProvider()
             );
 
             // Create a periodic poll

--- a/ffi/dnp3-ffi/src/association.rs
+++ b/ffi/dnp3-ffi/src/association.rs
@@ -191,6 +191,9 @@ pub unsafe fn association_perform_time_sync(
             }
             Err(TimeSyncError::Overflow) => ffi::TimeSyncResult::Overflow,
             Err(TimeSyncError::StillNeedsTime) => ffi::TimeSyncResult::StillNeedsTime,
+            Err(TimeSyncError::SystemTimeNotAvailable) => {
+                ffi::TimeSyncResult::SystemTimeNotAvailable
+            }
             Err(TimeSyncError::IINError(_)) => ffi::TimeSyncResult::IINError,
         };
 

--- a/ffi/dnp3-schema/src/association.rs
+++ b/ffi/dnp3-schema/src/association.rs
@@ -463,6 +463,7 @@ pub fn define(
             "StillNeedsTime",
             "Outstation did not clear the NEED_TIME IIN bit",
         )?
+        .push("SystemTimeNotAvailable", "System time not available")?
         .push("IINError", "Outstation indicated an error")?
         .doc("Result of a timesync operation")?
         .build()?;


### PR DESCRIPTION
Fix numerous issues of the time sync task. Since I lost faith in that code, I wrote a bunch of unit tests to help restore peace between me and the time sync task. Here's a list of the issues I found:

- Not all failures were reported back to the association
- Non-LAN time sync:
  - Was using `SystemTime` when not required. It made unit testing harder for nothing. Also, it introduced an unnecessary clock rollback error.
  - Did not accept a `DELAY_MEASURE` with a 16-bit count.
  - Accepted any response after its `WRITE`
 - LAN time sync:
   - Was not recording the time just before sending the `RECORD_CURRENT_TIME` and was actually not even using the outstation time at all.
   - Accepted any response after its `RECORD_CURRENT_TIME`.
   - Accepted any response after its `WRITE`.