### PR TITLE
Refactor/outstation session handling

### DIFF
--- a/dnp3/src/outstation/adapter.rs
+++ b/dnp3/src/outstation/adapter.rs
@@ -1,0 +1,100 @@
+use tracing::Instrument;
+
+use crate::app::Shutdown;
+use crate::outstation::session::RunError;
+use crate::outstation::task::OutstationTask;
+use crate::util::channel::{request_channel, Receiver, Sender};
+use crate::util::phys::PhysLayer;
+
+/// message that gets sent to OutstationTaskAdapter when
+/// it needs to switch to a new session
+#[derive(Debug)]
+pub(crate) struct NewSession {
+    pub(crate) id: u64,
+    pub(crate) phys: PhysLayer,
+}
+
+impl NewSession {
+    pub(crate) fn new(id: u64, phys: PhysLayer) -> Self {
+        Self { id, phys }
+    }
+}
+
+/// adapts an OutstationTask to something that can listen for new
+/// connections on a channel and shutdown an existing session
+pub(crate) struct OutstationTaskAdapter {
+    receiver: Receiver<NewSession>,
+    task: OutstationTask,
+}
+
+impl OutstationTaskAdapter {
+    pub(crate) fn create(task: OutstationTask) -> (Self, Sender<NewSession>) {
+        let (tx, rx) = request_channel();
+
+        (Self { receiver: rx, task }, tx)
+    }
+
+    async fn wait_for_session(&mut self) -> Result<NewSession, Shutdown> {
+        loop {
+            crate::tokio::select! {
+                session = self.receiver.receive() => {
+                    return session;
+                }
+                ret = self.task.process_messages() => {
+                    ret?
+                }
+            }
+        }
+    }
+
+    async fn run_one_session(&mut self, io: &mut PhysLayer) -> Result<NewSession, RunError> {
+        crate::tokio::select! {
+            res = self.task.run(io) => {
+                Err(res)
+            }
+            x = self.receiver.receive() => {
+                Ok(x?)
+            }
+        }
+    }
+
+    pub(crate) async fn run(&mut self) -> Result<(), Shutdown> {
+        let mut session = None;
+
+        loop {
+            match session.take() {
+                None => {
+                    session.replace(self.wait_for_session().await?);
+                }
+                Some(mut s) => {
+                    let id = s.id;
+
+                    let result = self
+                        .run_one_session(&mut s.phys)
+                        .instrument(tracing::info_span!("Session", "id" = id))
+                        .await;
+
+                    // reset outstation state in between sessions
+                    self.task.reset();
+
+                    match result {
+                        Ok(new_session) => {
+                            tracing::warn!(
+                                "closing session {} for new session {}",
+                                id,
+                                new_session.id
+                            );
+                            // go to next iteration with a new session
+                            session.replace(new_session);
+                        }
+                        Err(RunError::Link(err)) => {
+                            // go to next iteration to get a new session
+                            tracing::warn!("Session error: {}", err);
+                        }
+                        Err(RunError::Shutdown) => return Err(Shutdown),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dnp3/src/outstation/mod.rs
+++ b/dnp3/src/outstation/mod.rs
@@ -4,9 +4,8 @@ pub use traits::*;
 use crate::app::Shutdown;
 use crate::decode::DecodeLevel;
 use crate::outstation::database::DatabaseHandle;
-use crate::outstation::task::{ConfigurationChange, NewSession, OutstationMessage};
+use crate::outstation::task::{ConfigurationChange, OutstationMessage};
 use crate::util::channel::Sender;
-use crate::util::phys::PhysLayer;
 
 /// configuration types
 
@@ -37,17 +36,6 @@ impl OutstationHandle {
     pub async fn set_decode_level(&mut self, decode_level: DecodeLevel) -> Result<(), Shutdown> {
         self.sender
             .send(ConfigurationChange::SetDecodeLevel(decode_level).into())
-            .await?;
-        Ok(())
-    }
-
-    pub(crate) async fn change_session(
-        &mut self,
-        id: u64,
-        phys: PhysLayer,
-    ) -> Result<(), Shutdown> {
-        self.sender
-            .send(OutstationMessage::ChangeSession(NewSession::new(id, phys)))
             .await?;
         Ok(())
     }

--- a/dnp3/src/outstation/mod.rs
+++ b/dnp3/src/outstation/mod.rs
@@ -12,6 +12,8 @@ use crate::util::channel::Sender;
 /// database API to add/remove/update values
 pub mod database;
 
+/// wraps an outstation task so that it can switch communication sessions
+pub(crate) mod adapter;
 mod config;
 /// functionality for processing control requests
 pub(crate) mod control;

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -218,6 +218,14 @@ impl SessionState {
             last_broadcast_type: None,
         }
     }
+
+    // reset items that should reset between communication (TCP) sessions
+    fn reset(&mut self) {
+        self.last_valid_request = None;
+        self.select = None;
+        self.unsolicited_seq = Sequence::default();
+        self.deferred_read.clear();
+    }
 }
 
 pub(crate) struct OutstationSession {
@@ -334,6 +342,10 @@ impl OutstationSession {
                 return err;
             }
         }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.state.reset();
     }
 
     async fn write_unsolicited(

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -24,7 +24,7 @@ use crate::outstation::control::collection::{ControlCollection, ControlTransacti
 use crate::outstation::control::select::SelectState;
 use crate::outstation::database::{DatabaseHandle, ResponseInfo};
 use crate::outstation::deferred::DeferredRead;
-use crate::outstation::task::{ConfigurationChange, NewSession, OutstationMessage};
+use crate::outstation::task::{ConfigurationChange, OutstationMessage};
 use crate::outstation::traits::*;
 use crate::transport::{
     FragmentInfo, RequestGuard, TransportReader, TransportRequest, TransportRequestError,
@@ -289,30 +289,6 @@ impl From<LinkError> for RunError {
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum SessionError {
-    Run(RunError),
-    NewSession(NewSession),
-}
-
-impl From<RunError> for SessionError {
-    fn from(x: RunError) -> Self {
-        SessionError::Run(x)
-    }
-}
-
-impl From<LinkError> for SessionError {
-    fn from(err: LinkError) -> Self {
-        SessionError::Run(err.into())
-    }
-}
-
-impl From<Shutdown> for SessionError {
-    fn from(x: Shutdown) -> Self {
-        SessionError::Run(x.into())
-    }
-}
-
 impl OutstationSession {
     pub(crate) fn new(
         messages: Receiver<OutstationMessage>,
@@ -339,13 +315,10 @@ impl OutstationSession {
         }
     }
 
-    pub(crate) async fn wait_for_io(&mut self) -> Result<NewSession, Shutdown> {
+    /// used when the there is no running IO to process outstation messages
+    pub(crate) async fn process_messages(&mut self) -> Result<(), Shutdown> {
         loop {
-            match self.messages.receive().await? {
-                OutstationMessage::Shutdown => return Err(Shutdown),
-                OutstationMessage::Configuration(change) => self.handle_config_change(change),
-                OutstationMessage::ChangeSession(session) => return Ok(session),
-            }
+            self.handle_next_message().await?;
         }
     }
 
@@ -355,7 +328,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> SessionError {
+    ) -> RunError {
         loop {
             if let Err(err) = self.run_idle_state(io, reader, writer, database).await {
                 return err;
@@ -446,7 +419,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), RunError> {
         // handle a request fragment if present
         self.handle_one_request_from_idle(io, reader, writer, database)
             .await?;
@@ -495,7 +468,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> Result<Option<crate::tokio::time::Instant>, SessionError> {
+    ) -> Result<Option<crate::tokio::time::Instant>, RunError> {
         if self.config.unsolicited.is_disabled() {
             return Ok(None);
         }
@@ -552,7 +525,7 @@ impl OutstationSession {
         &mut self,
         io: &mut PhysLayer,
         writer: &mut TransportWriter,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), RunError> {
         if let Some(next) = self.next_link_status {
             // Wait until we need to send the link status
             if next > crate::tokio::time::Instant::now() {
@@ -579,7 +552,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> Result<UnsolicitedResult, SessionError> {
+    ) -> Result<UnsolicitedResult, RunError> {
         let header = ResponseHeader::new(
             ControlField::unsolicited_response(self.state.unsolicited_seq.increment()),
             ResponseFunction::UnsolicitedResponse,
@@ -602,7 +575,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> Result<Option<UnsolicitedResult>, SessionError> {
+    ) -> Result<Option<UnsolicitedResult>, RunError> {
         if !self.state.enabled_unsolicited_classes.any() {
             return Ok(None);
         }
@@ -647,7 +620,7 @@ impl OutstationSession {
         io: &mut PhysLayer,
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
-    ) -> Result<UnsolicitedResult, SessionError> {
+    ) -> Result<UnsolicitedResult, RunError> {
         let response = self
             .write_unsolicited(io, writer, response, database)
             .await?;
@@ -716,7 +689,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> Result<UnsolicitedWaitResult, SessionError> {
+    ) -> Result<UnsolicitedWaitResult, RunError> {
         if let Timeout::Yes = self.read_until(io, reader, deadline).await? {
             return Ok(UnsolicitedWaitResult::Timeout);
         }
@@ -836,7 +809,7 @@ impl OutstationSession {
         io: &mut PhysLayer,
         reader: &mut TransportReader,
         deadline: crate::tokio::time::Instant,
-    ) -> Result<Timeout, SessionError> {
+    ) -> Result<Timeout, RunError> {
         loop {
             let decode_level = self.config.decode_level;
             crate::tokio::select! {
@@ -855,7 +828,7 @@ impl OutstationSession {
     async fn sleep_until(
         &mut self,
         instant: Option<crate::tokio::time::Instant>,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), RunError> {
         async fn sleep_only(instant: Option<crate::tokio::time::Instant>) {
             match instant {
                 Some(x) => crate::tokio::time::sleep_until(x).await,
@@ -878,10 +851,9 @@ impl OutstationSession {
         }
     }
 
-    async fn handle_next_message(&mut self) -> Result<(), SessionError> {
+    async fn handle_next_message(&mut self) -> Result<(), Shutdown> {
         match self.messages.receive().await? {
-            OutstationMessage::Shutdown => Err(Shutdown.into()),
-            OutstationMessage::ChangeSession(session) => Err(SessionError::NewSession(session)),
+            OutstationMessage::Shutdown => Err(Shutdown),
             OutstationMessage::Configuration(change) => {
                 self.handle_config_change(change);
                 Ok(())
@@ -904,7 +876,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), RunError> {
         if let Some(x) = self.state.deferred_read.select(database) {
             tracing::info!("handling deferred READ request");
             let (response, mut series) = self.write_read_response(database, true, x.seq, x.iin2);
@@ -938,7 +910,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), RunError> {
         let mut guard = reader.pop_request();
         match guard.get() {
             Some(TransportRequest::Request(info, request)) => {
@@ -1055,7 +1027,7 @@ impl OutstationSession {
         writer: &mut TransportWriter,
         err: TransportRequestError,
         database: &DatabaseHandle,
-    ) -> Result<(), LinkError> {
+    ) -> Result<(), RunError> {
         let seq = match err {
             TransportRequestError::HeaderParseError(err) => match err {
                 HeaderParseError::UnknownFunction(seq, _) => Some(seq),
@@ -1803,7 +1775,7 @@ impl OutstationSession {
         writer: &mut TransportWriter,
         database: &mut DatabaseHandle,
         mut series: ResponseSeries,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), RunError> {
         self.info.enter_solicited_confirm_wait(series.ecsn);
 
         loop {
@@ -1850,7 +1822,7 @@ impl OutstationSession {
         reader: &mut TransportReader,
         writer: &mut TransportWriter,
         ecsn: Sequence,
-    ) -> Result<Confirm, SessionError> {
+    ) -> Result<Confirm, RunError> {
         let mut deadline = self.new_confirm_deadline();
         loop {
             match self.read_until(io, reader, deadline).await? {

--- a/dnp3/src/outstation/task.rs
+++ b/dnp3/src/outstation/task.rs
@@ -1,10 +1,9 @@
-use tracing::Instrument;
-
+use crate::app::Shutdown;
 use crate::decode::DecodeLevel;
 use crate::link::LinkErrorMode;
 use crate::outstation::config::*;
 use crate::outstation::database::{DatabaseHandle, EventBufferConfig};
-use crate::outstation::session::{OutstationSession, RunError, SessionError};
+use crate::outstation::session::{OutstationSession, RunError};
 use crate::outstation::traits::{ControlHandler, OutstationApplication, OutstationInformation};
 use crate::outstation::OutstationHandle;
 use crate::transport::{TransportReader, TransportWriter};
@@ -20,28 +19,9 @@ impl From<ConfigurationChange> for OutstationMessage {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct NewSession {
-    pub(crate) id: u64,
-    pub(crate) phys: PhysLayer,
-}
-
-impl From<NewSession> for OutstationMessage {
-    fn from(x: NewSession) -> Self {
-        OutstationMessage::ChangeSession(x)
-    }
-}
-
-impl NewSession {
-    pub(crate) fn new(id: u64, phys: PhysLayer) -> Self {
-        Self { id, phys }
-    }
-}
-
 pub(crate) enum OutstationMessage {
     Shutdown,
     Configuration(ConfigurationChange),
-    ChangeSession(NewSession),
 }
 
 pub(crate) struct OutstationTask {
@@ -96,60 +76,17 @@ impl OutstationTask {
     }
 
     /// run the outstation task asynchronously until a `SessionError` occurs
-    pub(crate) async fn run_io(&mut self, io: &mut PhysLayer) -> SessionError {
+    pub(crate) async fn run(&mut self, io: &mut PhysLayer) -> RunError {
         self.session
             .run(io, &mut self.reader, &mut self.writer, &mut self.database)
             .await
     }
 
-    /// run the outstation task asynchronously until a shutdown is requested
-    pub(crate) async fn run(&mut self) {
-        let mut session = None;
-
+    /// process received outstation messages
+    pub(crate) async fn process_messages(&mut self) -> Result<(), Shutdown> {
         loop {
-            match session.take() {
-                None => match self.session.wait_for_io().await {
-                    Err(_) => return,
-                    Ok(s) => {
-                        session.replace(s);
-                    }
-                },
-                Some(s) => {
-                    let id = s.id;
-
-                    let result = self
-                        .run_one_session(s.phys)
-                        .instrument(tracing::info_span!("Session", "id" = id))
-                        .await;
-
-                    match result {
-                        SessionError::Run(RunError::Shutdown) => return,
-                        SessionError::Run(RunError::Link(_)) => {
-                            // TODO - reset the session
-                        }
-                        SessionError::NewSession(s) => {
-                            session.replace(s);
-                        }
-                    }
-                }
-            }
+            self.session.process_messages().await?;
         }
-    }
-
-    async fn run_one_session(&mut self, mut phys: PhysLayer) -> SessionError {
-        let err = self.run_io(&mut phys).await;
-        match &err {
-            SessionError::Run(RunError::Shutdown) => {
-                tracing::info!("received shutdown");
-            }
-            SessionError::Run(RunError::Link(err)) => {
-                tracing::warn!("link error: {}", err);
-            }
-            SessionError::NewSession(session) => {
-                tracing::info!("closing for new connection: {}", session.id)
-            }
-        };
-        err
     }
 
     #[cfg(test)]

--- a/dnp3/src/outstation/task.rs
+++ b/dnp3/src/outstation/task.rs
@@ -82,11 +82,17 @@ impl OutstationTask {
             .await
     }
 
-    /// process received outstation messages
+    /// process received outstation messages while idle without a session
     pub(crate) async fn process_messages(&mut self) -> Result<(), Shutdown> {
         loop {
             self.session.process_messages().await?;
         }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.session.reset();
+        self.reader.reset();
+        self.writer.reset();
     }
 
     #[cfg(test)]

--- a/dnp3/src/outstation/tests/harness/harness.rs
+++ b/dnp3/src/outstation/tests/harness/harness.rs
@@ -5,7 +5,7 @@ use crate::link::header::{BroadcastConfirmMode, FrameInfo, FrameType};
 use crate::link::{EndpointAddress, LinkErrorMode};
 use crate::outstation::config::{Feature, OutstationConfig};
 use crate::outstation::database::EventBufferConfig;
-use crate::outstation::session::SessionError;
+use crate::outstation::session::RunError;
 use crate::outstation::task::OutstationTask;
 use crate::outstation::tests::harness::{
     ApplicationData, Event, EventHandle, MockControlHandler, MockOutstationApplication,
@@ -34,7 +34,7 @@ pub(crate) fn get_default_unsolicited_config() -> OutstationConfig {
 
 pub(crate) struct OutstationTestHarness<T>
 where
-    T: std::future::Future<Output = SessionError>,
+    T: std::future::Future<Output = RunError>,
 {
     pub(crate) handle: OutstationHandle,
     io: io::Handle,
@@ -45,7 +45,7 @@ where
 
 impl<T> OutstationTestHarness<T>
 where
-    T: std::future::Future<Output = SessionError>,
+    T: std::future::Future<Output = RunError>,
 {
     pub(crate) fn poll_pending(&mut self) {
         assert_pending!(self.task.poll());
@@ -109,21 +109,21 @@ where
 
 pub(crate) fn new_harness(
     config: OutstationConfig,
-) -> OutstationTestHarness<impl std::future::Future<Output = SessionError>> {
+) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
     new_harness_impl(config, None)
 }
 
 pub(crate) fn new_harness_for_broadcast(
     config: OutstationConfig,
     broadcast: BroadcastConfirmMode,
-) -> OutstationTestHarness<impl std::future::Future<Output = SessionError>> {
+) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
     new_harness_impl(config, Some(broadcast))
 }
 
 fn new_harness_impl(
     config: OutstationConfig,
     broadcast: Option<BroadcastConfirmMode>,
-) -> OutstationTestHarness<impl std::future::Future<Output = SessionError>> {
+) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
     let events = EventHandle::new();
 
     let (data, application) = MockOutstationApplication::new(events.clone());
@@ -154,7 +154,7 @@ fn new_harness_impl(
     OutstationTestHarness {
         handle,
         io: io_handle,
-        task: spawn(async move { task.run_io(&mut io).await }),
+        task: spawn(async move { task.run(&mut io).await }),
         events,
         application_data: data,
     }

--- a/dnp3/src/outstation/tests/unsolicited.rs
+++ b/dnp3/src/outstation/tests/unsolicited.rs
@@ -1,7 +1,7 @@
 use crate::app::measurement::*;
 use crate::outstation::config::OutstationConfig;
 use crate::outstation::database::*;
-use crate::outstation::session::SessionError;
+use crate::outstation::session::RunError;
 
 use super::harness::*;
 
@@ -48,14 +48,14 @@ fn generate_binary_event(handle: &mut DatabaseHandle) {
 
 fn enable_unsolicited<T>(harness: &mut OutstationTestHarness<T>)
 where
-    T: std::future::Future<Output = SessionError>,
+    T: std::future::Future<Output = RunError>,
 {
     harness.test_request_response(ENABLE_UNSOLICITED_SEQ0, EMPTY_RESPONSE_SEQ0);
 }
 
 fn confirm_null_unsolicited<T>(harness: &mut OutstationTestHarness<T>)
 where
-    T: std::future::Future<Output = SessionError>,
+    T: std::future::Future<Output = RunError>,
 {
     harness.expect_response(NULL_UNSOL_SEQ_0);
     harness.send(UNS_CONFIRM_SEQ_0);

--- a/dnp3/src/tcp/outstation.rs
+++ b/dnp3/src/tcp/outstation.rs
@@ -3,104 +3,13 @@ use tracing::Instrument;
 use crate::app::Shutdown;
 use crate::link::LinkErrorMode;
 use crate::outstation::database::EventBufferConfig;
-use crate::outstation::session::RunError;
 use crate::outstation::task::OutstationTask;
 use crate::outstation::OutstationHandle;
 use crate::outstation::*;
 use crate::tcp::{AddressFilter, FilterError};
-use crate::util::channel::{request_channel, Receiver, Sender};
-use crate::util::phys::PhysLayer;
+use crate::util::channel::Sender;
 
-/// message that gets sent to OutstationTaskAdapter when
-/// it needs to switch to a new session
-#[derive(Debug)]
-pub(crate) struct NewSession {
-    pub(crate) id: u64,
-    pub(crate) phys: PhysLayer,
-}
-
-impl NewSession {
-    pub(crate) fn new(id: u64, phys: PhysLayer) -> Self {
-        Self { id, phys }
-    }
-}
-
-/// adapts an OutstationTask to something that can listen for new
-/// connections on a channel and shutdown an existing session
-struct OutstationTaskAdapter {
-    receiver: Receiver<NewSession>,
-    task: OutstationTask,
-}
-
-impl OutstationTaskAdapter {
-    fn create(task: OutstationTask) -> (Self, Sender<NewSession>) {
-        let (tx, rx) = request_channel();
-
-        (Self { receiver: rx, task }, tx)
-    }
-
-    async fn wait_for_session(&mut self) -> Result<NewSession, Shutdown> {
-        loop {
-            crate::tokio::select! {
-                session = self.receiver.receive() => {
-                    return session;
-                }
-                ret = self.task.process_messages() => {
-                    ret?
-                }
-            }
-        }
-    }
-
-    async fn run_one_session(&mut self, io: &mut PhysLayer) -> Result<NewSession, RunError> {
-        crate::tokio::select! {
-            res = self.task.run(io) => {
-                Err(res)
-            }
-            x = self.receiver.receive() => {
-                Ok(x?)
-            }
-        }
-    }
-
-    async fn run(&mut self) -> Result<(), Shutdown> {
-        let mut session = None;
-
-        loop {
-            match session.take() {
-                None => {
-                    session.replace(self.wait_for_session().await?);
-                }
-                Some(mut s) => {
-                    let id = s.id;
-
-                    let result = self
-                        .run_one_session(&mut s.phys)
-                        .instrument(tracing::info_span!("Session", "id" = id))
-                        .await;
-
-                    match result {
-                        Ok(new_session) => {
-                            // TODO reset the task
-                            tracing::warn!(
-                                "closing session {} for new session {}",
-                                id,
-                                new_session.id
-                            );
-                            // go to next iteration with a new session
-                            session.replace(new_session);
-                        }
-                        Err(RunError::Link(err)) => {
-                            // TODO reset the task
-                            tracing::warn!("Session error: {}", err);
-                        }
-                        Err(RunError::Shutdown) => return Err(Shutdown),
-                    }
-                }
-            }
-        }
-    }
-}
+use crate::outstation::adapter::{NewSession, OutstationTaskAdapter};
 
 struct OutstationInfo {
     filter: AddressFilter,
@@ -234,10 +143,10 @@ impl TcpServer {
 
         crate::tokio::select! {
              _ = self.accept_loop(listener) => {
-
+                // if the accept loop shuts down we exit
              }
              _ = rx => {
-
+                // if we get the message or shutdown we exit
              }
         }
 


### PR DESCRIPTION
This PR removes the `NewSession` message from the set of messages an `OutstationSession` can receive.

Instead, we wrap the `OutstationTask` with an outer task that receives the new sessions on a separate mspc channel.

This decouples the core outstation functionality from the ability to switch sessions.