### PR TITLE
Added a test case and a fix of a mishandling of the buffer overflow condition

### DIFF
--- a/conformance/src/main/scala/io/stepfunc/dnp3rs_conformance/CustomConnectionStateListener.scala
+++ b/conformance/src/main/scala/io/stepfunc/dnp3rs_conformance/CustomConnectionStateListener.scala
@@ -1,0 +1,9 @@
+package io.stepfunc.dnp3rs_conformance
+
+import io.stepfunc.dnp3rs.{ConnectionState, ConnectionStateListener}
+
+class CustomConnectionStateListener extends ConnectionStateListener {
+  override def onChange(connectionState: ConnectionState): Unit = {
+
+  }
+}

--- a/conformance/src/main/scala/io/stepfunc/dnp3rs_conformance/Dnp3rsIntegrationPlugin.scala
+++ b/conformance/src/main/scala/io/stepfunc/dnp3rs_conformance/Dnp3rsIntegrationPlugin.scala
@@ -783,6 +783,7 @@ class Dnp3rsIntegrationPlugin extends IntegrationPlugin {
     val app = new CustomOutstationApplication(config.testDatabaseConfig.isGlobalLocalControl || config.testDatabaseConfig.isSingleLocalControl)
     val information = new CustomOutstationInformation
     this.controlHandler = new QueuedControlHandler(config.commandHandlerConfig.disableBinaryOutput, config.commandHandlerConfig.disableAnalogOutput)
+    val listener = new CustomConnectionStateListener
 
     val dnp3Config = new io.stepfunc.dnp3rs.OutstationConfig(ushort(config.linkConfig.source), ushort(config.linkConfig.destination))
 
@@ -804,7 +805,7 @@ class Dnp3rsIntegrationPlugin extends IntegrationPlugin {
     dnp3Config.maxUnsolicitedRetries = config.unsolicitedResponseConfig.maxNumRetries.map(x => uint(x)).getOrElse(UInteger.MAX)
 
     // Create the outstation
-    this.outstation = server.addOutstation(dnp3Config, EventBufferConfig.allTypes(ushort(200)), app, information, controlHandler, AddressFilter.any())
+    this.outstation = server.addOutstation(dnp3Config, EventBufferConfig.allTypes(ushort(200)), app, information, controlHandler, listener, AddressFilter.any())
 
     // Create the database
     this.trackingDatabase = new TrackingDatabase(app, this.outstation, config.testDatabaseConfig)

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -223,7 +223,6 @@ impl SessionState {
     fn reset(&mut self) {
         self.last_valid_request = None;
         self.select = None;
-        self.unsolicited_seq = Sequence::default();
         self.deferred_read.clear();
     }
 }
@@ -1381,7 +1380,7 @@ impl OutstationSession {
         };
 
         // Calculate IIN and return it
-        let mut iin = self.get_response_iin(database);
+        let mut iin = Iin::default();
 
         if let Ok(CommandStatus::NotSupported) = result {
             iin |= Iin2::PARAMETER_ERROR;
@@ -1512,7 +1511,7 @@ impl OutstationSession {
         }
 
         // Calculate IIN and return response
-        let mut iin = self.get_response_iin(database);
+        let mut iin = Iin::default();
 
         if let Ok(CommandStatus::NotSupported) = result {
             iin |= Iin2::PARAMETER_ERROR;
@@ -1592,7 +1591,7 @@ impl OutstationSession {
         };
 
         // Calculate IIN and return it
-        let mut iin = self.get_response_iin(database);
+        let mut iin = Iin::default();
 
         if status == CommandStatus::NotSupported {
             iin |= Iin2::PARAMETER_ERROR;

--- a/dnp3/src/outstation/tests/harness/harness.rs
+++ b/dnp3/src/outstation/tests/harness/harness.rs
@@ -110,18 +110,26 @@ where
 pub(crate) fn new_harness(
     config: OutstationConfig,
 ) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
-    new_harness_impl(config, None)
+    new_harness_impl(config, None, None)
+}
+
+pub(crate) fn new_harness_with_custom_event_buffers(
+    config: OutstationConfig,
+    event_config: EventBufferConfig,
+) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
+    new_harness_impl(config, Some(event_config), None)
 }
 
 pub(crate) fn new_harness_for_broadcast(
     config: OutstationConfig,
     broadcast: BroadcastConfirmMode,
 ) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
-    new_harness_impl(config, Some(broadcast))
+    new_harness_impl(config, None, Some(broadcast))
 }
 
 fn new_harness_impl(
     config: OutstationConfig,
+    event_config: Option<EventBufferConfig>,
     broadcast: Option<BroadcastConfirmMode>,
 ) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
     let events = EventHandle::new();
@@ -131,7 +139,7 @@ fn new_harness_impl(
     let (task, handle) = OutstationTask::create(
         LinkErrorMode::Close,
         config,
-        EventBufferConfig::all_types(5),
+        event_config.unwrap_or(EventBufferConfig::all_types(5)),
         application,
         MockOutstationInformation::new(events.clone()),
         MockControlHandler::new(events.clone()),


### PR DESCRIPTION
The reseting of the event counters was not done properly if an unsolicited response in an overflow condition was sent and some more events were added before a confirmation was received. The test case is pretty explicit.