### PR TITLE
Outstation connection-state events

### DIFF
--- a/dnp3/benches/benchmark.rs
+++ b/dnp3/benches/benchmark.rs
@@ -158,7 +158,7 @@ impl Pair {
                 DefaultOutstationApplication::create(),
                 DefaultOutstationInformation::create(),
                 DefaultControlHandler::create(),
-                Listener::None,
+                NullListener::create(),
                 AddressFilter::Any,
             )
             .unwrap();
@@ -215,7 +215,7 @@ impl Pair {
             Self::get_master_config(config.master_level),
             EndpointList::single(format!("127.0.0.1:{}", port)),
             ReconnectStrategy::default(),
-            Listener::None,
+            NullListener::create(),
         );
 
         let measurements = Measurements::new(config.max_index, config.num_values);

--- a/dnp3/benches/benchmark.rs
+++ b/dnp3/benches/benchmark.rs
@@ -158,6 +158,7 @@ impl Pair {
                 DefaultOutstationApplication::create(),
                 DefaultOutstationInformation::create(),
                 DefaultControlHandler::create(),
+                Listener::None,
                 AddressFilter::Any,
             )
             .unwrap();

--- a/dnp3/examples/master_serial.rs
+++ b/dnp3/examples/master_serial.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &get_serial_port_path(),
         SerialSettings::default(),
         Duration::from_secs(1),
-        Listener::None,
+        NullListener::create(),
     );
 
     // Create the association

--- a/dnp3/examples/master_tcp_client.rs
+++ b/dnp3/examples/master_tcp_client.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         get_master_channel_config()?,
         EndpointList::new("127.0.0.1:20000".to_owned(), &[]),
         ReconnectStrategy::default(),
-        Listener::None,
+        NullListener::create(),
     );
 
     // create the association

--- a/dnp3/examples/outstation_tcp_server.rs
+++ b/dnp3/examples/outstation_tcp_server.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultOutstationApplication::create(),
         DefaultOutstationInformation::create(),
         DefaultControlHandler::with_status(CommandStatus::NotSupported),
-        Listener::None,
+        Listener::BoxedFn(Box::new(|state| println!("Connection: {:?}", state))),
         // filter that controls what IP address(es) may connect to this outstation instance
         AddressFilter::Any,
     )?;

--- a/dnp3/examples/outstation_tcp_server.rs
+++ b/dnp3/examples/outstation_tcp_server.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use dnp3::app::control::*;
 use dnp3::app::measurement::*;
+use dnp3::app::Listener;
 use dnp3::decode::*;
 use dnp3::link::*;
 use dnp3::outstation::database::*;
@@ -52,6 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultOutstationApplication::create(),
         DefaultOutstationInformation::create(),
         DefaultControlHandler::with_status(CommandStatus::NotSupported),
+        Listener::None,
         // filter that controls what IP address(es) may connect to this outstation instance
         AddressFilter::Any,
     )?;

--- a/dnp3/examples/outstation_tcp_server.rs
+++ b/dnp3/examples/outstation_tcp_server.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use dnp3::app::control::*;
 use dnp3::app::measurement::*;
-use dnp3::app::Listener;
+use dnp3::app::NullListener;
 use dnp3::decode::*;
 use dnp3::link::*;
 use dnp3::outstation::database::*;
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultOutstationApplication::create(),
         DefaultOutstationInformation::create(),
         DefaultControlHandler::with_status(CommandStatus::NotSupported),
-        Listener::BoxedFn(Box::new(|state| println!("Connection: {:?}", state))),
+        NullListener::create(),
         // filter that controls what IP address(es) may connect to this outstation instance
         AddressFilter::Any,
     )?;

--- a/dnp3/src/app/listener.rs
+++ b/dnp3/src/app/listener.rs
@@ -8,3 +8,15 @@ pub enum Listener<T> {
     /// listener is a broadcast channel
     Watch(crate::tokio::sync::broadcast::Sender<T>),
 }
+
+impl<T> Listener<T> {
+    pub(crate) fn update(&mut self, value: T) {
+        match self {
+            Listener::None => {}
+            Listener::BoxedFn(func) => func(value),
+            Listener::Watch(s) => {
+                s.send(value).ok();
+            }
+        }
+    }
+}

