### PR TITLE
rename *Configuration -> *Config

### DIFF
--- a/dnp3/benches/benchmark.rs
+++ b/dnp3/benches/benchmark.rs
@@ -18,7 +18,7 @@ use dnp3::config::{DecodeLevel, LinkErrorMode};
 use dnp3::entry::master::tcp::EndpointList;
 use dnp3::entry::outstation::tcp::{ServerHandle, TcpServer};
 use dnp3::entry::outstation::AddressFilter;
-use dnp3::master::association::Configuration;
+use dnp3::master::association::AssociationConfig;
 use dnp3::master::handle::{
     AssociationHandler, HeaderInfo, Listener, MasterConfiguration, MasterHandle, ReadHandler,
 };
@@ -278,8 +278,8 @@ impl Pair {
         )
     }
 
-    fn get_association_config() -> Configuration {
-        let mut config = Configuration::quiet(RetryStrategy::default());
+    fn get_association_config() -> AssociationConfig {
+        let mut config = AssociationConfig::quiet(RetryStrategy::default());
         config.enable_unsol_classes = EventClasses::all();
         config
     }

--- a/dnp3/benches/benchmark.rs
+++ b/dnp3/benches/benchmark.rs
@@ -20,7 +20,7 @@ use dnp3::entry::outstation::tcp::{ServerHandle, TcpServer};
 use dnp3::entry::outstation::AddressFilter;
 use dnp3::master::association::AssociationConfig;
 use dnp3::master::handle::{
-    AssociationHandler, HeaderInfo, Listener, MasterConfiguration, MasterHandle, ReadHandler,
+    AssociationHandler, HeaderInfo, Listener, MasterConfig, MasterHandle, ReadHandler,
 };
 use dnp3::master::request::EventClasses;
 use dnp3::outstation::config::OutstationConfig;
@@ -269,8 +269,8 @@ impl Pair {
         EndpointAddress::from(1).unwrap()
     }
 
-    fn get_master_config(level: DecodeLevel) -> MasterConfiguration {
-        MasterConfiguration::new(
+    fn get_master_config(level: DecodeLevel) -> MasterConfig {
+        MasterConfig::new(
             Self::master_address(),
             level,
             ReconnectStrategy::default(),

--- a/dnp3/examples/master_tcp_client.rs
+++ b/dnp3/examples/master_tcp_client.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Create the association
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.auto_time_sync = Some(TimeSyncProcedure::Lan);
     config.keep_alive_timeout = Some(Duration::from_secs(60));
     let mut association = master

--- a/dnp3/examples/master_tcp_client.rs
+++ b/dnp3/examples/master_tcp_client.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // spawn the master onto another task
     let mut master = spawn_master_tcp_client(
         LinkErrorMode::Close,
-        MasterConfiguration::new(
+        MasterConfig::new(
             EndpointAddress::from(1)?,
             AppDecodeLevel::ObjectValues.into(),
             ReconnectStrategy::default(),

--- a/dnp3/src/entry/master/serial.rs
+++ b/dnp3/src/entry/master/serial.rs
@@ -1,6 +1,6 @@
 use crate::app::retry::ExponentialBackOff;
 use crate::entry::master::ClientState;
-use crate::master::handle::{Listener, MasterConfiguration, MasterHandle};
+use crate::master::handle::{Listener, MasterConfig, MasterHandle};
 use crate::master::session::{MasterSession, RunError};
 use crate::transport::TransportReader;
 use crate::transport::TransportWriter;
@@ -23,7 +23,7 @@ use tracing::Instrument;
 /// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
 /// It is preferable to use this method instead of `create(..)` when using `[tokio::main]`.
 pub fn spawn_master_serial_client(
-    config: MasterConfiguration,
+    config: MasterConfig,
     path: &str,
     serial_settings: SerialSettings,
     listener: Listener<ClientState>,
@@ -42,7 +42,7 @@ pub fn spawn_master_serial_client(
 /// tasks instead of within the context of a runtime, e.g. in applications that cannot use
 /// `[tokio::main]` such as C language bindings.
 pub fn create_master_serial_client(
-    config: MasterConfiguration,
+    config: MasterConfig,
     path: &str,
     settings: SerialSettings,
     listener: Listener<ClientState>,
@@ -72,7 +72,7 @@ impl MasterTask {
     fn new(
         path: &str,
         serial_settings: SerialSettings,
-        config: MasterConfiguration,
+        config: MasterConfig,
         listener: Listener<ClientState>,
     ) -> (Self, MasterHandle) {
         let (tx, rx) = crate::tokio::sync::mpsc::channel(100); // TODO

--- a/dnp3/src/entry/master/tcp.rs
+++ b/dnp3/src/entry/master/tcp.rs
@@ -1,7 +1,7 @@
 use crate::app::retry::ExponentialBackOff;
 use crate::config::LinkErrorMode;
 use crate::entry::master::ClientState;
-use crate::master::handle::{Listener, MasterConfiguration, MasterHandle};
+use crate::master::handle::{Listener, MasterConfig, MasterHandle};
 use crate::master::session::{MasterSession, RunError};
 use crate::tokio::net::TcpStream;
 use crate::transport::TransportReader;
@@ -101,7 +101,7 @@ impl EndpointList {
 /// It is preferable to use this method instead of `create(..)` when using `[tokio::main]`.
 pub fn spawn_master_tcp_client(
     link_error_mode: LinkErrorMode,
-    config: MasterConfiguration,
+    config: MasterConfig,
     endpoints: EndpointList,
     listener: Listener<ClientState>,
 ) -> MasterHandle {
@@ -120,7 +120,7 @@ pub fn spawn_master_tcp_client(
 /// `[tokio::main]` such as C language bindings.
 pub fn create_master_tcp_client(
     link_error_mode: LinkErrorMode,
-    config: MasterConfiguration,
+    config: MasterConfig,
     endpoints: EndpointList,
     listener: Listener<ClientState>,
 ) -> (impl Future<Output = ()> + 'static, MasterHandle) {
@@ -148,7 +148,7 @@ impl MasterTask {
     fn new(
         link_error_mode: LinkErrorMode,
         endpoints: EndpointList,
-        config: MasterConfiguration,
+        config: MasterConfig,
         listener: Listener<ClientState>,
     ) -> (Self, MasterHandle) {
         let (tx, rx) = crate::tokio::sync::mpsc::channel(100); // TODO

--- a/dnp3/src/lib.rs
+++ b/dnp3/src/lib.rs
@@ -25,7 +25,7 @@
 //! // spawn the master onto another task
 //! let mut master = spawn_master_tcp_client(
 //!         LinkErrorMode::Close,
-//!         MasterConfiguration::new(
+//!         MasterConfig::new(
 //!             EndpointAddress::from(1)?,
 //!             AppDecodeLevel::ObjectValues.into(),
 //!             ReconnectStrategy::default(),

--- a/dnp3/src/lib.rs
+++ b/dnp3/src/lib.rs
@@ -35,7 +35,7 @@
 //!         Listener::None,
 //!     );
 //!
-//!     let mut association = master.add_association(EndpointAddress::from(1024)?, Configuration::default(), NullHandler::boxed()).await?;
+//!     let mut association = master.add_association(EndpointAddress::from(1024)?, AssociationConfig::default(), NullHandler::boxed()).await?;
 //!     association.add_poll(
 //!         EventClasses::all().to_classes().to_request(),
 //!         Duration::from_secs(5),

--- a/dnp3/src/master/association.rs
+++ b/dnp3/src/master/association.rs
@@ -24,7 +24,7 @@ pub use crate::master::poll::PollHandle;
 use crate::master::session::RunError;
 
 #[derive(Copy, Clone)]
-pub struct Configuration {
+pub struct AssociationConfig {
     /// The event classes to disable on startup
     pub disable_unsol_classes: EventClasses,
     /// The event classes to enable on startup
@@ -48,7 +48,7 @@ pub struct Configuration {
     pub event_scan_on_events_available: EventClasses,
 }
 
-impl Configuration {
+impl AssociationConfig {
     pub fn quiet(auto_tasks_retry_strategy: RetryStrategy) -> Self {
         Self {
             disable_unsol_classes: EventClasses::none(),
@@ -63,7 +63,7 @@ impl Configuration {
     }
 }
 
-impl Default for Configuration {
+impl Default for AssociationConfig {
     fn default() -> Self {
         Self {
             disable_unsol_classes: EventClasses::all(),
@@ -126,7 +126,7 @@ impl AutoTaskState {
     }
 
     /// The task failed and needs rescheduling
-    fn failure(&mut self, config: &Configuration) {
+    fn failure(&mut self, config: &AssociationConfig) {
         *self = match self {
             Self::Failed(backoff, _) => {
                 let delay = backoff.on_failure();
@@ -173,7 +173,7 @@ impl TaskStates {
         self.enabled_unsolicited.demand();
     }
 
-    fn next(&self, config: &Configuration, association: &Association) -> Next<Task> {
+    fn next(&self, config: &AssociationConfig, association: &Association) -> Next<Task> {
         if self.clear_restart_iin.is_pending() {
             return self
                 .clear_restart_iin
@@ -242,7 +242,7 @@ pub(crate) struct Association {
     request_queue: VecDeque<Task>,
     auto_tasks: TaskStates,
     handler: Box<dyn AssociationHandler>,
-    config: Configuration,
+    config: AssociationConfig,
     polls: PollMap,
     next_link_status: Option<Instant>,
     startup_integrity_done: bool,
@@ -252,7 +252,7 @@ pub(crate) struct Association {
 impl Association {
     pub(crate) fn new(
         address: EndpointAddress,
-        config: Configuration,
+        config: AssociationConfig,
         handler: Box<dyn AssociationHandler>,
     ) -> Self {
         Self {

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -9,7 +9,7 @@ use crate::app::types::Timestamp;
 use crate::app::variations::Variation;
 use crate::config::DecodeLevel;
 use crate::config::EndpointAddress;
-use crate::master::association::{Association, Configuration};
+use crate::master::association::{Association, AssociationConfig};
 use crate::master::error::{AssociationError, CommandError, PollError, TaskError, TimeSyncError};
 use crate::master::messages::{AssociationMsg, AssociationMsgType, MasterMsg, Message};
 use crate::master::poll::{PollHandle, PollMsg};
@@ -103,7 +103,7 @@ impl MasterHandle {
     pub async fn add_association(
         &mut self,
         address: EndpointAddress,
-        config: Configuration,
+        config: AssociationConfig,
         handler: Box<dyn AssociationHandler>,
     ) -> Result<AssociationHandle, AssociationError> {
         let association = Association::new(address, config, handler);

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -38,7 +38,7 @@ pub struct AssociationHandle {
 
 /// Master configuration
 #[derive(Copy, Clone, Debug)]
-pub struct MasterConfiguration {
+pub struct MasterConfig {
     /// Local DNP3 master address
     pub address: EndpointAddress,
     /// Decode-level for DNP3 objects
@@ -57,7 +57,7 @@ pub struct MasterConfiguration {
     pub rx_buffer_size: usize,
 }
 
-impl MasterConfiguration {
+impl MasterConfig {
     /// Create a configuration with default buffer sizes
     pub fn new(
         address: EndpointAddress,

--- a/dnp3/src/master/tasks/restart.rs
+++ b/dnp3/src/master/tasks/restart.rs
@@ -125,7 +125,7 @@ mod tests {
     fn cold_restart() {
         let mut association = Association::new(
             EndpointAddress::from(1).unwrap(),
-            Configuration::default(),
+            AssociationConfig::default(),
             NullHandler::boxed(),
         );
         let (tx, mut rx) = crate::tokio::sync::oneshot::channel();
@@ -171,7 +171,7 @@ mod tests {
     fn warm_restart() {
         let mut association = Association::new(
             EndpointAddress::from(1).unwrap(),
-            Configuration::default(),
+            AssociationConfig::default(),
             NullHandler::boxed(),
         );
         let (tx, mut rx) = crate::tokio::sync::oneshot::channel();

--- a/dnp3/src/master/tasks/time.rs
+++ b/dnp3/src/master/tasks/time.rs
@@ -603,7 +603,7 @@ mod tests {
             let system_time = Timestamp::try_from_system_time(SystemTime::now()).unwrap();
             let association = Association::new(
                 EndpointAddress::from(1).unwrap(),
-                Configuration::default(),
+                AssociationConfig::default(),
                 Box::new(TestHandler::new(system_time)),
             );
             let (tx, rx) = crate::tokio::sync::oneshot::channel();
@@ -626,7 +626,7 @@ mod tests {
             let system_time = Timestamp::try_from_system_time(SystemTime::now()).unwrap();
             let association = Association::new(
                 EndpointAddress::from(1).unwrap(),
-                Configuration::default(),
+                AssociationConfig::default(),
                 Box::new(SingleTimestampTestHandler::new(system_time)),
             );
             let (tx, rx) = crate::tokio::sync::oneshot::channel();
@@ -874,7 +874,7 @@ mod tests {
             let system_time = Timestamp::try_from_system_time(SystemTime::now()).unwrap();
             let association = Association::new(
                 EndpointAddress::from(1).unwrap(),
-                Configuration::default(),
+                AssociationConfig::default(),
                 Box::new(SingleTimestampTestHandler::new(system_time)),
             );
             let (tx, rx) = crate::tokio::sync::oneshot::channel();

--- a/dnp3/src/master/tests/auto_tasks.rs
+++ b/dnp3/src/master/tests/auto_tasks.rs
@@ -9,7 +9,7 @@ use super::harness::requests::*;
 
 #[test]
 fn auto_integrity_scan_on_buffer_overflow() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.auto_integrity_scan_on_buffer_overflow = true;
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
@@ -33,7 +33,7 @@ fn auto_integrity_scan_on_buffer_overflow() {
 
 #[test]
 fn auto_integrity_scan_on_buffer_overflow_disabled() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.auto_integrity_scan_on_buffer_overflow = false;
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
@@ -55,7 +55,7 @@ fn auto_integrity_scan_on_buffer_overflow_disabled() {
 
 #[test]
 fn auto_event_class_scan() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.event_scan_on_events_available = EventClasses::all();
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
@@ -93,7 +93,7 @@ fn auto_event_class_scan() {
 
 #[test]
 fn auto_event_class_ignore_one_class_scan() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.event_scan_on_events_available = EventClasses::new(false, true, true);
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
@@ -115,7 +115,7 @@ fn auto_event_class_ignore_one_class_scan() {
 
 #[test]
 fn auto_event_class_scan_disabled() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.event_scan_on_events_available = EventClasses::none();
     let mut seq = Sequence::default();
     let mut harness = create_association(config);

--- a/dnp3/src/master/tests/harness/mod.rs
+++ b/dnp3/src/master/tests/harness/mod.rs
@@ -14,7 +14,7 @@ use std::task::Poll;
 pub(crate) mod requests;
 
 pub(crate) fn create_association(
-    config: Configuration,
+    config: AssociationConfig,
 ) -> TestHarness<impl Future<Output = RunError>> {
     let (io, io_handle) = io::mock();
 

--- a/dnp3/src/master/tests/startup.rs
+++ b/dnp3/src/master/tests/startup.rs
@@ -13,7 +13,7 @@ use super::harness::requests::*;
 
 #[test]
 fn master_startup_procedure() {
-    let config = Configuration::default();
+    let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
 
@@ -35,7 +35,7 @@ fn master_startup_procedure() {
 
 #[test]
 fn master_startup_procedure_skips_unsolicited_if_none() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.startup_integrity_classes = Classes::none();
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
@@ -72,7 +72,7 @@ fn master_startup_procedure_skips_unsolicited_if_none() {
 
 #[test]
 fn master_startup_procedure_skips_integrity_poll_if_none() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.disable_unsol_classes = EventClasses::none();
     config.enable_unsol_classes = EventClasses::none();
     let mut seq = Sequence::default();
@@ -86,7 +86,7 @@ fn master_startup_procedure_skips_integrity_poll_if_none() {
 
 #[test]
 fn clear_restart_iin_is_higher_priority() {
-    let config = Configuration::default();
+    let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
 
@@ -123,7 +123,7 @@ fn clear_restart_iin_is_higher_priority() {
 
 #[test]
 fn outstation_restart_procedure() {
-    let config = Configuration::default();
+    let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
 
@@ -152,7 +152,7 @@ fn outstation_restart_procedure() {
 
 #[test]
 fn detect_restart_in_read_response() {
-    let config = Configuration::default();
+    let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut harness = create_association(config);
 
@@ -199,7 +199,7 @@ fn detect_restart_in_read_response() {
 
 #[test]
 fn ignore_unsolicited_response_with_data_before_first_integrity_poll() {
-    let config = Configuration::default();
+    let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut unsol_seq = Sequence::default();
     let mut harness = create_association(config);
@@ -252,7 +252,7 @@ fn ignore_unsolicited_response_with_data_before_first_integrity_poll() {
 
 #[test]
 fn ignore_duplicate_unsolicited_response() {
-    let config = Configuration::default();
+    let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut unsol_seq = Sequence::default();
     let mut harness = create_association(config);
@@ -286,7 +286,7 @@ fn ignore_duplicate_unsolicited_response() {
 
 #[test]
 fn master_startup_retry_procedure() {
-    let mut config = Configuration::default();
+    let mut config = AssociationConfig::default();
     config.auto_tasks_retry_strategy =
         RetryStrategy::new(Duration::from_secs(1), Duration::from_secs(3));
     let mut seq = Sequence::default();

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -299,7 +299,7 @@ int main()
         .handle_octet_string = &handle_octet_strings,
         .ctx = NULL,
     };
-    association_configuration_t association_config = association_configuration_init(
+    association_config_t association_config = association_config_init(
         event_classes_init(true, true, true),
         event_classes_init(true, true, true),
         classes_all(),

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -264,7 +264,7 @@ int main()
     // ANCHOR_END: runtime_init
 
     // Create the master
-    master_configuration_t master_config = master_configuration_init(1);
+    master_config_t master_config = master_config_init(1);
     master_config.reconnection_strategy.min_delay = 100;
     master_config.reconnection_strategy.max_delay = 5000;
     master_config.decode_level.application = AppDecodeLevel_ObjectValues;

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -241,17 +241,8 @@ int main()
         .ctx = NULL,
     };
 
-    // logging configuration options
-    logging_configuration_t config = {
-        .level = LogLevel_Info,
-        .print_level = true,
-        .print_module_info = false,
-        .time_format = TimeFormat_System,
-        .output_format = LogOutputFormat_Json,
-    };
-
-    // initialize logging - may be called only once
-    configure_logging(config, logger);
+    // initialize logging with the default configuration
+    configure_logging(logging_config_init(), logger);
     // ANCHOR_END: logging_init
 
     // ANCHOR: runtime_init

--- a/ffi/bindings/c/outstation_example.c
+++ b/ffi/bindings/c/outstation_example.c
@@ -327,14 +327,8 @@ int main()
 		.on_message = &on_log_message,
 		.ctx = NULL,
 	};
-	logging_configuration_t log_config = {
-		.level = LogLevel_Info,
-		.print_level = true,
-		.print_module_info = false,
-		.time_format = TimeFormat_System,
-		.output_format = LogOutputFormat_Text,
-	};
-	configure_logging(log_config, logger);
+	// initialize logging with the default configuration
+	configure_logging(logging_config_init(), logger);
 
 	// Create runtime
 	runtime_config_t runtime_config =

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -171,10 +171,10 @@ class MainClass
         }
     }
 
-    private static MasterConfiguration GetMasterConfig()
+    private static MasterConfig GetMasterConfig()
     {
         // create a default configuration with a master address of "1"
-        var config = new MasterConfiguration(1)
+        var config = new MasterConfig(1)
         {
             // override the reconnect strategy            
             ReconnectionStrategy = new RetryStrategy

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -149,16 +149,10 @@ class MainClass
     public static void Main(string[] args)
     {
         // ANCHOR: logging_init
-        // called once during program initialization
+        // Initialize logging with the default configuration
+        // This may only be called once during program initialization
         Logging.Configure(
-            new LoggingConfiguration
-            {
-                Level = LogLevel.Info,
-                PrintLevel = true,
-                PrintModuleInfo = false,
-                TimeFormat = TimeFormat.System,
-                OutputFormat = LogOutputFormat.Text
-            },
+            new LoggingConfig(),
             new ConsoleLogger()
         );
         // ANCHOR_END: logging_init

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -203,7 +203,7 @@ class MainClass
         var readHandler = new TestReadHandler();
         var association = master.AddAssociation(
             1024,
-            new AssociationConfiguration(new EventClasses(true, true, true), new EventClasses(true, true, true), Classes.All(), new EventClasses(false, false, false))
+            new AssociationConfig(new EventClasses(true, true, true), new EventClasses(true, true, true), Classes.All(), new EventClasses(false, false, false))
             {
                 AutoTimeSync = AutoTimeSync.Lan,
                 AutoTasksRetryStrategy = new RetryStrategy

--- a/ffi/bindings/dotnet/examples/outstation/Program.cs
+++ b/ffi/bindings/dotnet/examples/outstation/Program.cs
@@ -91,9 +91,10 @@ class ExampleOutstation
     }
 
     private static async Task MainAsync()
-    {        
+    {
+        // Initialize logging with the default configuration
         Logging.Configure(
-            new LoggingConfiguration { Level = LogLevel.Info, PrintLevel = true, PrintModuleInfo = false, TimeFormat = TimeFormat.System, OutputFormat = LogOutputFormat.Text },
+            new LoggingConfig(),
             new TestLogger()
         );
 

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
@@ -153,23 +153,11 @@ class TestTimeProvider implements TimeProvider {
 
 public class MasterExample {
 
-  // ANCHOR: logging_config
-  // logging configuration
-  static LoggingConfiguration getLoggingConfig() {
-    LoggingConfiguration config = new LoggingConfiguration();
-    config.level = LogLevel.INFO;
-    config.printLevel = true;
-    config.printModuleInfo = false;
-    config.timeFormat = TimeFormat.SYSTEM;
-    config.outputFormat = LogOutputFormat.TEXT;
-    return config;
-  }
-  // ANCHOR_END: logging_config
-
   public static void main(String[] args) {
     // ANCHOR: logging_init
-    // called once during program initialization
-    Logging.configure(getLoggingConfig(), new ConsoleLogger());
+    // Initialize logging with the default configuration
+    // This may only be called once during program initialization
+    Logging.configure(new LoggingConfig(), new ConsoleLogger());
     // ANCHOR_END: logging_init
 
     // ANCHOR: runtime

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
@@ -193,16 +193,15 @@ public class MasterExample {
         new EndpointList("127.0.0.1:20000"), new TestListener());
 
     // Create the association
-    AssociationConfiguration associationConfiguration = new AssociationConfiguration(
-        new EventClasses(true, true, true), new EventClasses(true, true, true), Classes.all(),
-        new EventClasses(false, false, false));
-    associationConfiguration.autoTimeSync = AutoTimeSync.LAN;
-    associationConfiguration.keepAliveTimeout = Duration.ofSeconds(60);
+    AssociationConfig associationConfig = new AssociationConfig(new EventClasses(true, true, true),
+        new EventClasses(true, true, true), Classes.all(), new EventClasses(false, false, false));
+    associationConfig.autoTimeSync = AutoTimeSync.LAN;
+    associationConfig.keepAliveTimeout = Duration.ofSeconds(60);
 
     TestReadHandler readHandler = new TestReadHandler();
     AssociationHandlers associationHandlers =
         new AssociationHandlers(readHandler, readHandler, readHandler);
-    Association association = master.addAssociation(ushort(1024), associationConfiguration,
+    Association association = master.addAssociation(ushort(1024), associationConfig,
         associationHandlers, new TestTimeProvider());
 
     // Create a periodic poll

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
@@ -186,7 +186,7 @@ public class MasterExample {
 
   private static void run(Runtime runtime) throws Exception {
     // Create the master
-    MasterConfiguration masterConfig = new MasterConfiguration(ushort(1));
+    MasterConfig masterConfig = new MasterConfig(ushort(1));
     masterConfig.decodeLevel.application = AppDecodeLevel.OBJECT_VALUES;
 
     Master master = Master.createTcpSession(runtime, LinkErrorMode.CLOSE, masterConfig,

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/OutstationExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/OutstationExample.java
@@ -176,16 +176,6 @@ class TestControlHandler implements ControlHandler {
 
 public class OutstationExample {
 
-  static LoggingConfiguration getLoggingConfig() {
-    LoggingConfiguration config = new LoggingConfiguration();
-    config.level = LogLevel.INFO;
-    config.printLevel = true;
-    config.printModuleInfo = false;
-    config.timeFormat = TimeFormat.SYSTEM;
-    config.outputFormat = LogOutputFormat.TEXT;
-    return config;
-  }
-
   static OutstationConfig getOutstationConfig() {
     // ANCHOR: outstation_config
     // create an outstation configuration with default values
@@ -202,9 +192,9 @@ public class OutstationExample {
 
   public static void main(String[] args) {
     // Setup logging
-    Logging.configure(getLoggingConfig(), new TestLogger());
+    Logging.configure(new LoggingConfig(), new TestLogger());
 
-    // Create the tokio runtime
+    // Create the Tokio runtime
     try (Runtime runtime = new Runtime(new RuntimeConfig())) {
       run(runtime);
     }

--- a/ffi/dnp3-ffi/src/logging.rs
+++ b/ffi/dnp3-ffi/src/logging.rs
@@ -11,7 +11,7 @@ thread_local! {
    pub static LOG_BUFFER: std::cell::RefCell<Vec<u8>> = std::cell::RefCell::new(Vec::new());
 }
 
-pub fn configure_logging(config: ffi::LoggingConfiguration, handler: ffi::Logger) {
+pub fn configure_logging(config: ffi::LoggingConfig, handler: ffi::Logger) {
     tracing::subscriber::set_global_default(adapter(config, handler))
         .expect("unable to install tracing subscriber");
 }
@@ -40,7 +40,7 @@ impl std::io::Write for ThreadLocalBufferWriter {
 }
 
 fn adapter(
-    config: ffi::LoggingConfiguration,
+    config: ffi::LoggingConfig,
     handler: ffi::Logger,
 ) -> impl tracing::Subscriber + Send + Sync + 'static {
     Adapter {
@@ -49,7 +49,7 @@ fn adapter(
     }
 }
 
-impl ffi::LoggingConfiguration {
+impl ffi::LoggingConfig {
     fn build(&self) -> Box<dyn tracing::Subscriber + Send + Sync> {
         let level: tracing::Level = self.level().into();
 

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -13,9 +13,7 @@ use dnp3::entry::master::serial::{
 };
 use dnp3::entry::master::ClientState;
 use dnp3::master::association::AssociationConfig;
-use dnp3::master::handle::{
-    AssociationHandler, Listener, MasterConfiguration, MasterHandle, ReadHandler,
-};
+use dnp3::master::handle::{AssociationHandler, Listener, MasterConfig, MasterHandle, ReadHandler};
 use dnp3::master::request::{Classes, EventClasses, TimeSyncProcedure};
 use dnp3::prelude::master::create_master_tcp_client;
 use std::ffi::CStr;
@@ -28,7 +26,7 @@ pub struct Master {
 pub(crate) unsafe fn master_create_tcp_session(
     runtime: *mut crate::runtime::Runtime,
     link_error_mode: ffi::LinkErrorMode,
-    config: ffi::MasterConfiguration,
+    config: ffi::MasterConfig,
     endpoints: *const crate::EndpointList,
     listener: ffi::ClientStateListener,
 ) -> *mut Master {
@@ -68,7 +66,7 @@ pub(crate) unsafe fn master_create_tcp_session(
 
 pub(crate) unsafe fn master_create_serial_session(
     runtime: *mut crate::runtime::Runtime,
-    config: ffi::MasterConfiguration,
+    config: ffi::MasterConfig,
     path: &CStr,
     serial_params: ffi::SerialPortSettings,
     listener: ffi::ClientStateListener,
@@ -346,8 +344,8 @@ pub(crate) unsafe fn endpoint_list_add(list: *mut EndpointList, endpoint: &CStr)
     }
 }
 
-impl ffi::MasterConfiguration {
-    fn into(self) -> Option<MasterConfiguration> {
+impl ffi::MasterConfig {
+    fn into(self) -> Option<MasterConfig> {
         let address = match EndpointAddress::from(self.address()) {
             Ok(x) => x,
             Err(err) => {
@@ -371,7 +369,7 @@ impl ffi::MasterConfiguration {
             },
         );
 
-        Some(MasterConfiguration {
+        Some(MasterConfig {
             address,
             decode_level: self.decode_level().clone().into(),
             reconnection_strategy: strategy,

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -110,7 +110,7 @@ pub unsafe fn master_destroy(master: *mut Master) {
 pub unsafe fn master_add_association(
     master: *mut Master,
     address: u16,
-    config: ffi::AssociationConfiguration,
+    config: ffi::AssociationConfig,
     handlers: ffi::AssociationHandlers,
     time_provider: ffi::TimeProvider,
 ) -> *mut Association {

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -12,7 +12,7 @@ use dnp3::entry::master::serial::{
     create_master_serial_client, DataBits, FlowControl, Parity, StopBits,
 };
 use dnp3::entry::master::ClientState;
-use dnp3::master::association::Configuration;
+use dnp3::master::association::AssociationConfig;
 use dnp3::master::handle::{
     AssociationHandler, Listener, MasterConfiguration, MasterHandle, ReadHandler,
 };
@@ -130,7 +130,7 @@ pub unsafe fn master_add_association(
         }
     };
 
-    let config = Configuration {
+    let config = AssociationConfig {
         disable_unsol_classes: convert_event_classes(&config.disable_unsol_classes()),
         enable_unsol_classes: convert_event_classes(&config.enable_unsol_classes()),
         startup_integrity_classes: convert_classes(&config.startup_integrity_classes()),

--- a/ffi/dnp3-schema/src/logging.rs
+++ b/ffi/dnp3-schema/src/logging.rs
@@ -34,7 +34,7 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<NativeStructHandle, BindingErr
         .doc("Describes how each log event is formatted")?
         .build()?;
 
-    let logging_config_struct = lib.declare_native_struct("LoggingConfiguration")?;
+    let logging_config_struct = lib.declare_native_struct("LoggingConfig")?;
     let logging_config_struct = lib
         .define_native_struct(&logging_config_struct)?
         .add(

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -270,7 +270,7 @@ fn define_master_config(
     lib: &mut LibraryBuilder,
     shared: &SharedDefinitions,
 ) -> std::result::Result<NativeStructHandle, BindingError> {
-    let master_config = lib.declare_native_struct("MasterConfiguration")?;
+    let master_config = lib.declare_native_struct("MasterConfig")?;
     lib.define_native_struct(&master_config)?
         .add("address", Type::Uint16, "Local DNP3 data-link address")?
         .add("decode_level", StructElementType::Struct(shared.decode_level.clone()), "Decoding level for this master. You can modify this later on with {class:Master.SetDecodeLevel()}.")?

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -88,9 +88,9 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .doc("Automatic time synchronization configuration")?
         .build()?;
 
-    let association_configuration = lib.declare_native_struct("AssociationConfiguration")?;
-    let association_configuration = lib
-        .define_native_struct(&association_configuration)?
+    let association_config = lib.declare_native_struct("AssociationConfig")?;
+    let association_config = lib
+        .define_native_struct(&association_config)?
         .add(
             "disable_unsol_classes",
             Type::Struct(event_classes.clone()),
@@ -126,7 +126,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         )?
         .add("event_scan_on_events_available",
             Type::Struct(event_classes),
-            doc("Classes to automaticaly send reads when the IIN bit is asserted")
+            doc("Classes to automatically send reads when the IIN bit is asserted")
         )?
         .doc("Association configuration")?
         .build()?;
@@ -159,7 +159,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         )?
         .param(
             "config",
-            Type::Struct(association_configuration),
+            Type::Struct(association_config),
             "Association configuration",
         )?
         .param(


### PR DESCRIPTION
uniformly use the abbreviation `Config` instead of `Configuration` in struct definitions, both in Rust and the FFI.