### PR TITLE
Refactor/c ffi examples

### DIFF
--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -6,10 +6,6 @@
 #include <time.h>
 #include <inttypes.h>
 
-void print_qualifier(qualifier_code_t qualifier) { printf("%s", Variation_to_string(qualifier)); }
-
-void print_variation(variation_t variation) { printf(Variation_to_string(variation)); }
-
 // ANCHOR: logging_callback
 // callback which will receive log messages
 void on_log_message(log_level_t level, const char *msg, void *ctx) { printf("%s", msg); }
@@ -29,12 +25,8 @@ void end_fragment(read_type_t read_type, response_header_t header, void *arg) { 
 void handle_binary(header_info_t info, binary_iterator_t *it, void *arg)
 {
     printf("Binaries:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     binary_t *value = NULL;
     while (value = binary_next(it)) {
@@ -45,12 +37,8 @@ void handle_binary(header_info_t info, binary_iterator_t *it, void *arg)
 void handle_double_bit_binary(header_info_t info, double_bit_binary_iterator_t *it, void *arg)
 {
     printf("Double Bit Binaries:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     double_bit_binary_t *value = NULL;
     while (value = doublebitbinary_next(it)) {
@@ -61,12 +49,8 @@ void handle_double_bit_binary(header_info_t info, double_bit_binary_iterator_t *
 void handle_binary_output_status(header_info_t info, binary_output_status_iterator_t *it, void *arg)
 {
     printf("Binary Output Statuses:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     binary_output_status_t *value = NULL;
     while (value = binaryoutputstatus_next(it)) {
@@ -77,12 +61,8 @@ void handle_binary_output_status(header_info_t info, binary_output_status_iterat
 void handle_counter(header_info_t info, counter_iterator_t *it, void *arg)
 {
     printf("Counters:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     counter_t *value = NULL;
     while (value = counter_next(it)) {
@@ -93,12 +73,8 @@ void handle_counter(header_info_t info, counter_iterator_t *it, void *arg)
 void handle_frozen_counter(header_info_t info, frozen_counter_iterator_t *it, void *arg)
 {
     printf("Frozen Counters:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     frozen_counter_t *value = NULL;
     while (value = frozencounter_next(it)) {
@@ -109,12 +85,8 @@ void handle_frozen_counter(header_info_t info, frozen_counter_iterator_t *it, vo
 void handle_analog(header_info_t info, analog_iterator_t *it, void *arg)
 {
     printf("Analogs:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     analog_t *value = NULL;
     while (value = analog_next(it)) {
@@ -125,12 +97,8 @@ void handle_analog(header_info_t info, analog_iterator_t *it, void *arg)
 void handle_analog_output_status(header_info_t info, analog_output_status_iterator_t *it, void *arg)
 {
     printf("Analog Output Statuses:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     analog_output_status_t *value = NULL;
     while (value = analogoutputstatus_next(it)) {
@@ -141,12 +109,8 @@ void handle_analog_output_status(header_info_t info, analog_output_status_iterat
 void handle_octet_strings(header_info_t info, octet_string_iterator_t *it, void *arg)
 {
     printf("Octet Strings:\n");
-    printf("Qualifier: ");
-    print_qualifier(info.qualifier);
-    printf("\n");
-    printf("Variation: ");
-    print_variation(info.variation);
-    printf("\n");
+    printf("Qualifier: %s \n", QualifierCode_to_string(info.qualifier));
+    printf("Variation: %s \n", Variation_to_string(info.variation));
 
     octet_string_t *value = NULL;
     while (value = octetstring_next(it)) {

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -4,8 +4,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <inttypes.h>
 
-void print_qualifier(qualifier_code_t qualifier) { printf(Variation_to_string(qualifier)); }
+void print_qualifier(qualifier_code_t qualifier) { printf("%s", Variation_to_string(qualifier)); }
 
 void print_variation(variation_t variation) { printf(Variation_to_string(variation)); }
 
@@ -37,7 +38,7 @@ void handle_binary(header_info_t info, binary_iterator_t *it, void *arg)
 
     binary_t *value = NULL;
     while (value = binary_next(it)) {
-        printf("BI %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
+        printf("BI %u: Value=%u Flags=0x%02X Time=%" PRIu64 "\n", value->index, value->value, value->flags.value, value->time.value);
     }
 }
 
@@ -53,7 +54,7 @@ void handle_double_bit_binary(header_info_t info, double_bit_binary_iterator_t *
 
     double_bit_binary_t *value = NULL;
     while (value = doublebitbinary_next(it)) {
-        printf("DBBI %u: Value=%X Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
+        printf("DBBI %u: Value=%X Flags=0x%02X Time=%" PRIu64 "\n", value->index, value->value, value->flags.value, value->time.value);
     }
 }
 
@@ -69,7 +70,7 @@ void handle_binary_output_status(header_info_t info, binary_output_status_iterat
 
     binary_output_status_t *value = NULL;
     while (value = binaryoutputstatus_next(it)) {
-        printf("BOS %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
+        printf("BOS %u: Value=%u Flags=0x%02X Time=%" PRIu64 "\n", value->index, value->value, value->flags.value, value->time.value);
     }
 }
 
@@ -85,7 +86,7 @@ void handle_counter(header_info_t info, counter_iterator_t *it, void *arg)
 
     counter_t *value = NULL;
     while (value = counter_next(it)) {
-        printf("Counter %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
+        printf("Counter %u: Value=%u Flags=0x%02X Time=%" PRIu64 "\n", value->index, value->value, value->flags.value, value->time.value);
     }
 }
 
@@ -101,7 +102,7 @@ void handle_frozen_counter(header_info_t info, frozen_counter_iterator_t *it, vo
 
     frozen_counter_t *value = NULL;
     while (value = frozencounter_next(it)) {
-        printf("Frozen Counter %u: Value=%u Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
+        printf("Frozen Counter %u: Value=%u Flags=0x%02X Time=%" PRIu64 "\n", value->index, value->value, value->flags.value, value->time.value);
     }
 }
 
@@ -117,7 +118,7 @@ void handle_analog(header_info_t info, analog_iterator_t *it, void *arg)
 
     analog_t *value = NULL;
     while (value = analog_next(it)) {
-        printf("AI %u: Value=%f Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
+        printf("AI %u: Value=%f Flags=0x%02X Time=%" PRIu64 "\n", value->index, value->value, value->flags.value, value->time.value);
     }
 }
 
@@ -133,7 +134,7 @@ void handle_analog_output_status(header_info_t info, analog_output_status_iterat
 
     analog_output_status_t *value = NULL;
     while (value = analogoutputstatus_next(it)) {
-        printf("AOS %u: Value=%f Flags=0x%02X Time=%llu\n", value->index, value->value, value->flags.value, value->time.value);
+        printf("AOS %u: Value=%f Flags=0x%02X Time=%" PRIu64 "\n", value->index, value->value, value->flags.value, value->time.value);
     }
 }
 

--- a/ffi/dnp3-schema/src/shared.rs
+++ b/ffi/dnp3-schema/src/shared.rs
@@ -58,7 +58,7 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<SharedDefinitions, BindingErro
         .add_error("InvalidBufferSize", "Invalid buffer size")?
         .add_error(
             "AddressFilterConflict",
-            "Conflit in the address filter specification",
+            "Conflict in the address filter specification",
         )?
         .add_error("ServerAlreadyStarted", "Server already started")?
         .add_error(


### PR DESCRIPTION
 - Cleans up all GCC string-format specifier error messages in the C examples
 - Declare are long-lived heap allocated opaque pointers and then rely on NULL-safety in destructors