### PR TITLE
Refactor/command builder

### DIFF
--- a/dnp3/examples/master_serial.rs
+++ b/dnp3/examples/master_serial.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Err(err) = association
                     .operate(
                         CommandMode::SelectBeforeOperate,
-                        CommandBuilder::single_u16_header(
+                        CommandBuilder::single_header_u16(
                             Group12Var1::from_op_type(OpType::LatchOn),
                             3u16,
                         ),

--- a/dnp3/examples/master_tcp_client.rs
+++ b/dnp3/examples/master_tcp_client.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Err(err) = association
                     .operate(
                         CommandMode::SelectBeforeOperate,
-                        CommandBuilder::single_u16_header(
+                        CommandBuilder::single_header_u16(
                             Group12Var1::from_op_type(OpType::LatchOn),
                             3u16,
                         ),

--- a/dnp3/src/master/request.rs
+++ b/dnp3/src/master/request.rs
@@ -403,7 +403,7 @@ impl CommandBuilder {
     /// manually complete any partially built header
     /// this allows you to build multiple headers of the same type if desired,
     /// e.g. two g12v1 values in two separate headers
-    pub fn complete(&mut self) {
+    pub fn finish_header(&mut self) {
         if let Some(header) = self.partial.take() {
             self.headers.push(header);
         }
@@ -550,7 +550,7 @@ impl CommandBuilder {
     }
 
     pub fn build(mut self) -> CommandHeaders {
-        self.complete();
+        self.finish_header();
         CommandHeaders {
             headers: self.headers,
         }

--- a/dnp3/src/master/request.rs
+++ b/dnp3/src/master/request.rs
@@ -257,6 +257,7 @@ impl ReadRequest {
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum CommandHeader {
     G12V1U8(Vec<(Group12Var1, u8)>),
     G41V1U8(Vec<(Group41Var1, u8)>),
@@ -378,6 +379,7 @@ impl CommandHeaders {
     }
 }
 
+#[derive(Clone)]
 pub struct CommandBuilder {
     headers: Vec<CommandHeader>,
     partial: Option<CommandHeader>,

--- a/dnp3/src/master/request.rs
+++ b/dnp3/src/master/request.rs
@@ -257,52 +257,17 @@ impl ReadRequest {
     }
 }
 
-pub enum OneByteCommandHeader {
-    G12V1(Vec<(Group12Var1, u8)>),
-    G41V1(Vec<(Group41Var1, u8)>),
-    G41V2(Vec<(Group41Var2, u8)>),
-    G41V3(Vec<(Group41Var3, u8)>),
-    G41V4(Vec<(Group41Var4, u8)>),
-}
-
-pub enum TwoByteCommandHeader {
-    G12V1(Vec<(Group12Var1, u16)>),
-    G41V1(Vec<(Group41Var1, u16)>),
-    G41V2(Vec<(Group41Var2, u16)>),
-    G41V3(Vec<(Group41Var3, u16)>),
-    G41V4(Vec<(Group41Var4, u16)>),
-}
-
-impl OneByteCommandHeader {
-    pub(crate) fn wrap(self) -> CommandHeader {
-        CommandHeader::U8(self)
-    }
-
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
-        match self {
-            OneByteCommandHeader::G12V1(items) => writer.write_prefixed_items(items.iter()),
-            OneByteCommandHeader::G41V1(items) => writer.write_prefixed_items(items.iter()),
-            OneByteCommandHeader::G41V2(items) => writer.write_prefixed_items(items.iter()),
-            OneByteCommandHeader::G41V3(items) => writer.write_prefixed_items(items.iter()),
-            OneByteCommandHeader::G41V4(items) => writer.write_prefixed_items(items.iter()),
-        }
-    }
-}
-
-impl TwoByteCommandHeader {
-    pub(crate) fn wrap(self) -> CommandHeader {
-        CommandHeader::U16(self)
-    }
-
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
-        match self {
-            TwoByteCommandHeader::G12V1(items) => writer.write_prefixed_items(items.iter()),
-            TwoByteCommandHeader::G41V1(items) => writer.write_prefixed_items(items.iter()),
-            TwoByteCommandHeader::G41V2(items) => writer.write_prefixed_items(items.iter()),
-            TwoByteCommandHeader::G41V3(items) => writer.write_prefixed_items(items.iter()),
-            TwoByteCommandHeader::G41V4(items) => writer.write_prefixed_items(items.iter()),
-        }
-    }
+pub enum CommandHeader {
+    G12V1U8(Vec<(Group12Var1, u8)>),
+    G41V1U8(Vec<(Group41Var1, u8)>),
+    G41V2U8(Vec<(Group41Var2, u8)>),
+    G41V3U8(Vec<(Group41Var3, u8)>),
+    G41V4U8(Vec<(Group41Var4, u8)>),
+    G12V1U16(Vec<(Group12Var1, u16)>),
+    G41V1U16(Vec<(Group41Var1, u16)>),
+    G41V2U16(Vec<(Group41Var2, u16)>),
+    G41V3U16(Vec<(Group41Var3, u16)>),
+    G41V4U16(Vec<(Group41Var4, u16)>),
 }
 
 pub trait Command {
@@ -317,11 +282,11 @@ impl Command for Group12Var1 {
     }
 
     fn to_header_u8(&self, index: u8) -> CommandHeader {
-        OneByteCommandHeader::G12V1(vec![(*self, index)]).wrap()
+        CommandHeader::G12V1U8(vec![(*self, index)])
     }
 
     fn to_header_u16(&self, index: u16) -> CommandHeader {
-        TwoByteCommandHeader::G12V1(vec![(*self, index)]).wrap()
+        CommandHeader::G12V1U16(vec![(*self, index)])
     }
 }
 
@@ -331,11 +296,11 @@ impl Command for Group41Var1 {
     }
 
     fn to_header_u8(&self, index: u8) -> CommandHeader {
-        OneByteCommandHeader::G41V1(vec![(*self, index)]).wrap()
+        CommandHeader::G41V1U8(vec![(*self, index)])
     }
 
     fn to_header_u16(&self, index: u16) -> CommandHeader {
-        TwoByteCommandHeader::G41V1(vec![(*self, index)]).wrap()
+        CommandHeader::G41V1U16(vec![(*self, index)])
     }
 }
 
@@ -344,10 +309,10 @@ impl Command for Group41Var2 {
         self.status
     }
     fn to_header_u8(&self, index: u8) -> CommandHeader {
-        OneByteCommandHeader::G41V2(vec![(*self, index)]).wrap()
+        CommandHeader::G41V2U8(vec![(*self, index)])
     }
     fn to_header_u16(&self, index: u16) -> CommandHeader {
-        TwoByteCommandHeader::G41V2(vec![(*self, index)]).wrap()
+        CommandHeader::G41V2U16(vec![(*self, index)])
     }
 }
 
@@ -356,10 +321,10 @@ impl Command for Group41Var3 {
         self.status
     }
     fn to_header_u8(&self, index: u8) -> CommandHeader {
-        OneByteCommandHeader::G41V3(vec![(*self, index)]).wrap()
+        CommandHeader::G41V3U8(vec![(*self, index)])
     }
     fn to_header_u16(&self, index: u16) -> CommandHeader {
-        TwoByteCommandHeader::G41V3(vec![(*self, index)]).wrap()
+        CommandHeader::G41V3U16(vec![(*self, index)])
     }
 }
 
@@ -368,11 +333,11 @@ impl Command for Group41Var4 {
         self.status
     }
     fn to_header_u8(&self, index: u8) -> CommandHeader {
-        OneByteCommandHeader::G41V4(vec![(*self, index)]).wrap()
+        CommandHeader::G41V4U8(vec![(*self, index)])
     }
 
     fn to_header_u16(&self, index: u16) -> CommandHeader {
-        TwoByteCommandHeader::G41V4(vec![(*self, index)]).wrap()
+        CommandHeader::G41V4U16(vec![(*self, index)])
     }
 }
 
@@ -463,16 +428,19 @@ impl Default for CommandBuilder {
     }
 }
 
-pub enum CommandHeader {
-    U8(OneByteCommandHeader),
-    U16(TwoByteCommandHeader),
-}
-
 impl CommandHeader {
     pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
         match self {
-            CommandHeader::U8(header) => header.write(writer),
-            CommandHeader::U16(header) => header.write(writer),
+            CommandHeader::G12V1U8(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V1U8(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V2U8(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V3U8(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V4U8(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G12V1U16(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V1U16(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V2U16(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V3U16(items) => writer.write_prefixed_items(items.iter()),
+            CommandHeader::G41V4U16(items) => writer.write_prefixed_items(items.iter()),
         }
     }
 
@@ -509,61 +477,61 @@ impl CommandHeader {
 
     pub(crate) fn compare(&self, response: HeaderDetails) -> Result<(), CommandResponseError> {
         match self {
-            CommandHeader::U8(OneByteCommandHeader::G12V1(items)) => match response {
+            CommandHeader::G12V1U8(items) => match response {
                 HeaderDetails::OneByteCountAndPrefix(_, PrefixedVariation::Group12Var1(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U16(TwoByteCommandHeader::G12V1(items)) => match response {
+            CommandHeader::G12V1U16(items) => match response {
                 HeaderDetails::TwoByteCountAndPrefix(_, PrefixedVariation::Group12Var1(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U8(OneByteCommandHeader::G41V1(items)) => match response {
+            CommandHeader::G41V1U8(items) => match response {
                 HeaderDetails::OneByteCountAndPrefix(_, PrefixedVariation::Group41Var1(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U16(TwoByteCommandHeader::G41V1(items)) => match response {
+            CommandHeader::G41V1U16(items) => match response {
                 HeaderDetails::TwoByteCountAndPrefix(_, PrefixedVariation::Group41Var1(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U8(OneByteCommandHeader::G41V2(items)) => match response {
+            CommandHeader::G41V2U8(items) => match response {
                 HeaderDetails::OneByteCountAndPrefix(_, PrefixedVariation::Group41Var2(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U16(TwoByteCommandHeader::G41V2(items)) => match response {
+            CommandHeader::G41V2U16(items) => match response {
                 HeaderDetails::TwoByteCountAndPrefix(_, PrefixedVariation::Group41Var2(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U8(OneByteCommandHeader::G41V3(items)) => match response {
+            CommandHeader::G41V3U8(items) => match response {
                 HeaderDetails::OneByteCountAndPrefix(_, PrefixedVariation::Group41Var3(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U16(TwoByteCommandHeader::G41V3(items)) => match response {
+            CommandHeader::G41V3U16(items) => match response {
                 HeaderDetails::TwoByteCountAndPrefix(_, PrefixedVariation::Group41Var3(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U8(OneByteCommandHeader::G41V4(items)) => match response {
+            CommandHeader::G41V4U8(items) => match response {
                 HeaderDetails::OneByteCountAndPrefix(_, PrefixedVariation::Group41Var4(seq)) => {
                     Self::compare_items(seq, items)
                 }
                 _ => Err(CommandResponseError::HeaderTypeMismatch),
             },
-            CommandHeader::U16(TwoByteCommandHeader::G41V4(items)) => match response {
+            CommandHeader::G41V4U16(items) => match response {
                 HeaderDetails::TwoByteCountAndPrefix(_, PrefixedVariation::Group41Var4(seq)) => {
                     Self::compare_items(seq, items)
                 }

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -306,18 +306,18 @@ int main()
             request_destroy(request);
         }
         else if (strcmp(cbuf, "cmd\n") == 0) {
-            command_t *command = command_new();
+            commands_t *commands = commands_new();
             g12v1_t g12v1 = g12v1_init(control_code_init(TripCloseCode_Nul, false, OpType_LatchOn), 1, 1000, 1000);
-            command_add_u16_g12v1(command, 3, g12v1);
+            commands_add_g12v1_u16(commands, 3, g12v1);
 
             command_task_callback_t cb = {
                 .on_complete = &on_command_complete,
                 .ctx = NULL,
             };
 
-            master_operate(master, association_id, CommandMode_SelectBeforeOperate, command, cb);
+            master_operate(master, association_id, CommandMode_SelectBeforeOperate, commands, cb);
 
-            command_destroy(command);
+            commands_destroy(commands);
         }
         else if (strcmp(cbuf, "evt\n") == 0) {
             master_demand_poll(master, poll_id);

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -254,9 +254,9 @@ class MainClass
                     }
                 case "cmd":
                     {
-                        var command = new Command();
-                        command.AddU16g12v1(3, new G12v1(new ControlCode(TripCloseCode.Nul, false, OpType.LatchOn), 1, 1000, 1000));
-                        var result = await master.Operate(association, CommandMode.SelectBeforeOperate, command);
+                        var commands = new Commands();
+                        commands.AddG12v1u8(3, new G12v1(new ControlCode(TripCloseCode.Nul, false, OpType.LatchOn), 1, 1000, 1000));
+                        var result = await master.Operate(association, CommandMode.SelectBeforeOperate, commands);
                         Console.WriteLine($"Result: {result}");
                         break;
                     }

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/MasterExample.java
@@ -234,12 +234,12 @@ public class MasterExample {
           break;
         }
         case "cmd": {
-          Command command = new Command();
+          Commands commands = new Commands();
           G12v1 g12v1 = new G12v1(new ControlCode(TripCloseCode.NUL, false, OpType.LATCH_ON),
               ubyte(1), uint(1000), uint(1000));
-          command.addU16g12v1(ushort(3), g12v1);
+          commands.addG12v1u16(ushort(3), g12v1);
           CommandResult result =
-              master.operate(association, CommandMode.SELECT_BEFORE_OPERATE, command)
+              master.operate(association, CommandMode.SELECT_BEFORE_OPERATE, commands)
                   .toCompletableFuture().get();
           System.out.println("Result: " + result);
           break;

--- a/ffi/dnp3-ffi/src/command.rs
+++ b/ffi/dnp3-ffi/src/command.rs
@@ -3,17 +3,8 @@ use dnp3::master::*;
 
 use crate::ffi;
 
-#[derive(Clone)]
-enum CommandHeaderElement {
-    G12V1(Group12Var1),
-    G41V1(Group41Var1),
-    G41V2(Group41Var2),
-    G41V3(Group41Var3),
-    G41V4(Group41Var4),
-}
-
-impl From<&ffi::ControlCode> for ControlCode {
-    fn from(from: &ffi::ControlCode) -> Self {
+impl From<ffi::ControlCode> for ControlCode {
+    fn from(from: ffi::ControlCode) -> Self {
         Self {
             tcc: match from.tcc() {
                 ffi::TripCloseCode::Nul => TripCloseCode::Nul,
@@ -34,166 +25,81 @@ impl From<&ffi::ControlCode> for ControlCode {
     }
 }
 
-impl From<ffi::G12v1> for CommandHeaderElement {
-    fn from(from: ffi::G12v1) -> Self {
-        Self::G12V1(Group12Var1::new(
-            (&from.code).into(),
-            from.count,
-            from.on_time,
-            from.off_time,
-        ))
+impl From<ffi::G12v1> for Group12Var1 {
+    fn from(x: ffi::G12v1) -> Self {
+        Group12Var1::new(x.code.into(), x.count, x.on_time, x.off_time)
     }
 }
 
-impl From<Group41Var1> for CommandHeaderElement {
-    fn from(from: Group41Var1) -> Self {
-        Self::G41V1(from)
+// Commands is just a handle to a CommandBuilder
+pub type Commands = dnp3::master::CommandBuilder;
+
+pub unsafe fn commands_new() -> *mut Commands {
+    Box::into_raw(Box::new(CommandBuilder::new()))
+}
+
+pub unsafe fn commands_destroy(commands: *mut Commands) {
+    if !commands.is_null() {
+        Box::from_raw(commands);
     }
 }
 
-impl From<Group41Var2> for CommandHeaderElement {
-    fn from(from: Group41Var2) -> Self {
-        Self::G41V2(from)
+pub unsafe fn commands_add_g12v1_u8(commands: *mut Commands, idx: u8, value: ffi::G12v1) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group12Var1>::add_u8(commands, value.into(), idx);
     }
 }
 
-impl From<Group41Var3> for CommandHeaderElement {
-    fn from(from: Group41Var3) -> Self {
-        Self::G41V3(from)
+pub unsafe fn commands_add_g12v1_u16(commands: *mut Commands, idx: u16, value: ffi::G12v1) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group12Var1>::add_u16(commands, value.into(), idx);
     }
 }
 
-impl From<Group41Var4> for CommandHeaderElement {
-    fn from(from: Group41Var4) -> Self {
-        Self::G41V4(from)
+pub unsafe fn commands_add_g41v1_u8(commands: *mut Commands, idx: u8, value: i32) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var1>::add_u8(commands, Group41Var1::new(value), idx);
     }
 }
 
-#[derive(Clone)]
-enum CommandHeader {
-    U8(u8, CommandHeaderElement),
-    U16(u16, CommandHeaderElement),
-}
-
-impl CommandHeader {
-    fn u8(idx: u8, el: CommandHeaderElement) -> Self {
-        Self::U8(idx, el)
-    }
-
-    fn u16(idx: u16, el: CommandHeaderElement) -> Self {
-        Self::U16(idx, el)
+pub unsafe fn commands_add_g41v1_u16(commands: *mut Commands, idx: u16, value: i32) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var1>::add_u16(commands, Group41Var1::new(value), idx);
     }
 }
 
-#[derive(Clone)]
-pub struct Command {
-    headers: Vec<CommandHeader>,
-}
-
-impl Command {
-    fn new() -> Self {
-        Self {
-            headers: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, header: CommandHeader) {
-        self.headers.push(header);
-    }
-
-    pub(crate) fn build(self) -> dnp3::master::CommandHeaders {
-        let mut builder = dnp3::master::CommandBuilder::new();
-
-        for header in self.headers {
-            match header {
-                CommandHeader::U8(idx, el) => match el {
-                    CommandHeaderElement::G12V1(el) => builder.add_u8(el, idx),
-                    CommandHeaderElement::G41V1(el) => builder.add_u8(el, idx),
-                    CommandHeaderElement::G41V2(el) => builder.add_u8(el, idx),
-                    CommandHeaderElement::G41V3(el) => builder.add_u8(el, idx),
-                    CommandHeaderElement::G41V4(el) => builder.add_u8(el, idx),
-                },
-                CommandHeader::U16(idx, el) => match el {
-                    CommandHeaderElement::G12V1(el) => builder.add_u16(el, idx),
-                    CommandHeaderElement::G41V1(el) => builder.add_u16(el, idx),
-                    CommandHeaderElement::G41V2(el) => builder.add_u16(el, idx),
-                    CommandHeaderElement::G41V3(el) => builder.add_u16(el, idx),
-                    CommandHeaderElement::G41V4(el) => builder.add_u16(el, idx),
-                },
-            }
-        }
-
-        builder.build()
+pub unsafe fn commands_add_g41v2_u8(commands: *mut Commands, idx: u8, value: i16) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var2>::add_u8(commands, Group41Var2::new(value), idx);
     }
 }
 
-pub unsafe fn command_new() -> *mut Command {
-    let command = Box::new(Command::new());
-    Box::into_raw(command)
-}
-
-pub unsafe fn command_destroy(command: *mut Command) {
-    if !command.is_null() {
-        Box::from_raw(command);
+pub unsafe fn commands_add_g41v2_u16(commands: *mut Commands, idx: u16, value: i16) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var2>::add_u16(commands, Group41Var2::new(value), idx);
     }
 }
 
-pub unsafe fn command_add_u8_g12v1(command: *mut Command, idx: u8, header: ffi::G12v1) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u8(idx, header.into()));
+pub unsafe fn commands_add_g41v3_u8(commands: *mut Commands, idx: u8, value: f32) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var3>::add_u8(commands, Group41Var3::new(value), idx);
     }
 }
 
-pub unsafe fn command_add_u16_g12v1(command: *mut Command, idx: u16, header: ffi::G12v1) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u16(idx, header.into()));
+pub unsafe fn commands_add_g41v3_u16(commands: *mut Commands, idx: u16, value: f32) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var3>::add_u16(commands, Group41Var3::new(value), idx);
     }
 }
 
-pub unsafe fn command_add_u8_g41v1(command: *mut Command, idx: u8, value: i32) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u8(idx, Group41Var1::new(value).into()));
+pub unsafe fn commands_add_g41v4_u8(commands: *mut Commands, idx: u8, value: f64) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var4>::add_u8(commands, Group41Var4::new(value), idx);
     }
 }
 
-pub unsafe fn command_add_u16_g41v1(command: *mut Command, idx: u16, value: i32) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u16(idx, Group41Var1::new(value).into()));
-    }
-}
-
-pub unsafe fn command_add_u8_g41v2(command: *mut Command, idx: u8, value: i16) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u8(idx, Group41Var2::new(value).into()));
-    }
-}
-
-pub unsafe fn command_add_u16_g41v2(command: *mut Command, idx: u16, value: i16) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u16(idx, Group41Var2::new(value).into()));
-    }
-}
-
-pub unsafe fn command_add_u8_g41v3(command: *mut Command, idx: u8, value: f32) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u8(idx, Group41Var3::new(value).into()));
-    }
-}
-
-pub unsafe fn command_add_u16_g41v3(command: *mut Command, idx: u16, value: f32) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u16(idx, Group41Var3::new(value).into()));
-    }
-}
-
-pub unsafe fn command_add_u8_g41v4(command: *mut Command, idx: u8, value: f64) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u8(idx, Group41Var4::new(value).into()));
-    }
-}
-
-pub unsafe fn command_add_u16_g41v4(command: *mut Command, idx: u16, value: f64) {
-    if let Some(command) = command.as_mut() {
-        command.push(CommandHeader::u16(idx, Group41Var4::new(value).into()));
+pub unsafe fn commands_add_g41v4_u16(commands: *mut Commands, idx: u16, value: f64) {
+    if let Some(commands) = commands.as_mut() {
+        CommandSupport::<Group41Var4>::add_u16(commands, Group41Var4::new(value), idx);
     }
 }

--- a/ffi/dnp3-ffi/src/command.rs
+++ b/ffi/dnp3-ffi/src/command.rs
@@ -44,6 +44,12 @@ pub unsafe fn commands_destroy(commands: *mut Commands) {
     }
 }
 
+pub unsafe fn commands_finish_header(commands: *mut crate::Commands) {
+    if let Some(commands) = commands.as_mut() {
+        commands.finish_header();
+    }
+}
+
 pub unsafe fn commands_add_g12v1_u8(commands: *mut Commands, idx: u8, value: ffi::G12v1) {
     if let Some(commands) = commands.as_mut() {
         CommandSupport::<Group12Var1>::add_u8(commands, value.into(), idx);

--- a/ffi/dnp3-ffi/src/command.rs
+++ b/ffi/dnp3-ffi/src/command.rs
@@ -1,4 +1,5 @@
 use dnp3::app::control::*;
+use dnp3::master::*;
 
 use crate::ffi;
 
@@ -106,18 +107,18 @@ impl Command {
         for header in self.headers {
             match header {
                 CommandHeader::U8(idx, el) => match el {
-                    CommandHeaderElement::G12V1(el) => builder.add_u8_header(el, idx),
-                    CommandHeaderElement::G41V1(el) => builder.add_u8_header(el, idx),
-                    CommandHeaderElement::G41V2(el) => builder.add_u8_header(el, idx),
-                    CommandHeaderElement::G41V3(el) => builder.add_u8_header(el, idx),
-                    CommandHeaderElement::G41V4(el) => builder.add_u8_header(el, idx),
+                    CommandHeaderElement::G12V1(el) => builder.add_u8(el, idx),
+                    CommandHeaderElement::G41V1(el) => builder.add_u8(el, idx),
+                    CommandHeaderElement::G41V2(el) => builder.add_u8(el, idx),
+                    CommandHeaderElement::G41V3(el) => builder.add_u8(el, idx),
+                    CommandHeaderElement::G41V4(el) => builder.add_u8(el, idx),
                 },
                 CommandHeader::U16(idx, el) => match el {
-                    CommandHeaderElement::G12V1(el) => builder.add_u16_header(el, idx),
-                    CommandHeaderElement::G41V1(el) => builder.add_u16_header(el, idx),
-                    CommandHeaderElement::G41V2(el) => builder.add_u16_header(el, idx),
-                    CommandHeaderElement::G41V3(el) => builder.add_u16_header(el, idx),
-                    CommandHeaderElement::G41V4(el) => builder.add_u16_header(el, idx),
+                    CommandHeaderElement::G12V1(el) => builder.add_u16(el, idx),
+                    CommandHeaderElement::G41V1(el) => builder.add_u16(el, idx),
+                    CommandHeaderElement::G41V2(el) => builder.add_u16(el, idx),
+                    CommandHeaderElement::G41V3(el) => builder.add_u16(el, idx),
+                    CommandHeaderElement::G41V4(el) => builder.add_u16(el, idx),
                 },
             }
         }

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -401,7 +401,7 @@ pub unsafe extern "C" fn master_operate(
     master: *mut crate::Master,
     association: ffi::AssociationId,
     mode: ffi::CommandMode,
-    commands: *mut crate::Command,
+    commands: *mut crate::Commands,
     callback: ffi::CommandTaskCallback,
 ) {
     let master = match master.as_mut() {

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -818,6 +818,17 @@ fn define_command_builder(
         .doc("Destroy set of commands")?
         .build()?;
 
+    let command_finish_header_fn = lib
+        .declare_native_function("commands_finish_header")?
+        .param(
+            "commands",
+            Type::ClassRef(command.clone()),
+            "Commands on which to finish the header",
+        )?
+        .return_type(ReturnType::void())?
+        .doc("Finish any partially partially completed header. This allows for the construction of two headers with the same type and index")?
+        .build()?;
+
     let command_add_u8_g12v1_fn = lib
         .declare_native_function("commands_add_g12v1_u8")?
         .param(
@@ -1009,6 +1020,7 @@ fn define_command_builder(
         .method("AddG41V3U16", &command_add_u16_g41v3_fn)?
         .method("AddG41V4U8", &command_add_u8_g41v4_fn)?
         .method("AddG41V4U16", &command_add_u16_g41v4_fn)?
+        .method("FinishHeader", &command_finish_header_fn)?
         .doc("Builder type used to construct command requests")?
         .build()
 }

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -796,34 +796,34 @@ fn define_command_builder(
     lib: &mut LibraryBuilder,
     shared: &SharedDefinitions,
 ) -> std::result::Result<ClassHandle, BindingError> {
-    let command = lib.declare_class("Command")?;
+    let command = lib.declare_class("Commands")?;
 
     let command_new_fn = lib
-        .declare_native_function("command_new")?
+        .declare_native_function("commands_new")?
         .return_type(ReturnType::new(
             Type::ClassRef(command.clone()),
-            "Handle to the created command",
+            "Handle to the created set of commands",
         ))?
-        .doc("Create a new command")?
+        .doc("Create a new set of commands")?
         .build()?;
 
     let command_destroy_fn = lib
-        .declare_native_function("command_destroy")?
+        .declare_native_function("commands_destroy")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
-            "Command to destroy",
+            "Set of commands to destroy",
         )?
         .return_type(ReturnType::void())?
-        .doc("Destroy command")?
+        .doc("Destroy set of commands")?
         .build()?;
 
     let command_add_u8_g12v1_fn = lib
-        .declare_native_function("command_add_u8_g12v1")?
+        .declare_native_function("commands_add_g12v1_u8")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -840,7 +840,7 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u16_g12v1_fn = lib
-        .declare_native_function("command_add_u16_g12v1")?
+        .declare_native_function("commands_add_g12v1_u16")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
@@ -861,7 +861,7 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u8_g41v1_fn = lib
-        .declare_native_function("command_add_u8_g41v1")?
+        .declare_native_function("commands_add_g41v1_u8")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
@@ -878,11 +878,11 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u16_g41v1_fn = lib
-        .declare_native_function("command_add_u16_g41v1")?
+        .declare_native_function("commands_add_g41v1_u16")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -895,11 +895,11 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u8_g41v2_fn = lib
-        .declare_native_function("command_add_u8_g41v2")?
+        .declare_native_function("commands_add_g41v2_u8")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -912,11 +912,11 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u16_g41v2_fn = lib
-        .declare_native_function("command_add_u16_g41v2")?
+        .declare_native_function("commands_add_g41v2_u16")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -929,11 +929,11 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u8_g41v3_fn = lib
-        .declare_native_function("command_add_u8_g41v3")?
+        .declare_native_function("commands_add_g41v3_u8")?
         .param(
             "command",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -946,11 +946,11 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u16_g41v3_fn = lib
-        .declare_native_function("command_add_u16_g41v3")?
+        .declare_native_function("commands_add_g41v3_u16")?
         .param(
-            "command",
+            "commands",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -963,11 +963,11 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u8_g41v4_fn = lib
-        .declare_native_function("command_add_u8_g41v4")?
+        .declare_native_function("commands_add_g41v4_u8")?
         .param(
-            "command",
+            "commands",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -980,11 +980,11 @@ fn define_command_builder(
         .build()?;
 
     let command_add_u16_g41v4_fn = lib
-        .declare_native_function("command_add_u16_g41v4")?
+        .declare_native_function("commands_add_g41v4_u16")?
         .param(
-            "command",
+            "commands",
             Type::ClassRef(command.clone()),
-            "Command to modify",
+            "Commands to modify",
         )?
         .param(
             "idx",
@@ -999,16 +999,16 @@ fn define_command_builder(
     lib.define_class(&command)?
         .constructor(&command_new_fn)?
         .destructor(&command_destroy_fn)?
-        .method("AddU8G12V1", &command_add_u8_g12v1_fn)?
-        .method("AddU16G12V1", &command_add_u16_g12v1_fn)?
-        .method("AddU8G41V1", &command_add_u8_g41v1_fn)?
-        .method("AddU16G41V1", &command_add_u16_g41v1_fn)?
-        .method("AddU8G41V2", &command_add_u8_g41v2_fn)?
-        .method("AddU16G41V2", &command_add_u16_g41v2_fn)?
-        .method("AddU8G41V3", &command_add_u8_g41v3_fn)?
-        .method("AddU16G41V3", &command_add_u16_g41v3_fn)?
-        .method("AddU8G41V4", &command_add_u8_g41v4_fn)?
-        .method("AddU16G41V4", &command_add_u16_g41v4_fn)?
+        .method("AddG12V1U8", &command_add_u8_g12v1_fn)?
+        .method("AddG12V1U16", &command_add_u16_g12v1_fn)?
+        .method("AddG41V1U8", &command_add_u8_g41v1_fn)?
+        .method("AddG41V1U16", &command_add_u16_g41v1_fn)?
+        .method("AddG41V2U8", &command_add_u8_g41v2_fn)?
+        .method("AddG41V2U16", &command_add_u16_g41v2_fn)?
+        .method("AddG41V3U8", &command_add_u8_g41v3_fn)?
+        .method("AddG41V3U16", &command_add_u16_g41v3_fn)?
+        .method("AddG41V4U8", &command_add_u8_g41v4_fn)?
+        .method("AddG41V4U16", &command_add_u16_g41v4_fn)?
         .doc("Builder type used to construct command requests")?
         .build()
 }

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -826,7 +826,7 @@ fn define_command_builder(
             "Commands on which to finish the header",
         )?
         .return_type(ReturnType::void())?
-        .doc("Finish any partially partially completed header. This allows for the construction of two headers with the same type and index")?
+        .doc("Finish any partially completed header. This allows for the construction of two headers with the same type and index")?
         .build()?;
 
     let command_add_u8_g12v1_fn = lib


### PR DESCRIPTION
This PR makes it possible to precisely control how multi-command object headers are constructed.

It makes the `CommandBuilder` a state machine of sorts by adding a `partial` field to the struct:

```
#[derive(Clone)]
pub struct CommandBuilder {
    headers: Vec<CommandHeader>,
    partial: Option<CommandHeader>,
}
```

When adding g12/g41, the builder now checks to see if any partially constructed header is of the same type/index and adds it to the partially constructed header if so. The user may call `finish_header()` early if they want to construct two distinct headers with values of the same type and index.

The FFI code was simplified by making direct use of `CommandBuilder` as an opaque pointer.

