### PR TITLE
Feature/outstation serial

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 
 members = [
     "dnp3",
-
     "ffi/dnp3-schema",
     "ffi/dnp3-ffi",
     "ffi/dnp3-bindings",

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 tracing = "0.1"
 chrono = "0.4"
 tokio-mock = { git = "https://github.com/stepfunc/tokio-mock.git", branch="master" }
-tokio-one-serial = { git = "https://github.com/stepfunc/tokio-1.0-serial.git", branch="master" }
+tokio-serial = { git = "https://github.com/stepfunc/tokio-serial.git", branch="v4.4.0" }
 xxhash-rust = { version = "0.8.0-beta.5", features = ["xxh64"] }
 
 [dev-dependencies]

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 tracing = "0.1"
 chrono = "0.4"
 tokio-mock = { git = "https://github.com/stepfunc/tokio-mock.git", branch="master" }
-tokio-serial = { git = "https://github.com/stepfunc/tokio-serial.git", branch="v4.4.0" }
+tokio-serial = { git = "https://github.com/stepfunc/tokio-serial.git", branch="v4.4.0", default-features = false }
 xxhash-rust = { version = "0.8.0-beta.5", features = ["xxh64"] }
 
 [dev-dependencies]

--- a/dnp3/examples/master_serial.rs
+++ b/dnp3/examples/master_serial.rs
@@ -10,6 +10,15 @@ use dnp3::link::EndpointAddress;
 use dnp3::master::*;
 use dnp3::serial::*;
 
+fn get_serial_port_path() -> String {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        "/dev/pts/4".to_string()
+    } else {
+        args[1].clone()
+    }
+}
+
 /// example of using the master from within the Tokio runtime
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -25,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             AppDecodeLevel::ObjectValues.into(),
             Timeout::from_secs(1)?,
         ),
-        "/dev/pts/4",
+        &get_serial_port_path(),
         SerialSettings::default(),
         Duration::from_secs(1),
         Listener::None,

--- a/dnp3/examples/master_serial.rs
+++ b/dnp3/examples/master_serial.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     // spawn the master onto another task
-    let mut master = spawn_master_serial_client(
+    let mut master = spawn_master_serial(
         MasterConfig::new(
             EndpointAddress::from(1)?,
             AppDecodeLevel::ObjectValues.into(),

--- a/dnp3/examples/outstation_serial.rs
+++ b/dnp3/examples/outstation_serial.rs
@@ -1,0 +1,82 @@
+use std::time::Duration;
+
+use dnp3::app::control::*;
+use dnp3::app::measurement::*;
+use dnp3::decode::*;
+use dnp3::link::*;
+use dnp3::outstation::database::*;
+use dnp3::outstation::*;
+use dnp3::serial::*;
+
+fn get_serial_port_path() -> String {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        "/dev/pts/4".to_string()
+    } else {
+        args[1].clone()
+    }
+}
+
+fn get_outstation_config() -> OutstationConfig {
+    // ANCHOR: outstation_config
+    // create an outstation configuration with default values
+    let mut config = OutstationConfig::new(
+        // outstation address
+        EndpointAddress::from(1024).unwrap(),
+        // master address
+        EndpointAddress::from(1).unwrap(),
+    );
+    // override the default decoding
+    config.decode_level.application = AppDecodeLevel::ObjectValues;
+    // ANCHOR_END: outstation_config
+    config
+}
+
+/// example of using the outstation API asynchronously from within the Tokio runtime
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
+    let handle = spawn_outstation_serial(
+        &get_serial_port_path(),
+        SerialSettings::default(),
+        get_outstation_config(),
+        // event buffer space for 100 analog events
+        EventBufferConfig::new(0, 0, 0, 0, 0, 100, 0, 0),
+        // customizable trait that controls outstation behavior
+        DefaultOutstationApplication::create(),
+        // customizable trait to receive events about what the outstation is doing
+        DefaultOutstationInformation::create(),
+        // customizable trait to process control requests from the master
+        DefaultControlHandler::with_status(CommandStatus::NotSupported),
+    )?;
+
+    // setup the outstation's database before we spawn it
+    handle.database.transaction(|db| {
+        for i in 0..10 {
+            db.add(i, Some(EventClass::Class1), AnalogConfig::default());
+            db.update(
+                i,
+                &Analog::new(10.0, Flags::ONLINE, Time::synchronized(0)),
+                UpdateOptions::initialize(),
+            );
+        }
+    });
+
+    let mut value = 0.0;
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        handle.database.transaction(|db| {
+            db.update(
+                7,
+                &Analog::new(value, Flags::new(0x01), Time::synchronized(1)),
+                UpdateOptions::default(),
+            )
+        });
+        value += 1.0;
+    }
+}

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -12,12 +12,12 @@ use crate::transport::TransportReader;
 use crate::transport::TransportWriter;
 use crate::util::phys::PhysLayer;
 
