### PR TITLE
Add Windows serial support with tokio-serial 5.4.0-beta1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Next ###
+* Added support for serial ports on Windows.
+  See [#134](https://github.com/stepfunc/dnp3/pull/134).
+
 ### 0.9.1 ###
 * C bindings now provides static libraries with the `dnp3_static` CMake target.
   See [#128](https://github.com/stepfunc/dnp3/pull/128).

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 tracing = "0.1"
 chrono = "0.4"
 tokio-mock = { git = "https://github.com/stepfunc/tokio-mock.git", branch="master" }
-tokio-serial = { git = "https://github.com/stepfunc/tokio-serial.git", branch="v4.4.0", default-features = false }
+tokio-serial = "5.4.0-beta1"
 xxhash-rust = { version = "0.8.2", features = ["xxh64"] }
 
 [dev-dependencies]

--- a/dnp3/src/serial/mod.rs
+++ b/dnp3/src/serial/mod.rs
@@ -1,4 +1,4 @@
-pub use tokio_serial::{DataBits, FlowControl, Parity, StopBits};
+pub use tokio_serial::{DataBits, FlowControl, Parity, SerialStream, StopBits};
 
 /// serial port settings
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -41,14 +41,13 @@ impl Default for SerialSettings {
     }
 }
 
-pub(crate) fn open(path: &str, settings: SerialSettings) -> tokio_serial::Result<TTYPort> {
+pub(crate) fn open(path: &str, settings: SerialSettings) -> tokio_serial::Result<SerialStream> {
     let builder = settings.apply(tokio_serial::new(path, settings.baud_rate));
-    TTYPort::open(&builder)
+    SerialStream::open(&builder)
 }
 
 pub use master::*;
 pub use outstation::*;
-use tokio_serial::TTYPort;
 
 mod master;
 mod outstation;

--- a/dnp3/src/util/phys.rs
+++ b/dnp3/src/util/phys.rs
@@ -4,7 +4,7 @@ use crate::tokio::io::{AsyncReadExt, AsyncWriteExt};
 // encapsulates all possible physical layers as an enum
 pub(crate) enum PhysLayer {
     Tcp(crate::tokio::net::TcpStream),
-    Serial(tokio_serial::TTYPort),
+    Serial(tokio_serial::SerialStream),
     #[cfg(test)]
     Mock(tokio_mock::mock::test::io::MockIO),
 }

--- a/guide/docs/api/master/serial.mdx
+++ b/guide/docs/api/master/serial.mdx
@@ -8,10 +8,6 @@ slug: /api/master/serial
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::warning
-We currently only provide serial port support on Linux. We are waiting for Windows support to stabilize in a downstream dependency.
-:::
-
 Use the `MasterChannel::createSerialChannel` method to create a channel bound to a serial port. It requires the same serial port configuration parameters as the outstation serial port API.
 
 Unlike the outstation API, the master API opens the serial port API lazily after `MasterChannel.enable()` is called. It will try to open the port


### PR DESCRIPTION
Close #131.

Once a stable (non-beta) version is released, another update should be made. See https://github.com/berkowski/tokio-serial/issues/40 for more details.

This PR supersedes #133 for legal reasons.