### PR TITLE
Single ReadHandler

### DIFF
--- a/dnp3/benches/benchmark.rs
+++ b/dnp3/benches/benchmark.rs
@@ -213,6 +213,7 @@ impl Pair {
             LinkErrorMode::Close,
             Self::get_master_config(config.master_level),
             EndpointList::single(format!("127.0.0.1:{}", port)),
+            ReconnectStrategy::default(),
             Listener::None,
         );
 
@@ -252,7 +253,6 @@ impl Pair {
         MasterConfig::new(
             Self::master_address(),
             level,
-            ReconnectStrategy::default(),
             Timeout::from_secs(5).unwrap(),
         )
     }
@@ -277,11 +277,11 @@ struct TestHandler {
 }
 
 impl ReadHandler for TestHandler {
-    fn begin_fragment(&mut self, _header: ResponseHeader) {
+    fn begin_fragment(&mut self, _read_type: ReadType, _header: ResponseHeader) {
         self.count = 0;
     }
 
-    fn end_fragment(&mut self, _header: ResponseHeader) {
+    fn end_fragment(&mut self, _read_type: ReadType, _header: ResponseHeader) {
         self.tx.try_send(self.count).unwrap();
     }
 
@@ -355,15 +355,7 @@ impl ReadHandler for TestHandler {
 }
 
 impl AssociationHandler for TestHandler {
-    fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
-        self
-    }
-
-    fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
-        self
-    }
-
-    fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+    fn get_read_handler(&mut self) -> &mut dyn ReadHandler {
         self
     }
 }

--- a/dnp3/src/master/association.rs
+++ b/dnp3/src/master/association.rs
@@ -470,7 +470,7 @@ impl Association {
                     ReadType::Unsolicited,
                     response.header,
                     objects,
-                    self.handler.get_unsolicited_handler(),
+                    self.handler.get_read_handler(),
                 );
             }
 
@@ -492,7 +492,7 @@ impl Association {
             ReadType::StartupIntegrity,
             header,
             objects,
-            self.handler.get_integrity_handler(),
+            self.handler.get_read_handler(),
         );
     }
 
@@ -505,7 +505,7 @@ impl Association {
             ReadType::PeriodicPoll,
             header,
             objects,
-            self.handler.get_default_poll_handler(),
+            self.handler.get_read_handler(),
         );
     }
 
@@ -518,7 +518,7 @@ impl Association {
             ReadType::PeriodicPoll,
             header,
             objects,
-            self.handler.get_integrity_handler(),
+            self.handler.get_read_handler(),
         );
     }
 
@@ -531,7 +531,7 @@ impl Association {
             ReadType::SinglePoll,
             header,
             objects,
-            self.handler.get_default_poll_handler(),
+            self.handler.get_read_handler(),
         );
     }
 

--- a/dnp3/src/master/extract.rs
+++ b/dnp3/src/master/extract.rs
@@ -4,10 +4,12 @@ use crate::app::parse::parser::{HeaderCollection, HeaderDetails, ObjectHeader};
 use crate::app::variations::*;
 use crate::app::ResponseHeader;
 use crate::master::handle::ReadHandler;
+use crate::master::ReadType;
 
 /// Extract measurements from a HeaderCollection, sinking them into
 /// something that implements `MeasurementHandler`
 pub(crate) fn extract_measurements(
+    read_type: ReadType,
     header: ResponseHeader,
     objects: HeaderCollection,
     handler: &mut dyn ReadHandler,
@@ -67,11 +69,11 @@ pub(crate) fn extract_measurements(
         cto
     }
 
-    handler.begin_fragment(header);
+    handler.begin_fragment(read_type, header);
     objects
         .iter()
         .fold(None, |cto, header| handle(cto, header, handler));
-    handler.end_fragment(header);
+    handler.end_fragment(read_type, header);
 }
 
 #[cfg(test)]
