### PR TITLE
refactor phys layer API

### DIFF
--- a/dnp3/examples/master_serial.rs
+++ b/dnp3/examples/master_serial.rs
@@ -47,11 +47,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
+    master.enable().await?;
+
     let mut reader = FramedRead::new(tokio::io::stdin(), LinesCodec::new());
 
     loop {
         match reader.next().await.unwrap()?.as_str() {
             "x" => return Ok(()),
+            "enable" => {
+                master.enable().await?;
+            }
+            "disable" => {
+                master.disable().await?;
+            }
             "dln" => {
                 master.set_decode_level(DecodeLevel::nothing()).await?;
             }

--- a/dnp3/examples/master_serial.rs
+++ b/dnp3/examples/master_serial.rs
@@ -23,11 +23,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         MasterConfig::new(
             EndpointAddress::from(1)?,
             AppDecodeLevel::ObjectValues.into(),
-            ReconnectStrategy::default(),
             Timeout::from_secs(1)?,
         ),
         "/dev/pts/4",
         SerialSettings::default(),
+        Duration::from_secs(1),
         Listener::None,
     );
 

--- a/dnp3/examples/master_tcp_client.rs
+++ b/dnp3/examples/master_tcp_client.rs
@@ -34,10 +34,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         MasterConfig::new(
             EndpointAddress::from(1)?,
             AppDecodeLevel::ObjectValues.into(),
-            ReconnectStrategy::default(),
             Timeout::from_secs(1)?,
         ),
         EndpointList::new("127.0.0.1:20000".to_owned(), &[]),
+        ReconnectStrategy::default(),
         Listener::None,
     );
 

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -37,8 +37,6 @@ pub struct MasterConfig {
     pub address: EndpointAddress,
     /// Decode-level for DNP3 objects
     pub decode_level: DecodeLevel,
-    /// Reconnection strategy
-    pub reconnection_strategy: ReconnectStrategy,
     /// Response timeout
     pub response_timeout: Timeout,
     /// TX buffer size
@@ -56,13 +54,11 @@ impl MasterConfig {
     pub fn new(
         address: EndpointAddress,
         decode_level: DecodeLevel,
-        reconnection_strategy: ReconnectStrategy,
         response_timeout: Timeout,
     ) -> Self {
         Self {
             address,
             decode_level,
-            reconnection_strategy,
             response_timeout,
             tx_buffer_size: MasterSession::DEFAULT_TX_BUFFER_SIZE,
             rx_buffer_size: MasterSession::DEFAULT_RX_BUFFER_SIZE,

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -7,8 +7,7 @@ use crate::app::Shutdown;
 use crate::link::LinkErrorMode;
 use crate::master::session::{MasterSession, RunError, StateChange};
 use crate::master::*;
-use crate::serial::SerialSettings;
-use crate::tcp::ClientState;
+use crate::serial::{PortState, SerialSettings};
 use crate::transport::TransportReader;
 use crate::transport::TransportWriter;
 use crate::util::phys::PhysLayer;
@@ -23,7 +22,7 @@ pub fn spawn_master_serial_client(
     path: &str,
     serial_settings: SerialSettings,
     retry_delay: Duration,
-    listener: Listener<ClientState>,
+    listener: Listener<PortState>,
 ) -> MasterHandle {
     let (future, handle) =
         create_master_serial_client(config, path, serial_settings, retry_delay, listener);
@@ -44,7 +43,7 @@ pub fn create_master_serial_client(
     path: &str,
     settings: SerialSettings,
     retry_delay: Duration,
-    listener: Listener<ClientState>,
+    listener: Listener<PortState>,
 ) -> (impl Future<Output = ()> + 'static, MasterHandle) {
     let log_path = path.to_owned();
     let (mut task, handle) = MasterTask::new(path, settings, config, retry_delay, listener);
@@ -64,7 +63,7 @@ struct MasterTask {
     session: MasterSession,
     reader: TransportReader,
     writer: TransportWriter,
-    listener: Listener<ClientState>,
+    listener: Listener<PortState>,
 }
 
 impl MasterTask {
@@ -73,7 +72,7 @@ impl MasterTask {
         serial_settings: SerialSettings,
         config: MasterConfig,
         retry_delay: Duration,
-        listener: Listener<ClientState>,
+        listener: Listener<PortState>,
     ) -> (Self, MasterHandle) {
         let (tx, rx) = crate::util::channel::request_channel();
         let session = MasterSession::new(
@@ -101,11 +100,16 @@ impl MasterTask {
         (task, MasterHandle::new(tx))
     }
 
-    async fn run(&mut self) -> Result<(), Shutdown> {
+    async fn run(&mut self) {
+        let _ = self.run_impl().await;
+        self.listener.update(PortState::Shutdown);
+    }
+
+    async fn run_impl(&mut self) -> Result<(), Shutdown> {
         loop {
+            self.listener.update(PortState::Disabled);
             self.session.wait_for_enabled().await?;
             if let Err(StateChange::Shutdown) = self.run_enabled().await {
-                self.listener.update(ClientState::Shutdown);
                 return Err(Shutdown);
             }
         }
@@ -113,7 +117,6 @@ impl MasterTask {
 
     async fn run_enabled(&mut self) -> Result<(), StateChange> {
         loop {
-            self.listener.update(ClientState::Connecting);
             match tokio_one_serial::open(self.path.as_str(), self.serial_settings) {
                 Err(err) => {
                     tracing::warn!(
@@ -121,14 +124,13 @@ impl MasterTask {
                         err,
                         self.retry_delay.as_millis()
                     );
-                    self.listener
-                        .update(ClientState::WaitAfterFailedConnect(self.retry_delay));
+                    self.listener.update(PortState::Wait(self.retry_delay));
                     self.session.wait_for_retry(self.retry_delay).await?;
                 }
                 Ok(serial) => {
                     let mut io = PhysLayer::Serial(serial);
-                    tracing::info!("serial device open");
-                    self.listener.update(ClientState::Connected);
+                    tracing::info!("serial port open");
+                    self.listener.update(PortState::Open);
                     match self
                         .session
                         .run(&mut io, &mut self.writer, &mut self.reader)
@@ -143,8 +145,7 @@ impl MasterTask {
                                 "waiting {} ms to re-open",
                                 self.retry_delay.as_millis()
                             );
-                            self.listener
-                                .update(ClientState::WaitAfterDisconnect(self.retry_delay));
+                            self.listener.update(PortState::Wait(self.retry_delay));
                             self.session.wait_for_retry(self.retry_delay).await?;
                         }
                     }

--- a/dnp3/src/serial/mod.rs
+++ b/dnp3/src/serial/mod.rs
@@ -5,3 +5,16 @@ pub use tokio_one_serial::Settings as SerialSettings;
 pub use master::*;
 
 mod master;
+
+/// State of the serial port
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum PortState {
+    /// Disabled and idle until enabled
+    Disabled,
+    /// waiting to perform an open retry
+    Wait(std::time::Duration),
+    /// Port is open
+    Open,
+    /// Task has been shut down
+    Shutdown,
+}

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use tracing::Instrument;
 
-use crate::app::ExponentialBackOff;
 use crate::app::Shutdown;
+use crate::app::{ExponentialBackOff, ReconnectStrategy};
 use crate::link::LinkErrorMode;
 use crate::master::session::{MasterSession, RunError, StateChange};
 use crate::master::{Listener, MasterConfig, MasterHandle};
@@ -24,9 +24,11 @@ pub fn spawn_master_tcp_client(
     link_error_mode: LinkErrorMode,
     config: MasterConfig,
     endpoints: EndpointList,
+    reconnect: ReconnectStrategy,
     listener: Listener<ClientState>,
 ) -> MasterHandle {
-    let (future, handle) = create_master_tcp_client(link_error_mode, config, endpoints, listener);
+    let (future, handle) =
+        create_master_tcp_client(link_error_mode, config, endpoints, reconnect, listener);
     crate::tokio::spawn(future);
     handle
 }
@@ -43,10 +45,12 @@ pub fn create_master_tcp_client(
     link_error_mode: LinkErrorMode,
     config: MasterConfig,
     endpoints: EndpointList,
+    reconnect: ReconnectStrategy,
     listener: Listener<ClientState>,
 ) -> (impl Future<Output = ()> + 'static, MasterHandle) {
     let main_addr = endpoints.main_addr().to_string();
-    let (mut task, handle) = MasterTask::new(link_error_mode, endpoints, config, listener);
+    let (mut task, handle) =
+        MasterTask::new(link_error_mode, endpoints, config, reconnect, listener);
     let future = async move {
         let _ = task
             .run()
@@ -71,6 +75,7 @@ impl MasterTask {
         link_error_mode: LinkErrorMode,
         endpoints: EndpointList,
         config: MasterConfig,
+        reconnect: ReconnectStrategy,
         listener: Listener<ClientState>,
     ) -> (Self, MasterHandle) {
         let (tx, rx) = crate::util::channel::request_channel();
@@ -88,8 +93,8 @@ impl MasterTask {
         );
         let task = Self {
             endpoints,
-            back_off: ExponentialBackOff::new(config.reconnection_strategy.retry_strategy),
-            reconnect_delay: config.reconnection_strategy.reconnect_delay,
+            back_off: ExponentialBackOff::new(reconnect.retry_strategy),
+            reconnect_delay: reconnect.reconnect_delay,
             session,
             reader,
             writer,

--- a/dnp3/src/tcp/mod.rs
+++ b/dnp3/src/tcp/mod.rs
@@ -11,6 +11,7 @@ mod outstation;
 /// state of TCP client connection
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ClientState {
+    Disabled,
     Connecting,
     Connected,
     WaitAfterFailedConnect(std::time::Duration),

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -255,9 +255,7 @@ int main()
     // ANCHOR_END: runtime_init
 
     // Create the master
-    master_config_t master_config = master_config_init(1);
-    master_config.reconnection_strategy.min_delay = 100;
-    master_config.reconnection_strategy.max_delay = 5000;
+    master_config_t master_config = master_config_init(1);    
     master_config.decode_level.application = AppDecodeLevel_ObjectValues;
 
     endpoint_list_t* endpoints = endpoint_list_new("127.0.0.1:20000");
@@ -271,6 +269,8 @@ int main()
         LinkErrorMode_Close,
         master_config,
         endpoints,
+        retry_strategy_init(),
+        1000,
         listener
     );
     endpoint_list_destroy(endpoints);

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -168,15 +168,7 @@ class MainClass
     private static MasterConfig GetMasterConfig()
     {
         // create a default configuration with a master address of "1"
-        var config = new MasterConfig(1)
-        {
-            // override the reconnect strategy            
-            ReconnectionStrategy = new RetryStrategy
-            {
-                MinDelay = TimeSpan.FromMilliseconds(100),
-                MaxDelay = TimeSpan.FromSeconds(5),
-            }
-        };
+        var config = new MasterConfig(1);
         
         config.DecodeLevel.Application = AppDecodeLevel.ObjectValues;
 
@@ -191,6 +183,8 @@ class MainClass
             LinkErrorMode.Close,
             GetMasterConfig(),
             new EndpointList("127.0.0.1:20000"),
+            new RetryStrategy(),
+            TimeSpan.FromSeconds(1),
             new TestListener()
         );
 

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
@@ -178,7 +178,8 @@ public class MasterExample {
     masterConfig.decodeLevel.application = AppDecodeLevel.OBJECT_VALUES;
 
     Master master = Master.createTcpSession(runtime, LinkErrorMode.CLOSE, masterConfig,
-        new EndpointList("127.0.0.1:20000"), new TestListener());
+        new EndpointList("127.0.0.1:20000"), new RetryStrategy(), Duration.ofSeconds(1),
+        new TestListener());
 
     // Create the association
     AssociationConfig associationConfig = new AssociationConfig(EventClasses.all(),

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -22,6 +22,8 @@ pub(crate) unsafe fn master_create_tcp_session(
     link_error_mode: ffi::LinkErrorMode,
     config: ffi::MasterConfig,
     endpoints: *const crate::EndpointList,
+    connect_strategy: ffi::RetryStrategy,
+    reconnect_delay: Duration,
     listener: ffi::ClientStateListener,
 ) -> *mut Master {
     let config = if let Some(config) = config.into() {
@@ -37,10 +39,17 @@ pub(crate) unsafe fn master_create_tcp_session(
     };
     let listener = ClientStateListenerAdapter::new(listener);
 
+    let reconnect_delay = if reconnect_delay == Duration::from_millis(0) {
+        None
+    } else {
+        Some(reconnect_delay)
+    };
+
     let (future, handle) = dnp3::tcp::create_master_tcp_client(
         link_error_mode.into(),
         config,
         endpoints.clone(),
+        ReconnectStrategy::new(connect_strategy.into(), reconnect_delay),
         listener.into_listener(),
     );
 
@@ -63,6 +72,7 @@ pub(crate) unsafe fn master_create_serial_session(
     config: ffi::MasterConfig,
     path: &CStr,
     serial_params: ffi::SerialPortSettings,
+    retry_delay: Duration,
     listener: ffi::ClientStateListener,
 ) -> *mut Master {
     let config = if let Some(config) = config.into() {
@@ -76,6 +86,7 @@ pub(crate) unsafe fn master_create_serial_session(
         config,
         &path.to_string_lossy().to_string(),
         serial_params.into(),
+        retry_delay,
         listener.into_listener(),
     );
 
@@ -383,26 +394,19 @@ impl ffi::MasterConfig {
             }
         };
 
-        let strategy = ReconnectStrategy::new(
-            RetryStrategy::new(
-                self.reconnection_strategy().min_delay(),
-                self.reconnection_strategy().max_delay(),
-            ),
-            if self.reconnection_delay() != Duration::from_millis(0) {
-                Some(self.reconnection_delay())
-            } else {
-                None
-            },
-        );
-
         Some(MasterConfig {
             address,
             decode_level: self.decode_level().clone().into(),
-            reconnection_strategy: strategy,
             response_timeout: Timeout::from_duration(self.response_timeout()).unwrap(),
             tx_buffer_size: self.tx_buffer_size() as usize,
             rx_buffer_size: self.rx_buffer_size() as usize,
         })
+    }
+}
+
+impl From<ffi::RetryStrategy> for dnp3::app::RetryStrategy {
+    fn from(x: ffi::RetryStrategy) -> Self {
+        dnp3::app::RetryStrategy::new(x.min_delay(), x.max_delay())
     }
 }
 

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -27,7 +27,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .param("endpoints", Type::ClassRef(endpoint_list.declaration()), "List of IP endpoints.")?
         .param("connect_strategy", Type::Struct(shared.retry_strategy.clone()), "Connection retry strategy to use")?
         .param("reconnect_delay", Type::Duration(DurationMapping::Milliseconds), "delay before reconnecting after a disconnect")?
-        .param("listener", Type::Interface(tcp_client_state_listener.clone()), "TCP connection listener used to receive updates on the status of the connection")?
+        .param("listener", Type::Interface(tcp_client_state_listener), "TCP connection listener used to receive updates on the status of the connection")?
         .return_type(ReturnType::new(Type::ClassRef(master_class.clone()), "Handle to the master created, {null} if an error occurred"))?
         .doc(
             doc("Create a master TCP session connecting to the specified endpoint(s)")
@@ -41,8 +41,8 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .param("config", Type::Struct(master_config), "Master configuration")?
         .param("path", Type::String, "Path to the serial device. Generally /dev/tty0 on Linux and COM1 on Windows.")?
         .param("serial_params", Type::Struct(shared.serial_port_settings.clone()), "Serial port settings")?
-        .param("open_retry_delay", Type::Duration(DurationMapping::Milliseconds), "delay bbetween attempts to open the serial port")?
-        .param("listener", Type::Interface(tcp_client_state_listener), "Client connection listener to receive updates on the status of the connection")?
+        .param("open_retry_delay", Type::Duration(DurationMapping::Milliseconds), "delay between attempts to open the serial port")?
+        .param("listener", Type::Interface(shared.port_state_listener.clone()), "Listener to receive updates on the status of the serial port")?
         .return_type(ReturnType::new(Type::ClassRef(master_class.clone()), "Handle to the master created, {null} if an error occurred"))?
         .doc(
             doc("Create a master session on the specified serial port")
@@ -254,6 +254,7 @@ fn define_tcp_client_state_listener(
 ) -> std::result::Result<InterfaceHandle, BindingError> {
     let client_state_enum = lib
         .define_native_enum("ClientState")?
+        .push("Disabled", "Client is disabled and idle until disabled")?
         .push(
             "Connecting",
             "Client is trying to establish a connection to the remote device",

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -25,6 +25,8 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .param("link_error_mode", Type::Enum(shared.link_error_mode.clone()), "Controls how link errors are handled with respect to the TCP session")?
         .param("config", Type::Struct(master_config.clone()), "Master configuration")?
         .param("endpoints", Type::ClassRef(endpoint_list.declaration()), "List of IP endpoints.")?
+        .param("connect_strategy", Type::Struct(shared.retry_strategy.clone()), "Connection retry strategy to use")?
+        .param("reconnect_delay", Type::Duration(DurationMapping::Milliseconds), "delay before reconnecting after a disconnect")?
         .param("listener", Type::Interface(tcp_client_state_listener.clone()), "TCP connection listener used to receive updates on the status of the connection")?
         .return_type(ReturnType::new(Type::ClassRef(master_class.clone()), "Handle to the master created, {null} if an error occurred"))?
         .doc(
@@ -39,6 +41,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .param("config", Type::Struct(master_config), "Master configuration")?
         .param("path", Type::String, "Path to the serial device. Generally /dev/tty0 on Linux and COM1 on Windows.")?
         .param("serial_params", Type::Struct(shared.serial_port_settings.clone()), "Serial port settings")?
+        .param("open_retry_delay", Type::Duration(DurationMapping::Milliseconds), "delay bbetween attempts to open the serial port")?
         .param("listener", Type::Interface(tcp_client_state_listener), "Client connection listener to receive updates on the status of the connection")?
         .return_type(ReturnType::new(Type::ClassRef(master_class.clone()), "Handle to the master created, {null} if an error occurred"))?
         .doc(
@@ -291,8 +294,6 @@ fn define_master_config(
     lib.define_native_struct(&master_config)?
         .add("address", Type::Uint16, "Local DNP3 data-link address")?
         .add("decode_level", StructElementType::Struct(shared.decode_level.clone()), "Decoding level for this master. You can modify this later on with {class:Master.SetDecodeLevel()}.")?
-        .add("reconnection_strategy", Type::Struct(shared.retry_strategy.clone()), "Reconnection retry strategy to use")?
-        .add("reconnection_delay", StructElementType::Duration(DurationMapping::Milliseconds, Some(Duration::from_millis(0))), doc("Optional reconnection delay when a connection is lost.").details("A value of 0 means no delay."))?
         .add(
             "response_timeout",
             StructElementType::Duration(DurationMapping::Milliseconds, Some(Duration::from_secs(5))),


### PR DESCRIPTION
* Moves TCP retry parameter out of MasterConfig and makes them task spawn parameters
* Provides a distinct listener type and state enum for serial ports