### PR TITLE
[outstation] Add octet string support

### DIFF
--- a/dnp3/src/app/measurement.rs
+++ b/dnp3/src/app/measurement.rs
@@ -298,3 +298,23 @@ impl OctetString {
         self.value().into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_octet_string_greater_size() {
+        let octet_string = OctetString::new(&[0; 500]);
+        assert_eq!(255, octet_string.len());
+    }
+
+    #[test]
+    fn octet_string_methods() {
+        let octet_string = OctetString::new(&[0, 1, 2, 3, 4]);
+        assert_eq!(5, octet_string.len());
+        assert!(!octet_string.is_empty());
+        assert_eq!(&[0, 1, 2, 3, 4], octet_string.value());
+        assert_eq!(&[0, 1, 2, 3, 4], &*octet_string.as_boxed_slice());
+    }
+}

--- a/dnp3/src/app/measurement.rs
+++ b/dnp3/src/app/measurement.rs
@@ -259,3 +259,38 @@ impl AnalogOutputStatus {
         }
     }
 }
+
+#[allow(missing_copy_implementations)]
+#[derive(Clone, PartialEq, Debug)]
+pub struct OctetString {
+    /// buffer for the value
+    value: [u8; Self::MAX_SIZE],
+    /// Actual length
+    len: u8,
+}
+
+impl OctetString {
+    const MAX_SIZE: usize = 255;
+
+    pub fn new(value: &[u8]) -> Self {
+        let len = std::cmp::min(value.len(), Self::MAX_SIZE);
+        let mut result = Self {
+            value: [0u8; 255],
+            len: len as u8,
+        };
+        result.value[..len].copy_from_slice(&value[..len]);
+        result
+    }
+
+    pub fn value(&self) -> &[u8] {
+        &self.value[..self.len() as usize]
+    }
+
+    pub fn len(&self) -> u8 {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/dnp3/src/app/measurement.rs
+++ b/dnp3/src/app/measurement.rs
@@ -293,4 +293,8 @@ impl OctetString {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    pub(crate) fn as_boxed_slice(&self) -> Box<[u8]> {
+        self.value().into()
+    }
 }

--- a/dnp3/src/outstation/database/config.rs
+++ b/dnp3/src/outstation/database/config.rs
@@ -58,6 +58,10 @@ pub enum EventAnalogOutputStatusVariation {
     Group42Var8,
 }
 
+// This is always g111vX
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) struct EventOctetStringVariation;
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StaticBinaryVariation {
     Group1Var1,
@@ -112,6 +116,10 @@ pub enum StaticAnalogOutputStatusVariation {
     Group40Var4,
 }
 
+// This is always g110vX
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) struct StaticOctetStringVariation;
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct BinaryConfig {
     pub s_var: StaticBinaryVariation,
@@ -157,6 +165,9 @@ pub struct AnalogOutputStatusConfig {
     pub e_var: EventAnalogOutputStatusVariation,
     pub deadband: f64,
 }
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct OctetStringConfig;
 
 impl BinaryConfig {
     pub fn new(s_var: StaticBinaryVariation, e_var: EventBinaryVariation) -> Self {

--- a/dnp3/src/outstation/database/details/event/traits.rs
+++ b/dnp3/src/outstation/database/details/event/traits.rs
@@ -7,6 +7,8 @@ use crate::outstation::database::details::event::write_fn::{
 use crate::outstation::database::details::event::writer::HeaderType;
 use crate::util::cursor::{WriteCursor, WriteError};
 
+use super::write_fn::write_octet_string;
+
 pub(crate) trait EventVariation<T> {
     fn write(
         &self,
@@ -16,7 +18,7 @@ pub(crate) trait EventVariation<T> {
         cto: Time,
     ) -> Result<Continue, WriteError>;
     fn wrap(&self) -> HeaderType;
-    fn get_group_var(&self) -> (u8, u8);
+    fn get_group_var(&self, event: &T) -> (u8, u8);
     fn uses_cto(&self) -> bool {
         false
     }
@@ -54,6 +56,10 @@ impl BaseEvent for AnalogOutputStatus {
     type EventVariation = EventAnalogOutputStatusVariation;
 }
 
+impl BaseEvent for OctetString {
+    type EventVariation = EventOctetStringVariation;
+}
+
 impl EventVariation<Binary> for EventBinaryVariation {
     fn write(
         &self,
@@ -73,7 +79,7 @@ impl EventVariation<Binary> for EventBinaryVariation {
         HeaderType::Binary(*self)
     }
 
-    fn get_group_var(&self) -> (u8, u8) {
+    fn get_group_var(&self, _event: &Binary) -> (u8, u8) {
         match self {
             Self::Group2Var1 => (2, 1),
             Self::Group2Var2 => (2, 2),
@@ -108,7 +114,7 @@ impl EventVariation<BinaryOutputStatus> for EventBinaryOutputStatusVariation {
         HeaderType::BinaryOutputStatus(*self)
     }
 
-    fn get_group_var(&self) -> (u8, u8) {
+    fn get_group_var(&self, _event: &BinaryOutputStatus) -> (u8, u8) {
         match self {
             Self::Group11Var1 => (11, 1),
             Self::Group11Var2 => (11, 2),
@@ -139,7 +145,7 @@ impl EventVariation<DoubleBitBinary> for EventDoubleBitBinaryVariation {
         HeaderType::DoubleBitBinary(*self)
     }
 
-    fn get_group_var(&self) -> (u8, u8) {
+    fn get_group_var(&self, _event: &DoubleBitBinary) -> (u8, u8) {
         match self {
             Self::Group4Var1 => (4, 1),
             Self::Group4Var2 => (4, 2),
@@ -180,7 +186,7 @@ impl EventVariation<Counter> for EventCounterVariation {
         HeaderType::Counter(*self)
     }
 
-    fn get_group_var(&self) -> (u8, u8) {
+    fn get_group_var(&self, _event: &Counter) -> (u8, u8) {
         match self {
             Self::Group22Var1 => (22, 1),
             Self::Group22Var2 => (22, 2),
@@ -218,7 +224,7 @@ impl EventVariation<FrozenCounter> for EventFrozenCounterVariation {
         HeaderType::FrozenCounter(*self)
     }
 
-    fn get_group_var(&self) -> (u8, u8) {
+    fn get_group_var(&self, _event: &FrozenCounter) -> (u8, u8) {
         match self {
             Self::Group23Var1 => (23, 1),
             Self::Group23Var2 => (23, 2),
@@ -252,7 +258,7 @@ impl EventVariation<Analog> for EventAnalogVariation {
         HeaderType::Analog(*self)
     }
 
-    fn get_group_var(&self) -> (u8, u8) {
+    fn get_group_var(&self, _event: &Analog) -> (u8, u8) {
         match self {
             Self::Group32Var1 => (32, 1),
             Self::Group32Var2 => (32, 2),
@@ -306,7 +312,7 @@ impl EventVariation<AnalogOutputStatus> for EventAnalogOutputStatusVariation {
         HeaderType::AnalogOutputStatus(*self)
     }
 
-    fn get_group_var(&self) -> (u8, u8) {
+    fn get_group_var(&self, _event: &AnalogOutputStatus) -> (u8, u8) {
         match self {
             Self::Group42Var1 => (42, 1),
             Self::Group42Var2 => (42, 2),
@@ -317,5 +323,25 @@ impl EventVariation<AnalogOutputStatus> for EventAnalogOutputStatusVariation {
             Self::Group42Var7 => (42, 7),
             Self::Group42Var8 => (42, 8),
         }
+    }
+}
+
+impl EventVariation<OctetString> for EventOctetStringVariation {
+    fn write(
+        &self,
+        cursor: &mut WriteCursor,
+        event: &OctetString,
+        index: u16,
+        _cto: Time,
+    ) -> Result<Continue, WriteError> {
+        write_octet_string(cursor, event, index)
+    }
+
+    fn wrap(&self) -> HeaderType {
+        HeaderType::OctetString(*self)
+    }
+
+    fn get_group_var(&self, event: &OctetString) -> (u8, u8) {
+        (111, event.len())
     }
 }

--- a/dnp3/src/outstation/database/details/event/traits.rs
+++ b/dnp3/src/outstation/database/details/event/traits.rs
@@ -24,41 +24,10 @@ pub(crate) trait EventVariation<T> {
     }
 }
 
-pub(crate) trait BaseEvent: Sized {
-    type EventVariation: Copy + PartialEq + EventVariation<Self>;
-}
-
-impl BaseEvent for Binary {
-    type EventVariation = EventBinaryVariation;
-}
-
-impl BaseEvent for DoubleBitBinary {
-    type EventVariation = EventDoubleBitBinaryVariation;
-}
-
-impl BaseEvent for BinaryOutputStatus {
-    type EventVariation = EventBinaryOutputStatusVariation;
-}
-
-impl BaseEvent for Counter {
-    type EventVariation = EventCounterVariation;
-}
-
-impl BaseEvent for FrozenCounter {
-    type EventVariation = EventFrozenCounterVariation;
-}
-
-impl BaseEvent for Analog {
-    type EventVariation = EventAnalogVariation;
-}
-
-impl BaseEvent for AnalogOutputStatus {
-    type EventVariation = EventAnalogOutputStatusVariation;
-}
-
-impl BaseEvent for OctetString {
-    type EventVariation = EventOctetStringVariation;
-}
+/*pub(crate) trait BaseEvent: Sized {
+    type EventType;
+    type EventVariation: Copy + PartialEq + EventVariation<Self::EventType>;
+}*/
 
 impl EventVariation<Binary> for EventBinaryVariation {
     fn write(
@@ -326,11 +295,11 @@ impl EventVariation<AnalogOutputStatus> for EventAnalogOutputStatusVariation {
     }
 }
 
-impl EventVariation<OctetString> for EventOctetStringVariation {
+impl EventVariation<Box<[u8]>> for EventOctetStringVariation {
     fn write(
         &self,
         cursor: &mut WriteCursor,
-        event: &OctetString,
+        event: &Box<[u8]>,
         index: u16,
         _cto: Time,
     ) -> Result<Continue, WriteError> {
@@ -341,7 +310,7 @@ impl EventVariation<OctetString> for EventOctetStringVariation {
         HeaderType::OctetString(*self)
     }
 
-    fn get_group_var(&self, event: &OctetString) -> (u8, u8) {
-        (111, event.len())
+    fn get_group_var(&self, event: &Box<[u8]>) -> (u8, u8) {
+        (111, event.len() as u8)
     }
 }

--- a/dnp3/src/outstation/database/details/event/traits.rs
+++ b/dnp3/src/outstation/database/details/event/traits.rs
@@ -24,11 +24,6 @@ pub(crate) trait EventVariation<T> {
     }
 }
 
-/*pub(crate) trait BaseEvent: Sized {
-    type EventType;
-    type EventVariation: Copy + PartialEq + EventVariation<Self::EventType>;
-}*/
-
 impl EventVariation<Binary> for EventBinaryVariation {
     fn write(
         &self,

--- a/dnp3/src/outstation/database/details/event/write_fn.rs
+++ b/dnp3/src/outstation/database/details/event/write_fn.rs
@@ -1,4 +1,4 @@
-use crate::app::measurement::{Binary, DoubleBitBinary, Time, ToVariation, WireFlags};
+use crate::app::measurement::{Binary, DoubleBitBinary, OctetString, Time, ToVariation, WireFlags};
 use crate::app::parse::traits::FixedSize;
 use crate::app::variations::{Group2Var3, Group4Var3};
 use crate::util::cursor::{WriteCursor, WriteError};
@@ -72,6 +72,16 @@ where
     let variation = event.to_cto_variation(difference as u16); // difference in range [0, u16::max]
 
     write_prefixed(cursor, &variation, index).map(|_| Continue::Ok)
+}
+
+pub(crate) fn write_octet_string(
+    cursor: &mut WriteCursor,
+    event: &OctetString,
+    index: u16,
+) -> Result<Continue, WriteError> {
+    cursor.write_u16_le(index)?;
+    cursor.write(&event.value())?;
+    Ok(Continue::Ok)
 }
 
 impl ToVariationCTO<Group2Var3> for Binary {

--- a/dnp3/src/outstation/database/details/event/write_fn.rs
+++ b/dnp3/src/outstation/database/details/event/write_fn.rs
@@ -1,4 +1,4 @@
-use crate::app::measurement::{Binary, DoubleBitBinary, OctetString, Time, ToVariation, WireFlags};
+use crate::app::measurement::{Binary, DoubleBitBinary, Time, ToVariation, WireFlags};
 use crate::app::parse::traits::FixedSize;
 use crate::app::variations::{Group2Var3, Group4Var3};
 use crate::util::cursor::{WriteCursor, WriteError};
@@ -76,11 +76,11 @@ where
 
 pub(crate) fn write_octet_string(
     cursor: &mut WriteCursor,
-    event: &OctetString,
+    event: &[u8],
     index: u16,
 ) -> Result<Continue, WriteError> {
     cursor.write_u16_le(index)?;
-    cursor.write(&event.value())?;
+    cursor.write(&event)?;
     Ok(Continue::Ok)
 }
 

--- a/dnp3/src/outstation/database/details/event/writer.rs
+++ b/dnp3/src/outstation/database/details/event/writer.rs
@@ -4,7 +4,6 @@ use crate::app::parse::traits::{FixedSize, FixedSizeVariation};
 use crate::app::types::Timestamp;
 use crate::app::variations::{Group51Var1, Group51Var2};
 use crate::outstation::database::config::*;
-use crate::outstation::database::details::event::traits::BaseEvent;
 use crate::outstation::database::details::event::traits::EventVariation;
 use crate::outstation::database::details::event::write_fn::Continue;
 use crate::util::cursor::{WriteCursor, WriteError};
@@ -59,7 +58,9 @@ pub(crate) struct EventWriter {
     state: State,
 }
 
-pub(crate) trait Writable: Sized + BaseEvent {
+pub(crate) trait Writable: Sized {
+    type EventVariation: PartialEq + EventVariation<Self>;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation>;
 
     fn get_time(&self) -> Option<Time>;
@@ -216,6 +217,8 @@ impl EventWriter {
 }
 
 impl Writable for Binary {
+    type EventVariation = EventBinaryVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::Binary(var) => Some(*var),
@@ -229,6 +232,8 @@ impl Writable for Binary {
 }
 
 impl Writable for DoubleBitBinary {
+    type EventVariation = EventDoubleBitBinaryVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::DoubleBitBinary(var) => Some(*var),
@@ -242,6 +247,8 @@ impl Writable for DoubleBitBinary {
 }
 
 impl Writable for BinaryOutputStatus {
+    type EventVariation = EventBinaryOutputStatusVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::BinaryOutputStatus(var) => Some(*var),
@@ -255,6 +262,8 @@ impl Writable for BinaryOutputStatus {
 }
 
 impl Writable for Counter {
+    type EventVariation = EventCounterVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::Counter(var) => Some(*var),
@@ -268,6 +277,8 @@ impl Writable for Counter {
 }
 
 impl Writable for FrozenCounter {
+    type EventVariation = EventFrozenCounterVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::FrozenCounter(var) => Some(*var),
@@ -281,6 +292,8 @@ impl Writable for FrozenCounter {
 }
 
 impl Writable for Analog {
+    type EventVariation = EventAnalogVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::Analog(var) => Some(*var),
@@ -294,6 +307,8 @@ impl Writable for Analog {
 }
 
 impl Writable for AnalogOutputStatus {
+    type EventVariation = EventAnalogOutputStatusVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::AnalogOutputStatus(var) => Some(*var),
@@ -306,7 +321,9 @@ impl Writable for AnalogOutputStatus {
     }
 }
 
-impl Writable for OctetString {
+impl Writable for Box<[u8]> {
+    type EventVariation = EventOctetStringVariation;
+
     fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
         match header {
             HeaderType::OctetString(var) => Some(*var),

--- a/dnp3/src/outstation/database/details/event/writer.rs
+++ b/dnp3/src/outstation/database/details/event/writer.rs
@@ -45,6 +45,7 @@ pub(crate) enum HeaderType {
     FrozenCounter(EventFrozenCounterVariation),
     Analog(EventAnalogVariation),
     AnalogOutputStatus(EventAnalogOutputStatusVariation),
+    OctetString(EventOctetStringVariation),
 }
 
 #[derive(Copy, Clone)]
@@ -201,7 +202,7 @@ impl EventWriter {
                 }
             }
 
-            let (group, var) = variation.get_group_var();
+            let (group, var) = variation.get_group_var(event);
             let count_pos = Self::write_event_header(cursor, group, var)?;
             variation.write(cursor, event, index, time).map(|_| ())?;
             Ok(count_pos)
@@ -302,6 +303,19 @@ impl Writable for AnalogOutputStatus {
 
     fn get_time(&self) -> Option<Time> {
         self.time
+    }
+}
+
+impl Writable for OctetString {
+    fn get_header_variation(&self, header: &HeaderType) -> Option<Self::EventVariation> {
+        match header {
+            HeaderType::OctetString(var) => Some(*var),
+            _ => None,
+        }
+    }
+
+    fn get_time(&self) -> Option<Time> {
+        None
     }
 }
 

--- a/dnp3/src/outstation/database/details/range/traits.rs
+++ b/dnp3/src/outstation/database/details/range/traits.rs
@@ -43,6 +43,16 @@ fn double_bit_type<T>(variation: Variation, func: fn(&T) -> DoubleBit) -> WriteI
     }
 }
 
+fn octet_string(value: &OctetString) -> WriteInfo<OctetString> {
+    fn write(cursor: &mut WriteCursor, value: &OctetString) -> Result<(), WriteError> {
+        cursor.write(value.value())
+    }
+    WriteInfo {
+        variation: Variation::Group110(value.len()),
+        write_type: WriteType::Fixed(write),
+    }
+}
+
 #[derive(Copy, Clone)]
 pub(crate) enum WriteType<T> {
     Fixed(FixedWriteFn<T>),
@@ -64,7 +74,7 @@ pub(crate) trait StaticVariation<T>: Copy + PartialEq {
         *self
     }
 
-    fn get_write_info(&self) -> WriteInfo<T>;
+    fn get_write_info(&self, value: &T) -> WriteInfo<T>;
 }
 
 impl StaticVariation<Binary> for StaticBinaryVariation {
@@ -80,7 +90,7 @@ impl StaticVariation<Binary> for StaticBinaryVariation {
         }
     }
 
-    fn get_write_info(&self) -> WriteInfo<Binary> {
+    fn get_write_info(&self, _value: &Binary) -> WriteInfo<Binary> {
         match self {
             Self::Group1Var1 => bit_type(Variation::Group1Var1, |v| v.value),
             Self::Group1Var2 => fixed_type::<Binary, Group1Var2>(),
@@ -101,7 +111,7 @@ impl StaticVariation<DoubleBitBinary> for StaticDoubleBitBinaryVariation {
         }
     }
 
-    fn get_write_info(&self) -> WriteInfo<DoubleBitBinary> {
+    fn get_write_info(&self, _value: &DoubleBitBinary) -> WriteInfo<DoubleBitBinary> {
         match self {
             Self::Group3Var1 => double_bit_type(Variation::Group3Var1, |v| v.value),
             Self::Group3Var2 => fixed_type::<DoubleBitBinary, Group3Var2>(),
@@ -122,7 +132,7 @@ impl StaticVariation<BinaryOutputStatus> for StaticBinaryOutputStatusVariation {
         }
     }
 
-    fn get_write_info(&self) -> WriteInfo<BinaryOutputStatus> {
+    fn get_write_info(&self, _value: &BinaryOutputStatus) -> WriteInfo<BinaryOutputStatus> {
         match self {
             Self::Group10Var1 => bit_type(Variation::Group10Var1, |v| v.value),
             Self::Group10Var2 => fixed_type::<BinaryOutputStatus, Group10Var2>(),
@@ -131,7 +141,7 @@ impl StaticVariation<BinaryOutputStatus> for StaticBinaryOutputStatusVariation {
 }
 
 impl StaticVariation<Counter> for StaticCounterVariation {
-    fn get_write_info(&self) -> WriteInfo<Counter> {
+    fn get_write_info(&self, _value: &Counter) -> WriteInfo<Counter> {
         match self {
             StaticCounterVariation::Group20Var1 => fixed_type::<Counter, Group20Var1>(),
             StaticCounterVariation::Group20Var2 => fixed_type::<Counter, Group20Var2>(),
@@ -142,7 +152,7 @@ impl StaticVariation<Counter> for StaticCounterVariation {
 }
 
 impl StaticVariation<FrozenCounter> for StaticFrozenCounterVariation {
-    fn get_write_info(&self) -> WriteInfo<FrozenCounter> {
+    fn get_write_info(&self, _value: &FrozenCounter) -> WriteInfo<FrozenCounter> {
         match self {
             StaticFrozenCounterVariation::Group21Var1 => fixed_type::<FrozenCounter, Group21Var1>(),
             StaticFrozenCounterVariation::Group21Var2 => fixed_type::<FrozenCounter, Group21Var2>(),
@@ -157,7 +167,7 @@ impl StaticVariation<FrozenCounter> for StaticFrozenCounterVariation {
 }
 
 impl StaticVariation<Analog> for StaticAnalogVariation {
-    fn get_write_info(&self) -> WriteInfo<Analog> {
+    fn get_write_info(&self, _value: &Analog) -> WriteInfo<Analog> {
         match self {
             StaticAnalogVariation::Group30Var1 => fixed_type::<Analog, Group30Var1>(),
             StaticAnalogVariation::Group30Var2 => fixed_type::<Analog, Group30Var2>(),
@@ -170,7 +180,7 @@ impl StaticVariation<Analog> for StaticAnalogVariation {
 }
 
 impl StaticVariation<AnalogOutputStatus> for StaticAnalogOutputStatusVariation {
-    fn get_write_info(&self) -> WriteInfo<AnalogOutputStatus> {
+    fn get_write_info(&self, _value: &AnalogOutputStatus) -> WriteInfo<AnalogOutputStatus> {
         match self {
             StaticAnalogOutputStatusVariation::Group40Var1 => {
                 fixed_type::<AnalogOutputStatus, Group40Var1>()
@@ -185,5 +195,11 @@ impl StaticVariation<AnalogOutputStatus> for StaticAnalogOutputStatusVariation {
                 fixed_type::<AnalogOutputStatus, Group40Var4>()
             }
         }
+    }
+}
+
+impl StaticVariation<OctetString> for StaticOctetStringVariation {
+    fn get_write_info(&self, value: &OctetString) -> WriteInfo<OctetString> {
+        octet_string(value)
     }
 }

--- a/dnp3/src/outstation/database/details/range/writer.rs
+++ b/dnp3/src/outstation/database/details/range/writer.rs
@@ -306,7 +306,7 @@ mod tests {
 
         let mut writer = RangeWriter::new();
 
-        let g1v1 = StaticBinaryVariation::Group1Var1.get_write_info();
+        let g1v1 = StaticBinaryVariation::Group1Var1.get_write_info(&binary(false));
 
         fn is_odd(index: u16) -> bool {
             index % 2 == 1
@@ -353,7 +353,8 @@ mod tests {
             }
         }
 
-        let g3v1 = StaticDoubleBitBinaryVariation::Group3Var1.get_write_info();
+        let g3v1 = StaticDoubleBitBinaryVariation::Group3Var1
+            .get_write_info(&double_bit(DoubleBit::DeterminedOff));
 
         for index in 1..=5 {
             let value = double_bit(db_modulo(index));
@@ -388,7 +389,7 @@ mod tests {
         let mut cursor = WriteCursor::new(buffer.as_mut());
         let mut writer = RangeWriter::new();
 
-        let g1v2 = StaticBinaryVariation::Group1Var2.get_write_info();
+        let g1v2 = StaticBinaryVariation::Group1Var2.get_write_info(&binary(false));
 
         writer.write(&mut cursor, 2, &binary(true), g1v2).unwrap();
         writer.write(&mut cursor, 2, &binary(true), g1v2).unwrap();
@@ -412,7 +413,7 @@ mod tests {
         let mut cursor = WriteCursor::new(buffer.as_mut());
         let mut writer = RangeWriter::new();
 
-        let g1v2 = StaticBinaryVariation::Group1Var2.get_write_info();
+        let g1v2 = StaticBinaryVariation::Group1Var2.get_write_info(&binary(false));
 
         writer.write(&mut cursor, 1, &binary(true), g1v2).unwrap();
         writer.write(&mut cursor, 3, &binary(true), g1v2).unwrap();

--- a/dnp3/src/outstation/database/read.rs
+++ b/dnp3/src/outstation/database/read.rs
@@ -21,6 +21,7 @@ pub(crate) enum StaticReadHeader {
         Option<StaticAnalogOutputStatusVariation>,
         Option<IndexRange>,
     ),
+    OctetString(Option<IndexRange>),
 }
 
 #[derive(Copy, Clone)]
@@ -37,6 +38,7 @@ pub(crate) enum EventReadHeader {
     FrozenCounter(Option<EventFrozenCounterVariation>, Option<usize>),
     Analog(Option<EventAnalogVariation>, Option<usize>),
     AnalogOutputStatus(Option<EventAnalogOutputStatusVariation>, Option<usize>),
+    OctetString(Option<usize>),
 }
 
 /// Enum representation of all header types that can be in a READ request
@@ -437,16 +439,19 @@ impl ReadHeader {
             // group 80
             AllObjectsVariation::Group80Var1 => None,
             // group 110
-            AllObjectsVariation::Group110Var0 => None,
-            AllObjectsVariation::Group111Var0 => None,
+            AllObjectsVariation::Group110Var0 => Some(StaticReadHeader::OctetString(None).into()),
+            // group 111
+            AllObjectsVariation::Group111Var0 => Some(EventReadHeader::OctetString(None).into()),
         }
     }
 
     fn from_count(_header: &CountVariation) -> Option<ReadHeader> {
+        // TODO: implement this
         None
     }
 
     fn from_range(_header: &RangedVariation) -> Option<ReadHeader> {
+        // TODO: implement this
         None
     }
 }

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -697,6 +697,14 @@ impl OutstationSession {
                     length,
                     None,
                 ));
+
+                // Cancel unsolicited series if it's a DISABLE_UNSOLICITED
+                if request.header.function == FunctionCode::DisableUnsolicited {
+                    return Ok(UnsolicitedWaitResult::Complete(
+                        UnsolicitedResult::ReturnToIdle,
+                    ));
+                }
+
                 Ok(UnsolicitedWaitResult::ReadNext)
             }
             FragmentType::NewRead(hash, headers) => {


### PR DESCRIPTION
Add octet string support to the outstation. Fix #54.

- The internal database holds 255 bytes per octet string, so no dynamic allocation occurs there.
- The event buffer stores `Box<[u8]>`. Since an allocation is required here to avoid having a 255 bytes `Event` enum, it only stores the bytes required to hold the new value.
- By default, octet strings are **not** reported in Class 0 requests. I let the option to include it in Class 0, although the standard clearly forbids it (see IEEE 1815-2012 annex A.41 🚣)
- I had to play with the traits a little bit. `BaseEvent` does not exist anymore, since the type stored in the database (the `Insertable`) is not the same as the type stored in the event buffer (the `Writable`).
- Fixed implementation of `Insertable::is_type` for `AnalogOutputStatus`. I think it might have not cleared the event buffer for this type, although I never saw it in action. I just saw that the code was obviously wrong.
- Fixed a bug where an unsolicited retry series wouldn't stop when receiving a `DISABLE_UNSOLICITED` request. This was causing trouble when restarting a master for example.
  - IEEE 1815-2012 says "The request [`DISABLE_UNSOLICITED`] also cancels any pending expectation of confirmation for an unsolicited response that has already been sent from the outstation, but for which confirmation has not yet been received." (p. 60-61).
  - Added a unit test for this edge case.