### PR TITLE
update tokio-serial to 5.4.0-beta1

### DIFF
--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 tracing = "0.1"
 chrono = "0.4"
 tokio-mock = { git = "https://github.com/stepfunc/tokio-mock.git", branch="master" }
-tokio-serial = { git = "https://github.com/stepfunc/tokio-serial.git", branch="v4.4.0", default-features = false }
+tokio-serial = "5.4.0-beta1"
 xxhash-rust = { version = "0.8.2", features = ["xxh64"] }
 
 [dev-dependencies]

--- a/dnp3/src/serial/mod.rs
+++ b/dnp3/src/serial/mod.rs
@@ -41,14 +41,14 @@ impl Default for SerialSettings {
     }
 }
 
-pub(crate) fn open(path: &str, settings: SerialSettings) -> tokio_serial::Result<TTYPort> {
+pub(crate) fn open(path: &str, settings: SerialSettings) -> tokio_serial::Result<SerialStream> {
     let builder = settings.apply(tokio_serial::new(path, settings.baud_rate));
-    TTYPort::open(&builder)
+    SerialStream::open(&builder)
 }
 
 pub use master::*;
 pub use outstation::*;
-use tokio_serial::TTYPort;
+use tokio_serial::SerialStream;
 
 mod master;
 mod outstation;

--- a/dnp3/src/util/phys.rs
+++ b/dnp3/src/util/phys.rs
@@ -4,7 +4,7 @@ use crate::tokio::io::{AsyncReadExt, AsyncWriteExt};
 // encapsulates all possible physical layers as an enum
 pub(crate) enum PhysLayer {
     Tcp(crate::tokio::net::TcpStream),
-    Serial(tokio_serial::TTYPort),
+    Serial(tokio_serial::SerialStream),
     #[cfg(test)]
     Mock(tokio_mock::mock::test::io::MockIO),
 }


### PR DESCRIPTION
`tokio-serial` with tokio v1 support is now available on crates.io.  `dnp3` compiles and passes `cargo test` with these changes but I cannot comment on any further validity. 

This should close #131