### PR TITLE
Remove OneTimeCallback from schema. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -36,6 +35,10 @@ jobs:
         run: Copy-Item -Path .cargo/config-linux.toml -Destination .cargo/config.toml
       - name: Caching
         uses: Swatinem/rust-cache@v1
+      - name: Update dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
       - name: Run Rust unit tests
         uses: actions-rs/cargo@v1
         with:
@@ -58,8 +61,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy
-      - name: Caching
-        uses: Swatinem/rust-cache@v1
       - name: Format
         uses: actions-rs/cargo@v1
         with:
@@ -97,10 +98,14 @@ jobs:
         run: Copy-Item -Path .cargo/config-linux.toml -Destination .cargo/config.toml
       - name: Caching
         uses: Swatinem/rust-cache@v1
+      - name: Update dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
       - name: Build
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: build
           args: --release
       - name: C bindings
         uses: actions-rs/cargo@v1
@@ -141,6 +146,10 @@ jobs:
           override: true
       - name: Caching
         uses: Swatinem/rust-cache@v1
+      - name: Update dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
       - name: Download compiled FFI
         uses: actions/download-artifact@v2
         with:

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -154,6 +154,8 @@ int main()
     logger_t logger = {
         // function pointer where log messages will be sent
         .on_message = &on_log_message,
+        // no context to free
+        .on_destroy = NULL,
         // optional context argument applied to all log callbacks
         .ctx = NULL,
     };
@@ -183,6 +185,7 @@ int main()
     endpoint_list_t *endpoints = endpoint_list_new("127.0.0.1:20000");
     client_state_listener_t listener = {
         .on_change = &client_state_on_change,
+        .on_destroy = NULL,
         .ctx = NULL,
     };
     
@@ -204,6 +207,7 @@ int main()
         .handle_analog = &handle_analog,
         .handle_analog_output_status = &handle_analog_output_status,
         .handle_octet_string = &handle_octet_strings,
+        .on_destroy = NULL,
         .ctx = NULL,
     };
 
@@ -221,6 +225,7 @@ int main()
 
     time_provider_t time_provider = {
         .get_time = get_time,
+        .on_destroy = NULL,
         .ctx = NULL,
     };
     association_id_t association_id;
