### PR TITLE
refactor transport reader app decoding

### DIFF
--- a/dnp3/src/app/parse/mod.rs
+++ b/dnp3/src/app/parse/mod.rs
@@ -17,6 +17,12 @@ pub enum DecodeLogLevel {
     ObjectValues,
 }
 
+impl DecodeLogLevel {
+    pub(crate) fn enabled(&self) -> bool {
+        *self != Self::Nothing
+    }
+}
+
 pub(crate) mod bit;
 pub(crate) mod count;
 pub(crate) mod parser;

--- a/dnp3/src/app/parse/parser.rs
+++ b/dnp3/src/app/parse/parser.rs
@@ -20,7 +20,6 @@ pub(crate) struct DecodeSettings {
     level: DecodeLogLevel,
 }
 
-#[cfg(test)]
 impl DecodeSettings {
     pub(crate) fn none() -> Self {
         Self {


### PR DESCRIPTION
Perform decoding when a fragment is received. This eliminates the need to track whether its been logged or not