### PR TITLE
Refactor/master task errors

### DIFF
--- a/dnp3/src/master/session.rs
+++ b/dnp3/src/master/session.rs
@@ -338,7 +338,8 @@ impl MasterSession {
         match result {
             Ok(()) => Ok(()),
             Err(err) => match err {
-                TaskError::State(x) => Err(RunError::State(x)),
+                TaskError::Shutdown => Err(RunError::State(StateChange::Shutdown)),
+                TaskError::Disabled => Err(RunError::State(StateChange::Disable)),
                 TaskError::Link(err) => Err(RunError::Link(err)),
                 _ => Ok(()),
             },

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -135,7 +135,7 @@ void on_command_complete(command_result_t result, void *arg) { printf("CommandRe
 void on_timesync_complete(time_sync_result_t result, void *arg) { printf("TimeSyncResult: %s\n", TimeSyncResult_to_string(result)); }
 
 // Restart callback
-void on_restart_complete(restart_result_t result, void *arg) { printf("RestartResult: %s\n", RestartSuccess_to_string(result.success)); }
+void on_restart_complete(restart_result_t result, void *arg) { printf("RestartResult: %s\n", RestartError_to_string(result.error)); }
 
 void on_link_status_complete(link_status_result_t result, void *arg) { printf("LinkStatusResult: %s\n", LinkStatusResult_to_string(result)); }
 

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -234,7 +234,7 @@ pub(crate) unsafe fn master_read(
     let task = async move {
         let result = match handle.read(request).await {
             Ok(_) => ffi::ReadResult::Success,
-            Err(_) => ffi::ReadResult::TaskError,
+            Err(err) => err.into(),
         };
 
         callback.on_complete(result);
@@ -296,7 +296,7 @@ pub(crate) unsafe fn master_sync_time(
     let task = async move {
         let result = match association.synchronize_time(mode.into()).await {
             Ok(_) => ffi::TimeSyncResult::Success,
-            Err(TimeSyncError::Task(_)) => ffi::TimeSyncResult::TaskError,
+            Err(TimeSyncError::Task(err)) => err.into(),
             Err(TimeSyncError::ClockRollback) => ffi::TimeSyncResult::ClockRollback,
             Err(TimeSyncError::SystemTimeNotUnix) => ffi::TimeSyncResult::SystemTimeNotUnix,
             Err(TimeSyncError::BadOutstationTimeDelay(_)) => {
@@ -330,7 +330,7 @@ pub(crate) unsafe fn master_cold_restart(
     let task = async move {
         let result = match association.cold_restart().await {
             Ok(value) => ffi::RestartResult::new_success(value),
-            Err(_) => ffi::RestartResult::error(),
+            Err(err) => ffi::RestartResult::new_error(err.into()),
         };
 
         callback.on_complete(result);
@@ -353,7 +353,7 @@ pub(crate) unsafe fn master_warm_restart(
     let task = async move {
         let result = match association.warm_restart().await {
             Ok(value) => ffi::RestartResult::new_success(value),
-            Err(_) => ffi::RestartResult::error(),
+            Err(err) => ffi::RestartResult::new_error(err.into()),
         };
 
         callback.on_complete(result);
@@ -414,15 +414,15 @@ impl ffi::RestartResult {
     fn new_success(delay: Duration) -> Self {
         ffi::RestartResultFields {
             delay,
-            success: ffi::RestartSuccess::Success,
+            error: ffi::RestartError::Ok,
         }
         .into()
     }
 
-    fn error() -> Self {
+    fn new_error(error: ffi::RestartError) -> Self {
         ffi::RestartResultFields {
             delay: Duration::from_millis(0),
-            success: ffi::RestartSuccess::TaskError,
+            error,
         }
         .into()
     }
@@ -676,24 +676,33 @@ impl From<PollError> for ffi::Dnp3Error {
     }
 }
 
-impl From<TaskError> for ffi::CommandResult {
-    fn from(err: TaskError) -> Self {
-        match err {
-            TaskError::TooManyRequests => ffi::CommandResult::TooManyRequests,
-            TaskError::Link(_) => ffi::CommandResult::NoConnection,
-            TaskError::Transport => ffi::CommandResult::NoConnection,
-            TaskError::MalformedResponse(_) => ffi::CommandResult::BadResponse,
-            TaskError::UnexpectedResponseHeaders => ffi::CommandResult::BadResponse,
-            TaskError::NonFinWithoutCon => ffi::CommandResult::BadResponse,
-            TaskError::NeverReceivedFir => ffi::CommandResult::BadResponse,
-            TaskError::UnexpectedFir => ffi::CommandResult::BadResponse,
-            TaskError::MultiFragmentResponse => ffi::CommandResult::BadResponse,
-            TaskError::ResponseTimeout => ffi::CommandResult::ResponseTimeout,
-            TaskError::WriteError => ffi::CommandResult::WriteError,
-            TaskError::NoSuchAssociation(_) => ffi::CommandResult::AssociationRemoved,
-            TaskError::NoConnection => ffi::CommandResult::NoConnection,
-            TaskError::Shutdown => ffi::CommandResult::Shutdown,
-            TaskError::Disabled => ffi::CommandResult::NoConnection,
+macro_rules! define_task_from_impl {
+    ($name:ident) => {
+        impl From<TaskError> for ffi::$name {
+            fn from(err: TaskError) -> Self {
+                match err {
+                    TaskError::TooManyRequests => ffi::$name::TooManyRequests,
+                    TaskError::Link(_) => ffi::$name::NoConnection,
+                    TaskError::Transport => ffi::$name::NoConnection,
+                    TaskError::MalformedResponse(_) => ffi::$name::BadResponse,
+                    TaskError::UnexpectedResponseHeaders => ffi::$name::BadResponse,
+                    TaskError::NonFinWithoutCon => ffi::$name::BadResponse,
+                    TaskError::NeverReceivedFir => ffi::$name::BadResponse,
+                    TaskError::UnexpectedFir => ffi::$name::BadResponse,
+                    TaskError::MultiFragmentResponse => ffi::$name::BadResponse,
+                    TaskError::ResponseTimeout => ffi::$name::ResponseTimeout,
+                    TaskError::WriteError => ffi::$name::WriteError,
+                    TaskError::NoSuchAssociation(_) => ffi::$name::AssociationRemoved,
+                    TaskError::NoConnection => ffi::$name::NoConnection,
+                    TaskError::Shutdown => ffi::$name::Shutdown,
+                    TaskError::Disabled => ffi::$name::NoConnection,
+                }
+            }
         }
-    }
+    };
 }
+
+define_task_from_impl!(CommandResult);
+define_task_from_impl!(TimeSyncResult);
+define_task_from_impl!(RestartError);
+define_task_from_impl!(ReadResult);

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -268,16 +268,10 @@ pub unsafe fn master_operate(
             Err(CommandError::Response(err)) => match err {
                 CommandResponseError::Request(_) => ffi::CommandResult::TaskError,
                 CommandResponseError::BadStatus(_) => ffi::CommandResult::BadStatus,
-                CommandResponseError::HeaderCountMismatch => {
-                    ffi::CommandResult::HeaderCountMismatch
-                }
-                CommandResponseError::HeaderTypeMismatch => ffi::CommandResult::HeaderTypeMismatch,
-                CommandResponseError::ObjectCountMismatch => {
-                    ffi::CommandResult::ObjectCountMismatch
-                }
-                CommandResponseError::ObjectValueMismatch => {
-                    ffi::CommandResult::ObjectValueMismatch
-                }
+                CommandResponseError::HeaderCountMismatch => ffi::CommandResult::HeaderMismatch,
+                CommandResponseError::HeaderTypeMismatch => ffi::CommandResult::HeaderMismatch,
+                CommandResponseError::ObjectCountMismatch => ffi::CommandResult::HeaderMismatch,
+                CommandResponseError::ObjectValueMismatch => ffi::CommandResult::HeaderMismatch,
             },
         };
 

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -760,7 +760,7 @@ fn define_command_mode(
         .push("DirectOperate", "Perform a Direct Operate (0x05)")?
         .push(
             "SelectBeforeOperate",
-            "Perform a Select & Operate (0x03 then 0x04)",
+            "Perform a Select and Operate (0x03 then 0x04)",
         )?
         .doc("Command operation mode")?
         .build()
@@ -778,20 +778,8 @@ fn define_command_callback(
             "Outstation indicated that a command was not SUCCESS",
         )?
         .push(
-            "HeaderCountMismatch",
-            "Number of headers in the response doesn't match the number in the request",
-        )?
-        .push(
-            "HeaderTypeMismatch",
-            "Header in the response doesn't match the request",
-        )?
-        .push(
-            "ObjectCountMismatch",
-            "Number of objects in one of the headers doesn't match the request",
-        )?
-        .push(
-            "ObjectValueMismatch",
-            "Value in one of the objects in the response doesn't match the request",
+            "HeaderMismatch",
+            "Number of headers and/or objects in the response didn't match the number in the request",
         )?
         .doc("Result of a command")?
         .build()?;

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -7,7 +7,7 @@ use oo_bindgen::native_struct::*;
 use oo_bindgen::*;
 
 use crate::shared::SharedDefinitions;
-use oo_bindgen::native_enum::NativeEnumHandle;
+use oo_bindgen::native_enum::{NativeEnumBuilder, NativeEnumHandle};
 
 pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Result<(), BindingError> {
     let read_handler = crate::handler::define(lib, shared)?;
@@ -766,21 +766,38 @@ fn define_command_mode(
         .build()
 }
 
+fn add_task_errors(builder: NativeEnumBuilder) -> Result<NativeEnumBuilder, BindingError> {
+    builder
+        .push("TooManyRequests", "too many user requests queued")?
+        .push(
+            "BadResponse",
+            "response was malformed or contained object headers",
+        )?
+        .push(
+            "ResponseTimeout",
+            "timeout occurred before receiving a response",
+        )?
+        .push(
+            "WriteError",
+            "insufficient buffer space to serialize the request",
+        )?
+        .push("NoConnection", "no connection")?
+        .push("Shutdown", "master was shutdown")?
+        .push("AssociationRemoved", "association was removed mid-task")
+}
+
 fn define_command_callback(
     lib: &mut LibraryBuilder,
 ) -> std::result::Result<InterfaceHandle, BindingError> {
-    let command_result = lib
+    let builder = lib
         .define_native_enum("CommandResult")?
         .push("Success", "Command was a success")?
         .push("TaskError", "Failed b/c of a generic task execution error")?
-        .push(
-            "BadStatus",
-            "Outstation indicated that a command was not SUCCESS",
-        )?
-        .push(
-            "HeaderMismatch",
-            "Number of headers and/or objects in the response didn't match the number in the request",
-        )?
+        .push("BadStatus", "Outstation indicated that a command was not SUCCESS")?
+        .push("HeaderMismatch", "Number of headers and/or objects in the response didn't match the number in the request")?;
+
+    let command_result = add_task_errors(builder)?
+        // -------------------
         .doc("Result of a command")?
         .build()?;
 

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -451,7 +451,7 @@ fn define_read_callback(
     let read_result = lib
         .define_native_enum("ReadResult")?
         .push("Success", "Read was perform successfully")?
-        .push("TaskError", "The read was not performed properly")?
+        .add_task_errors()?
         .doc("Result of a read operation")?
         .build()?;
 
@@ -766,37 +766,46 @@ fn define_command_mode(
         .build()
 }
 
-fn add_task_errors(builder: NativeEnumBuilder) -> Result<NativeEnumBuilder, BindingError> {
-    builder
-        .push("TooManyRequests", "too many user requests queued")?
-        .push(
-            "BadResponse",
-            "response was malformed or contained object headers",
-        )?
-        .push(
-            "ResponseTimeout",
-            "timeout occurred before receiving a response",
-        )?
-        .push(
-            "WriteError",
-            "insufficient buffer space to serialize the request",
-        )?
-        .push("NoConnection", "no connection")?
-        .push("Shutdown", "master was shutdown")?
-        .push("AssociationRemoved", "association was removed mid-task")
+trait TaskErrors: Sized {
+    fn add_task_errors(self) -> std::result::Result<Self, BindingError>;
+}
+
+impl TaskErrors for NativeEnumBuilder<'_> {
+    fn add_task_errors(self) -> std::result::Result<Self, BindingError> {
+        self.push("TooManyRequests", "too many user requests queued")?
+            .push(
+                "BadResponse",
+                "response was malformed or contained object headers",
+            )?
+            .push(
+                "ResponseTimeout",
+                "timeout occurred before receiving a response",
+            )?
+            .push(
+                "WriteError",
+                "insufficient buffer space to serialize the request",
+            )?
+            .push("NoConnection", "no connection")?
+            .push("Shutdown", "master was shutdown")?
+            .push("AssociationRemoved", "association was removed mid-task")
+    }
 }
 
 fn define_command_callback(
     lib: &mut LibraryBuilder,
 ) -> std::result::Result<InterfaceHandle, BindingError> {
-    let builder = lib
+    let command_result = lib
         .define_native_enum("CommandResult")?
         .push("Success", "Command was a success")?
-        .push("BadStatus", "Outstation indicated that a command was not SUCCESS")?
-        .push("HeaderMismatch", "Number of headers or objects in the response didn't match the number in the request")?;
-
-    let command_result = add_task_errors(builder)?
-        // -------------------
+        .push(
+            "BadStatus",
+            "Outstation indicated that a command was not SUCCESS",
+        )?
+        .push(
+            "HeaderMismatch",
+            "Number of headers or objects in the response didn't match the number in the request",
+        )?
+        .add_task_errors()?
         .doc("Result of a command")?
         .build()?;
 
@@ -1053,7 +1062,6 @@ fn define_time_sync_callback(lib: &mut LibraryBuilder) -> Result<InterfaceHandle
     let timesync_result = lib
         .define_native_enum("TimeSyncResult")?
         .push("Success", "Time synchronization operation was a success")?
-        .push("TaskError", "Failed b/c of a generic task execution error")?
         .push("ClockRollback", "Detected a clock rollback")?
         .push(
             "SystemTimeNotUnix",
@@ -1070,6 +1078,7 @@ fn define_time_sync_callback(lib: &mut LibraryBuilder) -> Result<InterfaceHandle
         )?
         .push("SystemTimeNotAvailable", "System time not available")?
         .push("IinError", "Outstation indicated an error")?
+        .add_task_errors()?
         .doc("Result of a time sync operation")?
         .build()?;
 
@@ -1107,17 +1116,17 @@ fn define_time_sync_mode(lib: &mut LibraryBuilder) -> Result<NativeEnumHandle, B
 }
 
 fn define_restart_callback(lib: &mut LibraryBuilder) -> Result<InterfaceHandle, BindingError> {
-    let restart_success = lib
-        .define_native_enum("RestartSuccess")?
-        .push("Success", "Restart was perform successfully")?
-        .push("TaskError", "The restart was not performed properly")?
-        .doc("Result of a read operation")?
+    let restart_error = lib
+        .define_native_enum("RestartError")?
+        .push("Ok", "Restart was perform successfully")?
+        .add_task_errors()?
+        .doc("Result of a restart operation")?
         .build()?;
 
     let restart_result = lib.declare_native_struct("RestartResult")?;
     let restart_result = lib.define_native_struct(&restart_result)?
-        .add("success", Type::Enum(restart_success), "Success status of the restart task")?
-        .add("delay", Type::Duration(DurationMapping::Milliseconds), "Delay value returned by the outstation. Valid only if {struct:RestartResult.success} is {enum:RestartSuccess.Success}.")?
+        .add("error", Type::Enum(restart_error), "Success/failure of the restart task")?
+        .add("delay", Type::Duration(DurationMapping::Milliseconds), "Delay value returned by the outstation. Valid only if {struct:RestartResult.error} is {enum:RestartError.Ok}.")?
         .doc("Result of a restart task")?
         .build()?;
 

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -792,9 +792,8 @@ fn define_command_callback(
     let builder = lib
         .define_native_enum("CommandResult")?
         .push("Success", "Command was a success")?
-        .push("TaskError", "Failed b/c of a generic task execution error")?
         .push("BadStatus", "Outstation indicated that a command was not SUCCESS")?
-        .push("HeaderMismatch", "Number of headers and/or objects in the response didn't match the number in the request")?;
+        .push("HeaderMismatch", "Number of headers or objects in the response didn't match the number in the request")?;
 
     let command_result = add_task_errors(builder)?
         // -------------------


### PR DESCRIPTION
Defines a common set of task errors exposed to the FFI and a common mechanism in the schema to attach these task errors to a result enum.

Uses a macro to define a From<TaskError> to X:

Applied to:

```
define_task_from_impl!(CommandResult);
define_task_from_impl!(TimeSyncResult);
define_task_from_impl!(RestartError);
define_task_from_impl!(ReadResult);
```