### PR TITLE
higher level methods for the TransportReader

### DIFF
--- a/dnp3/src/app/parse/parser.rs
+++ b/dnp3/src/app/parse/parser.rs
@@ -216,16 +216,11 @@ impl<'a> ParsedFragment<'a> {
         fragment: &'a [u8],
     ) -> Result<Self, HeaderParseError> {
         let result = Self::parse_no_logging(fragment);
-        match &result {
-            Ok(fragment) => {
-                if let Some(view) = fragment.display_view(settings) {
-                    log::info!("{}", view);
-                }
+        if let Ok(fragment) = &result {
+            if let Some(view) = fragment.display_view(settings) {
+                log::info!("{}", view);
             }
-            Err(err) => {
-                log::warn!("error parsing fragment header: {}", err);
-            }
-        };
+        }
         result
     }
 }

--- a/dnp3/src/entry/master/tcp/mod.rs
+++ b/dnp3/src/entry/master/tcp/mod.rs
@@ -3,7 +3,7 @@ use crate::app::timeout::Timeout;
 use crate::master::error::Shutdown;
 use crate::master::handle::{Listener, MasterHandle};
 use crate::master::runner::{RunError, Runner};
-use crate::transport::{ReaderType, TransportType, WriterType};
+use crate::transport::{TransportReader, TransportType, WriterType};
 use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::macros::support::Future;
@@ -83,7 +83,7 @@ pub(crate) struct MasterTask {
     endpoint: SocketAddr,
     back_off: ExponentialBackOff,
     runner: Runner,
-    reader: ReaderType,
+    reader: TransportReader,
     writer: WriterType,
     listener: Listener<ClientState>,
 }

--- a/dnp3/src/entry/master/tcp/mod.rs
+++ b/dnp3/src/entry/master/tcp/mod.rs
@@ -3,7 +3,7 @@ use crate::app::timeout::Timeout;
 use crate::master::error::Shutdown;
 use crate::master::handle::{Listener, MasterHandle};
 use crate::master::runner::{RunError, Runner};
-use crate::transport::{ReaderType, WriterType};
+use crate::transport::{ReaderType, TransportType, WriterType};
 use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::macros::support::Future;