--- a/dnp3/src/app/listener.rs
+++ b/dnp3/src/app/listener.rs
@@ -1,0 +1,10 @@
+/// A generic listener type that can be invoked multiple times.
+/// The user can select to implement it using FnMut, Watch, or not at all.
+pub enum Listener<T> {
+    /// nothing is listening
+    None,
+    /// listener is a boxed FnMut
+    BoxedFn(Box<dyn FnMut(T) + Send + Sync>),
+    /// listener is a broadcast channel
+    Watch(crate::tokio::sync::broadcast::Sender<T>),
+}

--- a/dnp3/src/app/mod.rs
+++ b/dnp3/src/app/mod.rs
@@ -1,6 +1,7 @@
 pub use app_enums::*;
 pub use bytes::*;
 pub use header::*;
+pub use listener::*;
 pub use parse_error::*;
 pub use retry::*;
 pub use sequence::*;
@@ -37,6 +38,7 @@ mod app_enums;
 mod control_enums;
 mod extensions;
 mod header;
+mod listener;
 /// measurement types, e.g. Binary, Analog, Counter, etc
 pub mod measurement;
 /// application layer parser

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -302,18 +302,6 @@ impl<T> Promise<T> {
     }
 }
 
-impl<T> Listener<T> {
-    pub(crate) fn update(&mut self, value: T) {
-        match self {
-            Listener::None => {}
-            Listener::BoxedFn(func) => func(value),
-            Listener::Watch(s) => {
-                s.send(value).ok();
-            }
-        }
-    }
-}
-
 /// callbacks associated with a single master to outstation association
 pub trait AssociationHandler: Send {
     /// Retrieve the system time used for time synchronization

--- a/dnp3/src/master/handle.rs
+++ b/dnp3/src/master/handle.rs
@@ -278,17 +278,6 @@ impl AssociationHandle {
     }
 }
 
-/// A generic listener type that can be invoked multiple times.
-/// The user can select to implement it using FnMut, Watch, or not at all.
-pub enum Listener<T> {
-    /// nothing is listening
-    None,
-    /// listener is a boxed FnMut
-    BoxedFn(Box<dyn FnMut(T) + Send + Sync>),
-    /// listener is a broadcast channel
-    Watch(crate::tokio::sync::broadcast::Sender<T>),
-}
-
 /// A generic callback type that must be invoked once and only once.
 /// The user can select to implement it using FnOnce or a
 /// one-shot reply channel

--- a/dnp3/src/outstation/adapter.rs
+++ b/dnp3/src/outstation/adapter.rs
@@ -1,8 +1,9 @@
 use tracing::Instrument;
 
-use crate::app::Shutdown;
+use crate::app::{Listener, Shutdown};
 use crate::outstation::session::RunError;
 use crate::outstation::task::OutstationTask;
+use crate::outstation::ConnectionState;
 use crate::util::channel::{request_channel, Receiver, Sender};
 use crate::util::phys::PhysLayer;
 