@@ -114,8 +116,8 @@ mod test {
     }
 
     impl ReadHandler for MockHandler {
-        fn begin_fragment(&mut self, _header: ResponseHeader) {}
-        fn end_fragment(&mut self, _header: ResponseHeader) {}
+        fn begin_fragment(&mut self, _read_type: ReadType, _header: ResponseHeader) {}
+        fn end_fragment(&mut self, _read_type: ReadType, _header: ResponseHeader) {}
 
         fn handle_binary(&mut self, _info: HeaderInfo, x: &mut dyn Iterator<Item = (Binary, u16)>) {
             let next_header = match self.expected.pop() {
@@ -209,7 +211,7 @@ mod test {
         );
 
         handler.expect(Header::Binary(vec![expected]));
-        extract_measurements(header(), objects, &mut handler);
+        extract_measurements(ReadType::PeriodicPoll, header(), objects, &mut handler);
         assert!(handler.is_empty());
     }
 
@@ -236,7 +238,7 @@ mod test {
         );
 
         handler.expect(Header::Binary(vec![expected]));
-        extract_measurements(header(), objects, &mut handler);
+        extract_measurements(ReadType::PeriodicPoll, header(), objects, &mut handler);
         assert!(handler.is_empty());
     }
 
@@ -263,7 +265,7 @@ mod test {
         );
 
         handler.expect(Header::Binary(vec![expected]));
-        extract_measurements(header(), objects, &mut handler);
+        extract_measurements(ReadType::PeriodicPoll, header(), objects, &mut handler);
         assert!(handler.is_empty());
     }
 
@@ -290,7 +292,7 @@ mod test {
         );
 
         handler.expect(Header::Binary(vec![expected]));
-        extract_measurements(header(), objects, &mut handler);
+        extract_measurements(ReadType::PeriodicPoll, header(), objects, &mut handler);
         assert!(handler.is_empty());
     }
 
@@ -317,7 +319,7 @@ mod test {
         );
 
         handler.expect(Header::Binary(vec![expected]));
-        extract_measurements(header(), objects, &mut handler);
+        extract_measurements(ReadType::PeriodicPoll, header(), objects, &mut handler);
         assert!(handler.is_empty());
     }
 }

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -319,9 +319,22 @@ impl HeaderInfo {
     }
 }
 
+/// Describes the source of the read event
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ReadType {
+    /// Startup integrity poll
+    StartupIntegrity,
+    /// Unsolicited message
+    Unsolicited,
+    /// Single poll requested by the user
+    SinglePoll,
+    /// Periodic poll configured by the user
+    PeriodicPoll,
+}
+
 pub trait ReadHandler {
-    fn begin_fragment(&mut self, header: ResponseHeader);
-    fn end_fragment(&mut self, header: ResponseHeader);
+    fn begin_fragment(&mut self, read_type: ReadType, header: ResponseHeader);
+    fn end_fragment(&mut self, read_type: ReadType, header: ResponseHeader);
 
     fn handle_binary(&mut self, info: HeaderInfo, iter: &mut dyn Iterator<Item = (Binary, u16)>);
     fn handle_double_bit_binary(
@@ -365,9 +378,9 @@ impl NullHandler {
 }
 
 impl ReadHandler for NullHandler {
-    fn begin_fragment(&mut self, _header: ResponseHeader) {}
+    fn begin_fragment(&mut self, _read_type: ReadType, _header: ResponseHeader) {}
 
-    fn end_fragment(&mut self, _header: ResponseHeader) {}
+    fn end_fragment(&mut self, _read_type: ReadType, _header: ResponseHeader) {}
 
     fn handle_binary(&mut self, _info: HeaderInfo, _iter: &mut dyn Iterator<Item = (Binary, u16)>) {
     }

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -315,7 +315,7 @@ impl HeaderInfo {
     }
 }
 
-/// Describes the source of the read event
+/// Describes the source of a read event
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ReadType {
     /// Startup integrity poll

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -293,12 +293,8 @@ pub trait AssociationHandler: Send {
         Timestamp::try_from_system_time(SystemTime::now())
     }
 
-    /// retrieve a handler used to process integrity polls
-    fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler;
-    /// retrieve a handler used to process unsolicited responses
-    fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler;
-    /// retrieve a default handler used to process user-defined polls
-    fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler;
+    /// retrieve a handler used to process received measurement data
+    fn get_read_handler(&mut self) -> &mut dyn ReadHandler;
 }
 
 /// Information about the object header from which the measurement values were mapped
@@ -432,15 +428,7 @@ impl ReadHandler for NullHandler {
 }
 
 impl AssociationHandler for NullHandler {
-    fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
-        self
-    }
-
-    fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
-        self
-    }
-
-    fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+    fn get_read_handler(&mut self) -> &mut dyn ReadHandler {
         self
     }
 }