@@ -144,7 +144,8 @@ impl MasterTask {
     ) -> (Self, MasterHandle) {
         let (tx, rx) = tokio::sync::mpsc::channel(100); // TODO
         let runner = Runner::new(level, response_timeout, rx);
-        let (reader, writer) = crate::transport::create_transport_layer(true, address);
+        let (reader, writer) =
+            crate::transport::create_transport_layer(TransportType::Master, address);
         let task = Self {
             endpoint,
             back_off: ExponentialBackOff::new(strategy),

--- a/dnp3/src/master/runner.rs
+++ b/dnp3/src/master/runner.rs
@@ -687,7 +687,7 @@ mod test {
     use super::*;
     use crate::master::association::Configuration;
     use crate::master::handle::{MasterHandle, NullHandler};
-    use crate::transport::create_transport_layer;
+    use crate::transport::{create_transport_layer, TransportType};
     use tokio_test::io::Builder;
 
     #[tokio::test]
@@ -721,7 +721,7 @@ mod test {
             .read(&[0xC3, 0x81, 0x00, 0x00])
             .build_with_handle();
 
-        let (mut reader, mut writer) = create_transport_layer(true, 1);
+        let (mut reader, mut writer) = create_transport_layer(TransportType::Master, 1);
 
         let mut master_task =
             tokio_test::task::spawn(runner.run(&mut io, &mut writer, &mut reader));

--- a/dnp3/src/outstation/task.rs
+++ b/dnp3/src/outstation/task.rs
@@ -6,7 +6,7 @@ use crate::app::sequence::Sequence;
 use crate::link::error::LinkError;
 use crate::link::header::Address;
 use crate::outstation::database::{DatabaseConfig, DatabaseHandle};
-use crate::transport::{Fragment, ReaderType, WriterType};
+use crate::transport::{Fragment, ReaderType, TransportType, WriterType};
 
 use crate::util::buffer::Buffer;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -55,8 +55,10 @@ impl OutstationTask {
     /// create an `OutstationTask` and return it along with a `DatabaseHandle` for updating it
     pub fn create(config: OutstationConfig, database: DatabaseConfig) -> (Self, DatabaseHandle) {
         let handle = DatabaseHandle::new(database);
-        let (reader, writer) =
-            crate::transport::create_transport_layer(false, config.outstation_address);
+        let (reader, writer) = crate::transport::create_transport_layer(
+            TransportType::Outstation,
+            config.outstation_address,
+        );
         let task = Self {
             session: Session::new(config.tx_buffer_size, config.log_level, handle.clone()),
             reader,

--- a/dnp3/src/transport/mocks.rs
+++ b/dnp3/src/transport/mocks.rs
@@ -30,8 +30,8 @@ impl MockWriter {
     // just write the fragment directly to the I/O
     pub(crate) async fn write<W>(
         &mut self,
-        _level: DecodeLogLevel,
         io: &mut W,
+        _: DecodeLogLevel,
         _destination: u16,
         fragment: &[u8],
     ) -> Result<(), LinkError>

--- a/dnp3/src/transport/mocks.rs
+++ b/dnp3/src/transport/mocks.rs
@@ -1,7 +1,7 @@
 use crate::app::parse::DecodeLogLevel;
 use crate::link::error::LinkError;
 use crate::link::header::Address;
-use crate::transport::Fragment;
+use crate::transport::{Fragment, TransportType};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 pub(crate) struct MockWriter {
@@ -17,7 +17,7 @@ pub(crate) struct MockReader {
 
 // same signature as the real transport writer
 impl MockWriter {
-    pub(crate) fn new(_master: bool, _address: u16) -> Self {
+    pub(crate) fn new(_: TransportType, _: u16) -> Self {
         Self { num_writes: 0 }
     }
 
@@ -46,7 +46,7 @@ impl MockWriter {
 }
 
 impl MockReader {
-    pub(crate) fn new(_master: bool, address: u16) -> Self {
+    pub(crate) fn new(_: TransportType, address: u16) -> Self {
         Self {
             num_reads: 0,
             count: 0,

--- a/dnp3/src/transport/mod.rs
+++ b/dnp3/src/transport/mod.rs
@@ -22,6 +22,21 @@ pub(crate) mod reader;
 pub(crate) mod sequence;
 pub(crate) mod writer;
 
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum TransportType {
+    Master,
+    Outstation,
+}
+
+impl TransportType {
+    pub(crate) fn is_master(&self) -> bool {
+        match self {
+            TransportType::Master => true,
+            TransportType::Outstation => false,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct Fragment<'a> {
     pub(crate) address: Address,
@@ -33,9 +48,6 @@ pub(crate) mod constants {
     pub(crate) const FIR_MASK: u8 = 0b0100_0000;
 }
 
-pub(crate) fn create_transport_layer(is_master: bool, address: u16) -> (ReaderType, WriterType) {
-    (
-        ReaderType::new(is_master, address),
-        WriterType::new(is_master, address),
-    )
+pub(crate) fn create_transport_layer(typ: TransportType, address: u16) -> (ReaderType, WriterType) {
+    (ReaderType::new(typ, address), WriterType::new(typ, address))
 }

--- a/dnp3/src/transport/reader.rs
+++ b/dnp3/src/transport/reader.rs
@@ -2,7 +2,7 @@ use crate::link::error::LinkError;
 use crate::link::parser::FramePayload;
 use crate::transport::assembler::{Assembler, AssemblyState};
 use crate::transport::header::Header;
-use crate::transport::Fragment;
+use crate::transport::{Fragment, TransportType};
 use tokio::prelude::{AsyncRead, AsyncWrite};
 
 pub(crate) struct Reader {
@@ -11,9 +11,9 @@ pub(crate) struct Reader {
 }
 
 impl Reader {
-    pub(crate) fn new(is_master: bool, address: u16) -> Self {
+    pub(crate) fn new(tt: TransportType, address: u16) -> Self {
         Self {
-            link: crate::link::layer::Layer::new(is_master, address),
+            link: crate::link::layer::Layer::new(tt.is_master(), address),
             assembler: Assembler::new(),
         }
     }

--- a/dnp3/src/transport/writer.rs
+++ b/dnp3/src/transport/writer.rs
@@ -3,6 +3,7 @@ use crate::app::parse::DecodeLogLevel;
 use crate::link::error::LinkError;
 use crate::link::formatter::{LinkFormatter, Payload};
 use crate::transport::sequence::Sequence;
+use crate::transport::TransportType;
 use crate::util::cursor::WriteCursor;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
@@ -26,9 +27,9 @@ impl Writer {
         acc | seq.value()
     }
 
-    pub(crate) fn new(master: bool, address: u16) -> Self {
+    pub(crate) fn new(tt: TransportType, address: u16) -> Self {
         Self {
-            formatter: LinkFormatter::new(master, address),
+            formatter: LinkFormatter::new(tt.is_master(), address),
             seq: Sequence::default(),
             buffer: [0; crate::link::constant::MAX_LINK_FRAME_LENGTH],
         }

--- a/dnp3/src/transport/writer.rs
+++ b/dnp3/src/transport/writer.rs
@@ -41,8 +41,8 @@ impl Writer {
 
     pub(crate) async fn write<W>(
         &mut self,
-        level: DecodeLogLevel,
         io: &mut W,
+        level: DecodeLogLevel,
         destination: u16,
         fragment: &[u8],
     ) -> Result<(), LinkError>
@@ -50,7 +50,7 @@ impl Writer {
         W: AsyncWrite + Unpin,
     {
         if level != DecodeLogLevel::Nothing {
-            ParsedFragment::parse(level.transmit(), fragment).ok();
+            let _ = ParsedFragment::parse(level.transmit(), fragment);
         }
 
         let chunks = fragment.chunks(crate::link::constant::MAX_APP_BYTES_PER_FRAME);


### PR DESCRIPTION
New `TransportReader` type now wraps the typedef `ReaderType` and provides higher level `get_request` and `get_response` methods to avoid repetitive parsing/error handling in the master and outstation.

`TransportReader` provides all the logging required internally, and tracks whether the current fragment has already been logged or not, since there are situations (particularly in the outstation) where the code might parse the same fragment twice.