@@ -266,6 +271,7 @@ int main()
 
             read_task_callback_t cb = {
                 .on_complete = &on_read_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
             master_read(master, association_id, request, cb);
@@ -279,6 +285,7 @@ int main()
 
             read_task_callback_t cb = {
                 .on_complete = &on_read_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
             master_read(master, association_id, request, cb);
@@ -292,6 +299,7 @@ int main()
 
             command_task_callback_t cb = {
                 .on_complete = &on_command_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
 
@@ -305,6 +313,7 @@ int main()
         else if (strcmp(cbuf, "lts\n") == 0) {
             time_sync_task_callback_t cb = {
                 .on_complete = &on_timesync_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
             master_sync_time(master, association_id, TimeSyncMode_Lan, cb);
@@ -312,6 +321,7 @@ int main()
         else if (strcmp(cbuf, "nts\n") == 0) {
             time_sync_task_callback_t cb = {
                 .on_complete = &on_timesync_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
             master_sync_time(master, association_id, TimeSyncMode_NonLan, cb);
@@ -319,6 +329,7 @@ int main()
         else if (strcmp(cbuf, "crt\n") == 0) {
             restart_task_callback_t cb = {
                 .on_complete = &on_restart_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
             master_cold_restart(master, association_id, cb);
@@ -326,6 +337,7 @@ int main()
         else if (strcmp(cbuf, "wrt\n") == 0) {
             restart_task_callback_t cb = {
                 .on_complete = &on_restart_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
             master_warm_restart(master, association_id, cb);
@@ -333,6 +345,7 @@ int main()
         else if (strcmp(cbuf, "lsr\n") == 0) {
             link_status_callback_t cb = {
                 .on_complete = &on_link_status_complete,
+                .on_destroy = NULL,
                 .ctx = NULL,
             };
             master_check_link_status(master, association_id, cb);

--- a/ffi/bindings/c/outstation_example.c
+++ b/ffi/bindings/c/outstation_example.c
@@ -296,6 +296,7 @@ int main()
     // Setup initial points
     outstation_transaction_t startup_transaction = {
         .execute = &outstation_transaction_startup,
+        .on_destroy = NULL,
         .ctx = NULL,
     };
     outstation_transaction(outstation, startup_transaction);
@@ -326,6 +327,7 @@ int main()
         else if (strcmp(cbuf, "bi\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &binary_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);
@@ -333,6 +335,7 @@ int main()
         else if (strcmp(cbuf, "dbbi\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &double_bit_binary_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);
@@ -340,6 +343,7 @@ int main()
         else if (strcmp(cbuf, "bos\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &binary_output_status_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);
@@ -347,6 +351,7 @@ int main()
         else if (strcmp(cbuf, "co\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &counter_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);
@@ -354,6 +359,7 @@ int main()
         else if (strcmp(cbuf, "fco\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &frozen_counter_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);
@@ -361,6 +367,7 @@ int main()
         else if (strcmp(cbuf, "ai\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &analog_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);
@@ -368,6 +375,7 @@ int main()
         else if (strcmp(cbuf, "aos\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &analog_output_status_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);
@@ -375,6 +383,7 @@ int main()
         else if (strcmp(cbuf, "os\n") == 0) {
             outstation_transaction_t transaction = {
                 .execute = &octet_string_transaction,
+                .on_destroy = NULL,
                 .ctx = &database_points,
             };
             outstation_transaction(outstation, transaction);

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -1041,9 +1041,7 @@ fn define_command_builder(
         .build()
 }
 
-fn define_time_sync_callback(
-    lib: &mut LibraryBuilder,
-) -> Result<InterfaceHandle, BindingError> {
+fn define_time_sync_callback(lib: &mut LibraryBuilder) -> Result<InterfaceHandle, BindingError> {
     let timesync_result = lib
         .define_native_enum("TimeSyncResult")?
         .push("Success", "Time synchronization operation was a success")?
@@ -1100,9 +1098,7 @@ fn define_time_sync_mode(lib: &mut LibraryBuilder) -> Result<NativeEnumHandle, B
         .build()
 }
 
-fn define_restart_callback(
-    lib: &mut LibraryBuilder,
-) -> Result<InterfaceHandle, BindingError> {
+fn define_restart_callback(lib: &mut LibraryBuilder) -> Result<InterfaceHandle, BindingError> {
     let restart_success = lib
         .define_native_enum("RestartSuccess")?
         .push("Success", "Restart was perform successfully")?
@@ -1133,9 +1129,7 @@ fn define_restart_callback(
         .build()
 }
 
-fn define_link_status_callback(
-    lib: &mut LibraryBuilder,
-) -> Result<InterfaceHandle, BindingError> {
+fn define_link_status_callback(lib: &mut LibraryBuilder) -> Result<InterfaceHandle, BindingError> {
     let link_status_enum = lib
         .define_native_enum("LinkStatusResult")?
         .push(

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use oo_bindgen::callback::{InterfaceHandle, OneTimeCallbackHandle};
+use oo_bindgen::callback::InterfaceHandle;
 use oo_bindgen::class::ClassHandle;
 use oo_bindgen::native_function::*;
 use oo_bindgen::native_struct::*;
@@ -244,7 +244,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .param("master", Type::ClassRef(master_class.clone()), "Master on which to perform the operation")?
         .param("association", Type::Struct(association_id.clone()), "Association on which to perform the read")?
         .param("request", Type::ClassRef(request_class.declaration()), "Request to send")?
-        .param("callback", Type::OneTimeCallback(read_callback), "Callback that will be invoked once the read is complete")?
+        .param("callback", Type::Interface(read_callback), "Callback that will be invoked once the read is complete")?
         .return_type(ReturnType::void())?
         .fails_with(shared.error_type.clone())?
         .doc(
@@ -277,7 +277,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         )?
         .param(
             "callback",
-            Type::OneTimeCallback(command_cb),
+            Type::Interface(command_cb),
             "Callback that will receive the result of the command",
         )?
         .return_type(ReturnType::void())?
@@ -303,7 +303,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         .param("mode", Type::Enum(time_sync_mode), "Time sync mode")?
         .param(
             "callback",
-            Type::OneTimeCallback(time_sync_cb),
+            Type::Interface(time_sync_cb),
             "Callback that will receive the result of the time sync",
         )?
         .return_type(ReturnType::void())?
@@ -327,7 +327,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         )?
         .param(
             "callback",
-            Type::OneTimeCallback(restart_cb.clone()),
+            Type::Interface(restart_cb.clone()),
             "Callback that will receive the result of the restart",
         )?
         .return_type(ReturnType::void())?
@@ -349,7 +349,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         )?
         .param(
             "callback",
-            Type::OneTimeCallback(restart_cb),
+            Type::Interface(restart_cb),
             "Callback that will receive the result of the restart",
         )?
         .return_type(ReturnType::void())?
@@ -373,7 +373,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<()
         )?
         .param(
             "callback",
-            Type::OneTimeCallback(link_status_cb),
+            Type::Interface(link_status_cb),
             "Callback that will receive the result of the link status",
         )?
         .return_type(ReturnType::void())?
@@ -447,7 +447,7 @@ fn define_poll_id(
 
 fn define_read_callback(
     lib: &mut LibraryBuilder,
-) -> std::result::Result<OneTimeCallbackHandle, BindingError> {
+) -> std::result::Result<InterfaceHandle, BindingError> {
     let read_result = lib
         .define_native_enum("ReadResult")?
         .push("Success", "Read was perform successfully")?
@@ -455,7 +455,7 @@ fn define_read_callback(
         .doc("Result of a read operation")?
         .build()?;
 
-    lib.define_one_time_callback("ReadTaskCallback", "Handler for read tasks")?
+    lib.define_interface("ReadTaskCallback", "Handler for read tasks")?
         .callback(
             "on_complete",
             "Called when the read task reached completion or failed",
@@ -463,6 +463,7 @@ fn define_read_callback(
         .param("result", Type::Enum(read_result), "Result of the read task")?
         .return_type(ReturnType::void())?
         .build()?
+        .destroy_callback("on_destroy")?
         .build()
 }
 
@@ -763,7 +764,7 @@ fn define_command_mode(
 
 fn define_command_callback(
     lib: &mut LibraryBuilder,
-) -> std::result::Result<OneTimeCallbackHandle, BindingError> {
+) -> std::result::Result<InterfaceHandle, BindingError> {
     let command_result = lib
         .define_native_enum("CommandResult")?
         .push("Success", "Command was a success")?
@@ -791,7 +792,7 @@ fn define_command_callback(
         .doc("Result of a command")?
         .build()?;
 
-    lib.define_one_time_callback("CommandTaskCallback", "Handler for command tasks")?
+    lib.define_interface("CommandTaskCallback", "Handler for command tasks")?
         .callback(
             "on_complete",
             "Called when the command task reached completion or failed",
@@ -803,6 +804,7 @@ fn define_command_callback(
         )?
         .return_type(ReturnType::void())?
         .build()?
+        .destroy_callback("on_destroy")?
         .build()
 }
 
@@ -1041,7 +1043,7 @@ fn define_command_builder(
 
 fn define_time_sync_callback(
     lib: &mut LibraryBuilder,
-) -> Result<OneTimeCallbackHandle, BindingError> {
+) -> Result<InterfaceHandle, BindingError> {
     let timesync_result = lib
         .define_native_enum("TimeSyncResult")?
         .push("Success", "Time synchronization operation was a success")?
@@ -1065,7 +1067,7 @@ fn define_time_sync_callback(
         .doc("Result of a time sync operation")?
         .build()?;
 
-    lib.define_one_time_callback(
+    lib.define_interface(
         "TimeSyncTaskCallback",
         "Handler for time synchronization tasks",
     )?
@@ -1080,6 +1082,7 @@ fn define_time_sync_callback(
     )?
     .return_type(ReturnType::void())?
     .build()?
+    .destroy_callback("on_destroy")?
     .build()
 }
 
@@ -1099,7 +1102,7 @@ fn define_time_sync_mode(lib: &mut LibraryBuilder) -> Result<NativeEnumHandle, B
 
 fn define_restart_callback(
     lib: &mut LibraryBuilder,
-) -> Result<OneTimeCallbackHandle, BindingError> {
+) -> Result<InterfaceHandle, BindingError> {
     let restart_success = lib
         .define_native_enum("RestartSuccess")?
         .push("Success", "Restart was perform successfully")?
@@ -1114,7 +1117,7 @@ fn define_restart_callback(
         .doc("Result of a restart task")?
         .build()?;
 
-    lib.define_one_time_callback("RestartTaskCallback", "Handler for restart tasks")?
+    lib.define_interface("RestartTaskCallback", "Handler for restart tasks")?
         .callback(
             "on_complete",
             "Called when the restart task reached completion or failed",
@@ -1126,12 +1129,13 @@ fn define_restart_callback(
         )?
         .return_type(ReturnType::void())?
         .build()?
+        .destroy_callback("on_destroy")?
         .build()
 }
 
 fn define_link_status_callback(
     lib: &mut LibraryBuilder,
-) -> Result<OneTimeCallbackHandle, BindingError> {
+) -> Result<InterfaceHandle, BindingError> {
     let link_status_enum = lib
         .define_native_enum("LinkStatusResult")?
         .push(
@@ -1149,7 +1153,7 @@ fn define_link_status_callback(
         .doc("Result of a link status check. See {class:Master.CheckLinkStatus()}")?
         .build()?;
 
-    lib.define_one_time_callback("LinkStatusCallback", "Handler for link status check")?
+    lib.define_interface("LinkStatusCallback", "Handler for link status check")?
         .callback("on_complete", "Called when a link status is received")?
         .param(
             "result",
@@ -1158,5 +1162,6 @@ fn define_link_status_callback(
         )?
         .return_type(ReturnType::void())?
         .build()?
+        .destroy_callback("on_destroy")?
         .build()
 }

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -121,7 +121,7 @@ fn define_outstation(
     types: &OutstationTypes,
 ) -> Result<ClassHandle, BindingError> {
     let transaction_interface = lib
-        .define_one_time_callback("OutstationTransaction", "Outstation transaction interface")?
+        .define_interface("OutstationTransaction", "Outstation transaction interface")?
         .callback(
             "execute",
             "Execute the transaction with the provided database",
@@ -133,6 +133,7 @@ fn define_outstation(
         )?
         .return_type(ReturnType::void())?
         .build()?
+        .destroy_callback("on_destroy")?
         .build()?;
 
     let outstation = lib.declare_class("Outstation")?;
@@ -198,7 +199,7 @@ fn define_outstation(
         )?
         .param(
             "callback",
-            Type::OneTimeCallback(transaction_interface),
+            Type::Interface(transaction_interface),
             "Method to execute as a transaction",
         )?
         .return_type(ReturnType::void())?


### PR DESCRIPTION
Explicitly initialize `on_destroy` members of interfaces.

C99 compliant compilers will initialize any struct members not specified to zero, but some compilers may complain about uninitialized members.