-/// Spawn a task onto the `Tokio` runtime. The task runs until the returned handle, and any
+/// Spawn a master task onto the `Tokio` runtime. The task runs until the returned handle, and any
 /// `AssociationHandle` created from it, are dropped.
 ///
 /// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
 /// It is preferable to use this method instead of `create(..)` when using `[tokio::main]`.
-pub fn spawn_master_serial_client(
+pub fn spawn_master_serial(
     config: MasterConfig,
     path: &str,
     serial_settings: SerialSettings,
@@ -25,12 +25,12 @@ pub fn spawn_master_serial_client(
     listener: Listener<PortState>,
 ) -> MasterHandle {
     let (future, handle) =
-        create_master_serial_client(config, path, serial_settings, retry_delay, listener);
+        create_master_serial(config, path, serial_settings, retry_delay, listener);
     crate::tokio::spawn(future);
     handle
 }
 
-/// Create a Future, which can be spawned onto a runtime, along with a controlling handle.
+/// Create a master future, which can be spawned onto a runtime, along with a controlling handle.
 ///
 /// Once spawned or otherwise executed using the `run` method, the task runs until the handle
 /// and any `AssociationHandle` created from it are dropped.
@@ -38,7 +38,7 @@ pub fn spawn_master_serial_client(
 /// **Note**: This function is required instead of `spawn` when using a runtime to directly spawn
 /// tasks instead of within the context of a runtime, e.g. in applications that cannot use
 /// `[tokio::main]` such as C language bindings.
-pub fn create_master_serial_client(
+pub fn create_master_serial(
     config: MasterConfig,
     path: &str,
     settings: SerialSettings,

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -117,7 +117,7 @@ impl MasterTask {
 
     async fn run_enabled(&mut self) -> Result<(), StateChange> {
         loop {
-            match tokio_one_serial::open(self.path.as_str(), self.serial_settings) {
+            match crate::serial::open(self.path.as_str(), self.serial_settings) {
                 Err(err) => {
                     tracing::warn!(
                         "{} - waiting {} ms to re-open port",

--- a/dnp3/src/serial/mod.rs
+++ b/dnp3/src/serial/mod.rs
@@ -3,8 +3,10 @@ pub use tokio_one_serial::{DataBits, FlowControl, Parity, StopBits};
 pub use tokio_one_serial::Settings as SerialSettings;
 
 pub use master::*;
+pub use outstation::*;
 
 mod master;
+mod outstation;
 
 /// State of the serial port
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/dnp3/src/serial/mod.rs
+++ b/dnp3/src/serial/mod.rs
@@ -1,9 +1,48 @@
-pub use tokio_one_serial::{DataBits, FlowControl, Parity, StopBits};
-// re-export these from the serial crate
-pub use tokio_one_serial::Settings as SerialSettings;
+pub use tokio_serial::{DataBits, FlowControl, Parity, StopBits};
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SerialSettings {
+    pub baud_rate: u32,
+    pub data_bits: DataBits,
+    pub flow_control: FlowControl,
+    pub stop_bits: StopBits,
+    pub parity: Parity,
+}
+
+impl SerialSettings {
+    pub(crate) fn apply(
+        &self,
+        builder: tokio_serial::SerialPortBuilder,
+    ) -> tokio_serial::SerialPortBuilder {
+        builder
+            .baud_rate(self.baud_rate)
+            .data_bits(self.data_bits)
+            .flow_control(self.flow_control)
+            .stop_bits(self.stop_bits)
+            .parity(self.parity)
+    }
+}
+
+impl Default for SerialSettings {
+    fn default() -> Self {
+        Self {
+            baud_rate: 9600,
+            data_bits: DataBits::Eight,
+            flow_control: FlowControl::None,
+            stop_bits: StopBits::One,
+            parity: Parity::None,
+        }
+    }
+}
+
+pub(crate) fn open(path: &str, settings: SerialSettings) -> tokio_serial::Result<TTYPort> {
+    let builder = settings.apply(tokio_serial::new(path, settings.baud_rate));
+    TTYPort::open(&builder)
+}
 
 pub use master::*;
 pub use outstation::*;
+use tokio_serial::TTYPort;
 
 mod master;
 mod outstation;

--- a/dnp3/src/serial/outstation.rs
+++ b/dnp3/src/serial/outstation.rs
@@ -1,0 +1,78 @@
+use std::future::Future;
+
+use tracing::Instrument;
+
+use crate::link::LinkErrorMode;
+use crate::outstation::database::EventBufferConfig;
+use crate::outstation::task::OutstationTask;
+use crate::outstation::{
+    ControlHandler, OutstationApplication, OutstationConfig, OutstationHandle,
+    OutstationInformation,
+};
+use crate::serial::SerialSettings;
+use crate::util::phys::PhysLayer;
+
+/// Spawn an outstation task onto the `Tokio` runtime. The task runs until the returned handle is dropped or
+/// a serial port error occurs, e.g. a serial port is removed from the OS.
+///
+/// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
+/// It is preferable to use this method instead of `create_outstation_serial(..)` when using `[tokio::main]`.
+pub fn spawn_outstation_serial(
+    path: &str,
+    settings: SerialSettings,
+    config: OutstationConfig,
+    event_config: EventBufferConfig,
+    application: Box<dyn OutstationApplication>,
+    information: Box<dyn OutstationInformation>,
+    control_handler: Box<dyn ControlHandler>,
+) -> std::io::Result<OutstationHandle> {
+    let (future, handle) = create_outstation_serial(
+        path,
+        settings,
+        config,
+        event_config,
+        application,
+        information,
+        control_handler,
+    )?;
+    crate::tokio::spawn(future);
+    Ok(handle)
+}
+
+/// Create an outstation future, which can be spawned onto a runtime, along with a controlling handle.
+///
+/// Once spawned or otherwise executed using the `run` method, the task runs until the handle
+/// is dropped or the serial port is removed from the OS.
+///
+/// **Note**: This function is required instead of `spawn` when using a runtime to directly spawn
+/// tasks instead of within the context of a runtime, e.g. in applications that cannot use
+/// `[tokio::main]` such as C language bindings.
+pub fn create_outstation_serial(
+    path: &str,
+    settings: SerialSettings,
+    config: OutstationConfig,
+    event_config: EventBufferConfig,
+    application: Box<dyn OutstationApplication>,
+    information: Box<dyn OutstationInformation>,
+    control_handler: Box<dyn ControlHandler>,
+) -> std::io::Result<(impl Future<Output = ()> + 'static, OutstationHandle)> {
+    let serial = tokio_one_serial::open(path, settings)?;
+    let (mut task, handle) = OutstationTask::create(
+        LinkErrorMode::Discard,
+        config,
+        event_config,
+        application,
+        information,
+        control_handler,
+    );
+
+    let log_path = path.to_owned();
+    let future = async move {
+        let mut io = PhysLayer::Serial(serial);
+        let _ = task
+            .run(&mut io)
+            .instrument(tracing::info_span!("DNP3-Master-Serial", "port" = ?log_path))
+            .await;
+    };
+    Ok((future, handle))
+}

--- a/dnp3/src/serial/outstation.rs
+++ b/dnp3/src/serial/outstation.rs
@@ -56,7 +56,7 @@ pub fn create_outstation_serial(
     information: Box<dyn OutstationInformation>,
     control_handler: Box<dyn ControlHandler>,
 ) -> std::io::Result<(impl Future<Output = ()> + 'static, OutstationHandle)> {
-    let serial = tokio_one_serial::open(path, settings)?;
+    let serial = crate::serial::open(path, settings)?;
     let (mut task, handle) = OutstationTask::create(
         LinkErrorMode::Discard,
         config,

--- a/dnp3/src/util/phys.rs
+++ b/dnp3/src/util/phys.rs
@@ -2,12 +2,22 @@ use crate::decode::PhysDecodeLevel;
 use crate::tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 // encapsulates all possible physical layers as an enum
-#[derive(Debug)]
 pub(crate) enum PhysLayer {
     Tcp(crate::tokio::net::TcpStream),
-    Serial(tokio_one_serial::AsyncSerial),
+    Serial(tokio_serial::TTYPort),
     #[cfg(test)]
     Mock(tokio_mock::mock::test::io::MockIO),
+}
+
+impl std::fmt::Debug for PhysLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            PhysLayer::Tcp(_) => f.write_str("Tcp"),
+            PhysLayer::Serial(_) => f.write_str("Serial"),
+            #[cfg(test)]
+            PhysLayer::Mock(_) => f.write_str("Mock"),
+        }
+    }
 }
 
 impl PhysLayer {

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -81,7 +81,7 @@ pub(crate) unsafe fn master_create_serial_session(
     };
     let listener = PortStateListenerAdapter::new(listener);
 
-    let (future, handle) = create_master_serial_client(
+    let (future, handle) = create_master_serial(
         config,
         &path.to_string_lossy().to_string(),
         serial_params.into(),

--- a/ffi/dnp3-schema/src/logging.rs
+++ b/ffi/dnp3-schema/src/logging.rs
@@ -101,9 +101,8 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<NativeStructHandle, BindingErr
         )?
         .build()?;
 
-    let logging_class = lib.declare_class("Logging")?;
     let _logging_class = lib
-        .define_class(&logging_class)?
+        .define_static_class("Logging")?
         .static_method("Configure", &configure_logging_fn)?
         .doc("Provides a static method for configuring logging")?
         .build()?;


### PR DESCRIPTION
This fixes Linux serial port support and adds outstation support.

I forked the `v4.4.0` branch of `tokio-serial`:

https://github.com/stepfunc/tokio-serial

I added a windows module that mirrors the unix module and uses `unimplemented!` for all of the public functions so that we don't have to deal with platform issues in dnp4rs. It'll be easy to switch back to the main tokio-serial repo when windows support is available there again.