@@ -25,13 +26,23 @@ impl NewSession {
 pub(crate) struct OutstationTaskAdapter {
     receiver: Receiver<NewSession>,
     task: OutstationTask,
+    listener: Listener<ConnectionState>,
 }
 
 impl OutstationTaskAdapter {
-    pub(crate) fn create(task: OutstationTask) -> (Self, Sender<NewSession>) {
+    pub(crate) fn create(
+        task: OutstationTask,
+        listener: Listener<ConnectionState>,
+    ) -> (Self, Sender<NewSession>) {
         let (tx, rx) = request_channel();
-
-        (Self { receiver: rx, task }, tx)
+        (
+            Self {
+                receiver: rx,
+                task,
+                listener,
+            },
+            tx,
+        )
     }
 
     async fn wait_for_session(&mut self) -> Result<NewSession, Shutdown> {
@@ -69,10 +80,12 @@ impl OutstationTaskAdapter {
                 Some(mut s) => {
                     let id = s.id;
 
+                    self.listener.update(ConnectionState::Connected);
                     let result = self
                         .run_one_session(&mut s.phys)
                         .instrument(tracing::info_span!("Session", "id" = id))
                         .await;
+                    self.listener.update(ConnectionState::Disconnected);
 
                     // reset outstation state in between sessions
                     self.task.reset();

--- a/dnp3/src/outstation/adapter.rs
+++ b/dnp3/src/outstation/adapter.rs
@@ -26,13 +26,13 @@ impl NewSession {
 pub(crate) struct OutstationTaskAdapter {
     receiver: Receiver<NewSession>,
     task: OutstationTask,
-    listener: Listener<ConnectionState>,
+    listener: Box<dyn Listener<ConnectionState>>,
 }
 
 impl OutstationTaskAdapter {
     pub(crate) fn create(
         task: OutstationTask,
-        listener: Listener<ConnectionState>,
+        listener: Box<dyn Listener<ConnectionState>>,
     ) -> (Self, Sender<NewSession>) {
         let (tx, rx) = request_channel();
         (

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -51,6 +51,15 @@ pub enum WriteTimeResult {
     Ok,
 }
 
+/// Outstation state for connection oriented transports, e.g. TCP
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ConnectionState {
+    /// Connected to the master
+    Connected,
+    /// Disconnected from the master
+    Disconnected,
+}
+
 /// dynamic information required by the outstation from the user application
 pub trait OutstationApplication: Sync + Send + 'static {
     /// The value returned by this method is used in conjunction with the `Delay Measurement`

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -51,7 +51,7 @@ pub enum WriteTimeResult {
     Ok,
 }
 
-/// Outstation state for connection oriented transports, e.g. TCP
+/// Outstation connection state for connection-oriented transports, e.g. TCP
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ConnectionState {
     /// Connected to the master

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -22,7 +22,7 @@ pub fn spawn_master_serial(
     path: &str,
     serial_settings: SerialSettings,
     retry_delay: Duration,
-    listener: Listener<PortState>,
+    listener: Box<dyn Listener<PortState>>,
 ) -> MasterChannel {
     let (future, handle) =
         create_master_serial(config, path, serial_settings, retry_delay, listener);
@@ -43,7 +43,7 @@ pub fn create_master_serial(
     path: &str,
     settings: SerialSettings,
     retry_delay: Duration,
-    listener: Listener<PortState>,
+    listener: Box<dyn Listener<PortState>>,
 ) -> (impl Future<Output = ()> + 'static, MasterChannel) {
     let log_path = path.to_owned();
     let (mut task, handle) = MasterTask::new(path, settings, config, retry_delay, listener);
@@ -63,7 +63,7 @@ struct MasterTask {
     session: MasterSession,
     reader: TransportReader,
     writer: TransportWriter,
-    listener: Listener<PortState>,
+    listener: Box<dyn Listener<PortState>>,
 }
 
 impl MasterTask {
@@ -72,7 +72,7 @@ impl MasterTask {
         serial_settings: SerialSettings,
         config: MasterChannelConfig,
         retry_delay: Duration,
-        listener: Listener<PortState>,
+        listener: Box<dyn Listener<PortState>>,
     ) -> (Self, MasterChannel) {
         let (tx, rx) = crate::util::channel::request_channel();
         let session = MasterSession::new(

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use tracing::Instrument;
 
-use crate::app::Shutdown;
+use crate::app::{Listener, Shutdown};
 use crate::link::LinkErrorMode;
 use crate::master::session::{MasterSession, RunError, StateChange};
 use crate::master::*;

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -25,7 +25,7 @@ pub fn spawn_master_tcp_client(
     config: MasterChannelConfig,
     endpoints: EndpointList,
     reconnect: ReconnectStrategy,
-    listener: Listener<ClientState>,
+    listener: Box<dyn Listener<ClientState>>,
 ) -> MasterChannel {
     let (future, handle) =
         create_master_tcp_client(link_error_mode, config, endpoints, reconnect, listener);
@@ -46,7 +46,7 @@ pub fn create_master_tcp_client(
     config: MasterChannelConfig,
     endpoints: EndpointList,
     reconnect: ReconnectStrategy,
-    listener: Listener<ClientState>,
+    listener: Box<dyn Listener<ClientState>>,
 ) -> (impl Future<Output = ()> + 'static, MasterChannel) {
     let main_addr = endpoints.main_addr().to_string();
     let (mut task, handle) =
@@ -66,7 +66,7 @@ struct MasterTask {
     session: MasterSession,
     reader: TransportReader,
     writer: TransportWriter,
-    listener: Listener<ClientState>,
+    listener: Box<dyn Listener<ClientState>>,
 }
 
 impl MasterTask {
@@ -75,7 +75,7 @@ impl MasterTask {
         endpoints: EndpointList,
         config: MasterChannelConfig,
         reconnect: ReconnectStrategy,
-        listener: Listener<ClientState>,
+        listener: Box<dyn Listener<ClientState>>,
     ) -> (Self, MasterChannel) {
         let (tx, rx) = crate::util::channel::request_channel();
         let session = MasterSession::new(

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use tracing::Instrument;
 
 use crate::app::Shutdown;
-use crate::app::{ExponentialBackOff, ReconnectStrategy};
+use crate::app::{ExponentialBackOff, Listener, ReconnectStrategy};
 use crate::link::LinkErrorMode;
 use crate::master::session::{MasterSession, RunError, StateChange};
-use crate::master::{Listener, MasterChannel, MasterChannelConfig};
+use crate::master::{MasterChannel, MasterChannelConfig};
 use crate::tcp::ClientState;
 use crate::tcp::EndpointList;
 use crate::tokio::net::TcpStream;

--- a/dnp3/src/tcp/outstation.rs
+++ b/dnp3/src/tcp/outstation.rs
@@ -1,6 +1,6 @@
 use tracing::Instrument;
 
-use crate::app::Shutdown;
+use crate::app::{Listener, Shutdown};
 use crate::link::LinkErrorMode;
 use crate::outstation::database::EventBufferConfig;
 use crate::outstation::task::OutstationTask;
@@ -45,6 +45,7 @@ impl TcpServer {
     }
 
     /// associate an outstation with the TcpServer, but do not spawn it
+    #[allow(clippy::too_many_arguments)]
     pub fn add_outstation(
         &mut self,
         config: OutstationConfig,
@@ -52,6 +53,7 @@ impl TcpServer {
         application: Box<dyn OutstationApplication>,
         information: Box<dyn OutstationInformation>,
         control_handler: Box<dyn ControlHandler>,
+        listener: Listener<ConnectionState>,
         filter: AddressFilter,
     ) -> Result<(OutstationHandle, impl std::future::Future<Output = ()>), FilterError> {
         for item in self.outstations.iter() {
@@ -69,7 +71,7 @@ impl TcpServer {
             control_handler,
         );
 
-        let (mut adapter, tx) = OutstationTaskAdapter::create(task);
+        let (mut adapter, tx) = OutstationTaskAdapter::create(task, listener);
 
         let outstation = OutstationInfo {
             filter,
@@ -91,6 +93,7 @@ impl TcpServer {
     }
 
     /// associate an outstation with the TcpServer and spawn it on the Tokio runtime.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn_outstation(
         &mut self,
         config: OutstationConfig,
@@ -98,6 +101,7 @@ impl TcpServer {
         application: Box<dyn OutstationApplication>,
         information: Box<dyn OutstationInformation>,
         control_handler: Box<dyn ControlHandler>,
+        listener: Listener<ConnectionState>,
         filter: AddressFilter,
     ) -> Result<OutstationHandle, FilterError> {
         let (handle, future) = self.add_outstation(
@@ -106,6 +110,7 @@ impl TcpServer {
             application,
             information,
             control_handler,
+            listener,
             filter,
         )?;
         crate::tokio::spawn(future);

--- a/dnp3/src/tcp/outstation.rs
+++ b/dnp3/src/tcp/outstation.rs
@@ -53,7 +53,7 @@ impl TcpServer {
         application: Box<dyn OutstationApplication>,
         information: Box<dyn OutstationInformation>,
         control_handler: Box<dyn ControlHandler>,
-        listener: Listener<ConnectionState>,
+        listener: Box<dyn Listener<ConnectionState>>,
         filter: AddressFilter,
     ) -> Result<(OutstationHandle, impl std::future::Future<Output = ()>), FilterError> {
         for item in self.outstations.iter() {
@@ -101,7 +101,7 @@ impl TcpServer {
         application: Box<dyn OutstationApplication>,
         information: Box<dyn OutstationInformation>,
         control_handler: Box<dyn ControlHandler>,
-        listener: Listener<ConnectionState>,
+        listener: Box<dyn Listener<ConnectionState>>,
         filter: AddressFilter,
     ) -> Result<OutstationHandle, FilterError> {
         let (handle, future) = self.add_outstation(

--- a/ffi/bindings/c/outstation_example.c
+++ b/ffi/bindings/c/outstation_example.c
@@ -188,6 +188,20 @@ void octet_string_transaction(dnp3_database_t *db, void *context)
     dnp3_octet_string_destroy(octet_string);
 }
 
+void on_connection_state_change(dnp3_connection_state_t state, void* ctx)
+{
+    printf("Connection state change: %s\n", dnp3_connection_state_to_string(state));
+}
+
+dnp3_connection_state_listener_t get_connection_state_listener()
+{
+    return (dnp3_connection_state_listener_t) {
+        .on_change = &on_connection_state_change,
+        .on_destroy = NULL,
+        .ctx = NULL,
+    };
+}
+
 // ANCHOR: event_buffer_config
 dnp3_event_buffer_config_t get_event_buffer_config() {
     return dnp3_event_buffer_config_init(
@@ -295,7 +309,16 @@ int main()
 
     // ANCHOR: tcpserver_add_outstation
     dnp3_address_filter_t *address_filter = dnp3_address_filter_any();
-    err = dnp3_tcpserver_add_outstation(server, config, get_event_buffer_config(), application, information, control_handler, address_filter, &outstation);
+    err = dnp3_tcpserver_add_outstation(
+        server,
+        config,
+        get_event_buffer_config(),
+        application, information,
+        control_handler,
+        get_connection_state_listener(),
+        address_filter,
+        &outstation
+    );
     dnp3_address_filter_destroy(address_filter);
     if (err) {
         printf("unable to add outstation: %s \n", dnp3_param_error_to_string(err));

--- a/ffi/bindings/dotnet/examples/outstation/Program.cs
+++ b/ffi/bindings/dotnet/examples/outstation/Program.cs
@@ -99,6 +99,14 @@ class ExampleOutstation
         public CommandStatus OperateG41v4(double value, ushort index, OperateType opType, Database database) { return CommandStatus.NotSupported; }       
     }
 
+    class TestListener : IConnectionStateListener
+    {
+        public void OnChange(ConnectionState state)
+        {
+            Console.WriteLine("Connection state change: " + state);
+        }
+    }
+
     public static void Main(string[] args)
     {
         MainAsync().GetAwaiter().GetResult();
@@ -153,6 +161,7 @@ class ExampleOutstation
                     new TestOutstationApplication(),
                     new TestOutstationInformation(),
                     new TestControlHandler(),
+                    new TestListener(),
                     AddressFilter.Any()
                 );
                 // ANCHOR_END: tcp_server_add_outstation

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/OutstationExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3rs/examples/OutstationExample.java
@@ -163,6 +163,13 @@ class TestControlHandler implements ControlHandler {
   }
 }
 
+class TestConnectionStateListener implements ConnectionStateListener {
+  @Override
+  public void onChange(ConnectionState state) {
+    System.out.println("Connection state change: " + state);
+  }
+}
+
 public class OutstationExample {
 
   static OutstationConfig getOutstationConfig() {
@@ -234,6 +241,7 @@ public class OutstationExample {
             new TestApplication(),
             new TestOutstationInformation(),
             new TestControlHandler(),
+            new TestConnectionStateListener(),
             AddressFilter.any());
     // ANCHOR_END: tcp_server_add_outstation
 

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -1,9 +1,7 @@
 use std::ffi::CStr;
 use std::time::Duration;
 
-use dnp3::app::Timeout;
-use dnp3::app::Timestamp;
-use dnp3::app::{ReconnectStrategy, RetryStrategy};
+use dnp3::app::{Listener, ReconnectStrategy, RetryStrategy, Timeout, Timestamp};
 use dnp3::link::{EndpointAddress, LinkStatusResult, SpecialAddressError};
 use dnp3::master::*;
 use dnp3::serial::*;

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -11,7 +11,7 @@ use dnp3::tcp::{FilterError, ServerHandle};
 pub use struct_constructors::*;
 
 use crate::{ffi, Runtime, RuntimeHandle};
-use dnp3::app::Listener;
+use dnp3::app::NullListener;
 use dnp3::serial::create_outstation_serial;
 
 mod adapters;
@@ -83,7 +83,7 @@ pub unsafe fn tcpserver_add_outstation(
         Box::new(application),
         Box::new(information),
         Box::new(control_handler),
-        Listener::None,
+        NullListener::create(),
         filter,
     )?;
 

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -56,6 +56,7 @@ pub unsafe fn tcpserver_destroy(server: *mut TcpServer) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn tcpserver_add_outstation(
     server: *mut TcpServer,
     config: ffi::OutstationConfig,

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -3,15 +3,16 @@ use std::net::AddrParseError;
 use std::time::Duration;
 
 pub use database::*;
+use dnp3::app::Listener;
 use dnp3::link::{EndpointAddress, LinkErrorMode};
 use dnp3::outstation::database::{ClassZeroConfig, EventBufferConfig};
-use dnp3::outstation::{BufferSize, Feature, Features, OutstationConfig};
+use dnp3::outstation::{BufferSize, ConnectionState, Feature, Features, OutstationConfig};
 use dnp3::outstation::{BufferSizeError, OutstationHandle};
 use dnp3::tcp::{FilterError, ServerHandle};
 pub use struct_constructors::*;
 
 use crate::{ffi, Runtime, RuntimeHandle};
-use dnp3::app::NullListener;
+
 use dnp3::serial::create_outstation_serial;
 
 mod adapters;
@@ -62,6 +63,7 @@ pub unsafe fn tcpserver_add_outstation(
     application: ffi::OutstationApplication,
     information: ffi::OutstationInformation,
     control_handler: ffi::ControlHandler,
+    listener: ffi::ConnectionStateListener,
     filter: *mut AddressFilter,
 ) -> Result<*mut Outstation, ffi::ParamError> {
     let server = server.as_mut().ok_or(ffi::ParamError::NullParameter)?;
@@ -83,7 +85,7 @@ pub unsafe fn tcpserver_add_outstation(
         Box::new(application),
         Box::new(information),
         Box::new(control_handler),
-        NullListener::create(),
+        Box::new(listener),
         filter,
     )?;
 
@@ -210,6 +212,21 @@ fn convert_outstation_config(
         max_read_request_headers: Some(config.max_read_request_headers),
         max_controls_per_request: Some(config.max_controls_per_request),
     })
+}
+
+impl Listener<ConnectionState> for ffi::ConnectionStateListener {
+    fn update(&mut self, value: ConnectionState) {
+        self.on_change(value.into())
+    }
+}
+
+impl From<ConnectionState> for ffi::ConnectionState {
+    fn from(x: ConnectionState) -> Self {
+        match x {
+            ConnectionState::Connected => ffi::ConnectionState::Connected,
+            ConnectionState::Disconnected => ffi::ConnectionState::Disconnected,
+        }
+    }
 }
 
 impl From<&ffi::OutstationFeatures> for Features {

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -11,6 +11,7 @@ use dnp3::tcp::{FilterError, ServerHandle};
 pub use struct_constructors::*;
 
 use crate::{ffi, Runtime, RuntimeHandle};
+use dnp3::app::Listener;
 use dnp3::serial::create_outstation_serial;
 
 mod adapters;
@@ -82,6 +83,7 @@ pub unsafe fn tcpserver_add_outstation(
         Box::new(application),
         Box::new(information),
         Box::new(control_handler),
+        Listener::None,
         filter,
     )?;
 


### PR DESCRIPTION
* Modify Listener<T> to just be  Boxed trait like the others
* Add a `Listener<ConnectionState>` to the `add_outstation` methods of TCPServer
* FFI calls this a `ConnectionStateListener` interface