--- a/dnp3/src/master/tasks/time.rs
+++ b/dnp3/src/master/tasks/time.rs
@@ -347,15 +347,7 @@ mod tests {
             self.time.take()
         }
 
-        fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
-            &mut self.handler
-        }
-
-        fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
-            &mut self.handler
-        }
-
-        fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+        fn get_read_handler(&mut self) -> &mut dyn ReadHandler {
             &mut self.handler
         }
     }
@@ -391,15 +383,7 @@ mod tests {
                 Some(self.time)
             }
 
-            fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
-                &mut self.handler
-            }
-
-            fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
-                &mut self.handler
-            }
-
-            fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+            fn get_read_handler(&mut self) -> &mut dyn ReadHandler {
                 &mut self.handler
             }
         }

--- a/dnp3/src/master/tests/harness/mod.rs
+++ b/dnp3/src/master/tests/harness/mod.rs
@@ -11,6 +11,7 @@ use crate::master::handle::{
     AssociationHandle, AssociationHandler, HeaderInfo, MasterHandle, ReadHandler,
 };
 use crate::master::session::{MasterSession, RunError};
+use crate::master::ReadType;
 use crate::tokio::test::*;
 use crate::transport::create_master_transport_layer;
 use crate::util::phys::PhysLayer;
@@ -96,9 +97,9 @@ impl AssociationHandler for CountHandler {
 }
 
 impl ReadHandler for CountHandler {
-    fn begin_fragment(&mut self, _header: crate::app::ResponseHeader) {}
+    fn begin_fragment(&mut self, _read_type: ReadType, _header: crate::app::ResponseHeader) {}
 
-    fn end_fragment(&mut self, _header: crate::app::ResponseHeader) {}
+    fn end_fragment(&mut self, _read_type: ReadType, _header: crate::app::ResponseHeader) {}
 
     fn handle_binary(
         &mut self,

--- a/dnp3/src/master/tests/harness/mod.rs
+++ b/dnp3/src/master/tests/harness/mod.rs
@@ -83,15 +83,7 @@ impl CountHandler {
 }
 
 impl AssociationHandler for CountHandler {
-    fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
-        self
-    }
-
-    fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
-        self
-    }
-
-    fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
+    fn get_read_handler(&mut self) -> &mut dyn ReadHandler {
         self
     }
 }

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -30,12 +30,12 @@ void client_state_on_change(client_state_t state, void* arg)
 }
 
 // ReadHandler callbacks
-void begin_fragment(response_header_t header, void* arg)
+void begin_fragment(read_type_t read_type, response_header_t header, void* arg)
 {
     printf("Beginning fragment (broadcast: %u)\n", iin1_is_set(&header.iin.iin1, Iin1Flag_Broadcast));
 }
 
-void end_fragment(response_header_t header, void* arg)
+void end_fragment(read_type_t read_type, response_header_t header, void* arg)
 {
     printf("End fragment\n");
 }
@@ -50,11 +50,10 @@ void handle_binary(header_info_t info, binary_iterator_t* it, void* arg)
     print_variation(info.variation);
     printf("\n");
 
-    binary_t* value = binary_next(it);
-    while(value != NULL)
+    binary_t* value = NULL;
+    while(value = binary_next(it))
     {
-        printf("BI %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
-        value = binary_next(it);
+        printf("BI %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);        
     }
 }
 
@@ -68,11 +67,10 @@ void handle_double_bit_binary(header_info_t info, double_bit_binary_iterator_t* 
     print_variation(info.variation);
     printf("\n");
 
-    double_bit_binary_t* value = doublebitbinary_next(it);
-    while(value != NULL)
+    double_bit_binary_t* value = NULL;
+    while(value = doublebitbinary_next(it))
     {
-        printf("DBBI %u: Value=%X Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
-        value = doublebitbinary_next(it);
+        printf("DBBI %u: Value=%X Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);        
     }
 }
 
@@ -86,11 +84,10 @@ void handle_binary_output_status(header_info_t info, binary_output_status_iterat
     print_variation(info.variation);
     printf("\n");
 
-    binary_output_status_t* value = binaryoutputstatus_next(it);
-    while(value != NULL)
+    binary_output_status_t* value = NULL;
+    while(value = binaryoutputstatus_next(it))
     {
-        printf("BOS %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
-        value = binaryoutputstatus_next(it);
+        printf("BOS %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);        
     }
 }
 
@@ -104,11 +101,10 @@ void handle_counter(header_info_t info, counter_iterator_t* it, void* arg)
     print_variation(info.variation);
     printf("\n");
 
-    counter_t* value = counter_next(it);
-    while(value != NULL)
+    counter_t* value = NULL;
+    while(value = counter_next(it))
     {
-        printf("Counter %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
-        value = counter_next(it);
+        printf("Counter %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);        
     }
 }
 
@@ -122,11 +118,10 @@ void handle_frozen_counter(header_info_t info, frozen_counter_iterator_t* it, vo
     print_variation(info.variation);
     printf("\n");
 
-    frozen_counter_t* value = frozencounter_next(it);
-    while(value != NULL)
+    frozen_counter_t* value = NULL;
+    while(value = frozencounter_next(it))
     {
-        printf("Frozen Counter %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
-        value = frozencounter_next(it);
+        printf("Frozen Counter %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);        
     }
 }
 
@@ -140,11 +135,10 @@ void handle_analog(header_info_t info, analog_iterator_t* it, void* arg)
     print_variation(info.variation);
     printf("\n");
 
-    analog_t* value = analog_next(it);
-    while(value != NULL)
+    analog_t* value = NULL;
+    while(value = analog_next(it))
     {
-        printf("AI %u: Value=%f Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
-        value = analog_next(it);
+        printf("AI %u: Value=%f Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);        
     }
 }
 
@@ -158,11 +152,10 @@ void handle_analog_output_status(header_info_t info, analog_output_status_iterat
     print_variation(info.variation);
     printf("\n");
 
-    analog_output_status_t* value = analogoutputstatus_next(it);
-    while(value != NULL)
+    analog_output_status_t* value = NULL;
+    while(value = analogoutputstatus_next(it))
     {
-        printf("AOS %u: Value=%f Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
-        value = analogoutputstatus_next(it);
+        printf("AOS %u: Value=%f Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);        
     }
 }
 
@@ -176,8 +169,8 @@ void handle_octet_strings(header_info_t info, octet_string_iterator_t* it, void*
     print_variation(info.variation);
     printf("\n");
 
-    octet_string_t* value = octetstring_next(it);
-    while(value != NULL)
+    octet_string_t* value = NULL;
+    while(value = octetstring_next(it))
     {
         printf("Octet String: %u: Value=", value->index);
         byte_t* single_byte = byte_next(value->value);
@@ -187,8 +180,7 @@ void handle_octet_strings(header_info_t info, octet_string_iterator_t* it, void*
             single_byte = byte_next(value->value);
         }
 
-        printf("\n");
-        value = octetstring_next(it);
+        printf("\n");        
     }
 }
 

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -303,8 +303,7 @@ int main()
     );
     association_config.auto_time_sync = AutoTimeSync_Lan;
     association_config.keep_alive_timeout = 60;
-
-    association_handlers_t association_handlers = association_handlers_init(read_handler, read_handler, read_handler);
+   
     time_provider_t time_provider =
     {
         .get_time = get_time,
@@ -314,7 +313,7 @@ int main()
         master,
         1024,
         association_config,
-        association_handlers,
+        read_handler,
         time_provider
     );
 

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -26,12 +26,12 @@ class MainClass
 
     class TestReadHandler : IReadHandler
     {
-        public void BeginFragment(ResponseHeader header)
+        public void BeginFragment(ReadType readType, ResponseHeader header)
         {
             Console.WriteLine($"Beginning fragment (broadcast: {header.Iin.Iin1.IsSet(Iin1Flag.Broadcast)})");
         }
 
-        public void EndFragment(ResponseHeader header)
+        public void EndFragment(ReadType readType, ResponseHeader header)
         {
             Console.WriteLine("End fragment");
         }

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -187,8 +187,7 @@ class MainClass
             TimeSpan.FromSeconds(1),
             new TestListener()
         );
-
-        var readHandler = new TestReadHandler();
+        
         var association = master.AddAssociation(
             1024,
             new AssociationConfig(EventClasses.All(), EventClasses.All(), Classes.All(), EventClasses.None())
@@ -201,7 +200,7 @@ class MainClass
                 },
                 KeepAliveTimeout = TimeSpan.FromSeconds(60),
             },
-            new AssociationHandlers(readHandler, readHandler, readHandler),
+            new TestReadHandler(),            
             new TestTimeProvider()
         );
 

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
@@ -34,13 +34,13 @@ class TestListener implements ClientStateListener {
 class TestReadHandler implements ReadHandler {
 
   @Override
-  public void beginFragment(ResponseHeader header) {
+  public void beginFragment(ReadType readType, ResponseHeader header) {
     System.out.println(
         "Beginning fragment (broadcast: " + header.iin.iin1.isSet(Iin1Flag.BROADCAST) + ")");
   }
 
   @Override
-  public void endFragment(ResponseHeader header) {
+  public void endFragment(ReadType readType, ResponseHeader header) {
     System.out.println("End fragment");
   }
 

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
@@ -187,11 +187,8 @@ public class MasterExample {
     associationConfig.autoTimeSync = AutoTimeSync.LAN;
     associationConfig.keepAliveTimeout = Duration.ofSeconds(60);
 
-    TestReadHandler readHandler = new TestReadHandler();
-    AssociationHandlers associationHandlers =
-        new AssociationHandlers(readHandler, readHandler, readHandler);
     Association association = master.addAssociation(ushort(1024), associationConfig,
-        associationHandlers, new TestTimeProvider());
+        new TestReadHandler(), new TestTimeProvider());
 
     // Create a periodic poll
     Request pollRequest = Request.classRequest(false, true, true, true);

--- a/ffi/dnp3-ffi/src/handler.rs
+++ b/ffi/dnp3-ffi/src/handler.rs
@@ -1,16 +1,16 @@
 use dnp3::app::measurement::*;
 use dnp3::app::*;
 use dnp3::app::{Iin1, Iin2, ResponseFunction, ResponseHeader};
-use dnp3::master::{HeaderInfo, ReadHandler};
+use dnp3::master::{HeaderInfo, ReadHandler, ReadType};
 
 use crate::ffi;
 
 impl ReadHandler for ffi::ReadHandler {
-    fn begin_fragment(&mut self, header: ResponseHeader) {
+    fn begin_fragment(&mut self, _read_type: ReadType, header: ResponseHeader) {
         ffi::ReadHandler::begin_fragment(self, header.into());
     }
 
-    fn end_fragment(&mut self, header: ResponseHeader) {
+    fn end_fragment(&mut self, _read_type: ReadType, header: ResponseHeader) {
         ffi::ReadHandler::end_fragment(self, header.into());
     }
 

--- a/ffi/dnp3-ffi/src/handler.rs
+++ b/ffi/dnp3-ffi/src/handler.rs
@@ -6,12 +6,12 @@ use dnp3::master::{HeaderInfo, ReadHandler, ReadType};
 use crate::ffi;
 
 impl ReadHandler for ffi::ReadHandler {
-    fn begin_fragment(&mut self, _read_type: ReadType, header: ResponseHeader) {
-        ffi::ReadHandler::begin_fragment(self, header.into());
+    fn begin_fragment(&mut self, read_type: ReadType, header: ResponseHeader) {
+        ffi::ReadHandler::begin_fragment(self, read_type.into(), header.into());
     }
 
-    fn end_fragment(&mut self, _read_type: ReadType, header: ResponseHeader) {
-        ffi::ReadHandler::end_fragment(self, header.into());
+    fn end_fragment(&mut self, read_type: ReadType, header: ResponseHeader) {
+        ffi::ReadHandler::end_fragment(self, read_type.into(), header.into());
     }
 
     fn handle_binary(&mut self, info: HeaderInfo, iter: &mut dyn Iterator<Item = (Binary, u16)>) {
@@ -80,6 +80,17 @@ impl ReadHandler for ffi::ReadHandler {
         let info = info.into();
         let mut iterator = OctetStringIterator::new(iter);
         ffi::ReadHandler::handle_octet_string(self, info, &mut iterator);
+    }
+}
+
+impl From<ReadType> for ffi::ReadType {
+    fn from(x: ReadType) -> Self {
+        match x {
+            ReadType::Unsolicited => ffi::ReadType::Unsolicited,
+            ReadType::StartupIntegrity => ffi::ReadType::StartupIntegrity,
+            ReadType::PeriodicPoll => ffi::ReadType::PeriodicPoll,
+            ReadType::SinglePoll => ffi::ReadType::SinglePoll,
+        }
     }
 }
 

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -130,7 +130,7 @@ pub unsafe fn master_add_association(
     master: *mut Master,
     address: u16,
     config: ffi::AssociationConfig,
-    handlers: ffi::AssociationHandlers,
+    read_handler: ffi::ReadHandler,
     time_provider: ffi::TimeProvider,
 ) -> *mut Association {
     let master = match master.as_mut() {
@@ -170,9 +170,7 @@ pub unsafe fn master_add_association(
     };
 
     let handler = AssociationHandlerAdapter {
-        integrity_handler: handlers.integrity_handler,
-        unsolicited_handler: handlers.unsolicited_handler,
-        default_poll_handler: handlers.default_poll_handler,
+        read_handler,
         time_provider,
     };
 
@@ -288,9 +286,7 @@ fn convert_auto_time_sync(config: &ffi::AutoTimeSync) -> Option<TimeSyncProcedur
 }
 
 struct AssociationHandlerAdapter {
-    integrity_handler: ffi::ReadHandler,
-    unsolicited_handler: ffi::ReadHandler,
-    default_poll_handler: ffi::ReadHandler,
+    read_handler: ffi::ReadHandler,
     time_provider: ffi::TimeProvider,
 }
 
@@ -303,16 +299,8 @@ impl AssociationHandler for AssociationHandlerAdapter {
         }
     }
 
-    fn get_integrity_handler(&mut self) -> &mut dyn ReadHandler {
-        &mut self.integrity_handler
-    }
-
-    fn get_unsolicited_handler(&mut self) -> &mut dyn ReadHandler {
-        &mut self.unsolicited_handler
-    }
-
-    fn get_default_poll_handler(&mut self) -> &mut dyn ReadHandler {
-        &mut self.default_poll_handler
+    fn get_read_handler(&mut self) -> &mut dyn ReadHandler {
+        &mut self.read_handler
     }
 }
 

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -149,18 +149,6 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .doc("Association configuration")?
         .build()?;
 
-    let association_handlers = lib.declare_native_struct("AssociationHandlers")?;
-    let association_handlers = lib
-        .define_native_struct(&association_handlers)?
-        .add("integrity_handler", Type::Interface(read_handler.clone()), "Handler for the initial integrity scan")?
-        .add("unsolicited_handler", Type::Interface(read_handler.clone()), "Handler for unsolicited responses")?
-        .add("default_poll_handler", Type::Interface(read_handler), "Handler for all other responses")?
-        .doc(
-            doc("Handlers that will receive readings.")
-            .details("You can set all handlers to the same handler if knowing what type of event generated the value is not required.")
-        )?
-        .build()?;
-
     let time_provider_interface = define_time_provider(lib)?;
 
     let add_association_fn = lib
@@ -181,9 +169,9 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
             "Association configuration",
         )?
         .param(
-            "handlers",
-            Type::Struct(association_handlers),
-            "Handlers to call when receiving point data",
+            "read_handler",
+            Type::Interface(read_handler),
+            "Interface uses to load measurement data",
         )?
         .param(
             "time_provider",


### PR DESCRIPTION
`AssociationHandler` now returns a single `ReadHandler` instead of different ones for different situations.

This information is preserved by adding a `ReadType` to the `start_fragment` and `end_fragment` methods describing what triggered the read operation.