### PR TITLE
Add AArch64 support to Java and .NET.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: cargo-license --avoid-dev-deps --avoid-build-deps -j > ../dependencies.json
       - name: Generate dependencies.txt
         working-directory: complicense
-        run: cargo run -- --import ../dnp3/dependencies.json --config ../dnp3/deps-config.json  --token ${{ github.token }} > ../dnp3/dependencies.txt
+        run: cargo run -- --import ../dnp3/dependencies.json --config ../dnp3/deps-config.json --token ${{ github.token }} > ../dnp3/dependencies.txt
       - name: Upload dependencies info
         uses: actions/upload-artifact@v2
         with:
@@ -194,6 +194,65 @@ jobs:
         with:
           name: ffi-modules
           path: ffi/bindings/java/dnp3/src/main/resources
+  # Build bindings on Linux AArch64
+  bindings-aarch64:
+    needs: lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+          override: true
+      - name: Caching
+        uses: Swatinem/rust-cache@v1
+      - name: Download Cargo.lock
+        uses: actions/download-artifact@v2
+        with:
+          name: dependencies
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target aarch64-unknown-linux-gnu
+      - name: C bindings
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: run
+          args: --release --target aarch64-unknown-linux-gnu --bin dnp3-bindings -- --c --no-tests
+      - name: .NET bindings
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: run
+          args: --release --target aarch64-unknown-linux-gnu --bin dnp3-bindings -- --dotnet --no-tests
+      - name: Java bindings
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: run
+          args: --release --target aarch64-unknown-linux-gnu --bin dnp3-bindings -- --java --no-tests
+      - name: Upload compiled FFI modules
+        uses: actions/upload-artifact@v2
+        with:
+          name: ffi-modules
+          path: ffi/bindings/c/generated/aarch64-unknown-linux-gnu/lib
+      - name: Upload C bindings
+        uses: actions/upload-artifact@v2
+        with:
+          name: c-bindings
+          path: ffi/bindings/c/generated
+      - name: Upload compiled Java bindings
+        uses: actions/upload-artifact@v2
+        with:
+          name: ffi-modules
+          path: ffi/bindings/java/dnp3/src/main/resources
   # Cross-compilation for ARM devices and produce C bindings
   cross:
     needs: lock
@@ -204,7 +263,6 @@ jobs:
           - arm-unknown-linux-gnueabi # ARMv6 Linux (kernel 3.2, glibc 2.17)
           - arm-unknown-linux-gnueabihf # ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
           - armv7-unknown-linux-gnueabihf # ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)
-          - aarch64-unknown-linux-gnu # ARM64 Linux (kernel 4.2, glibc 2.17+)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -244,7 +302,7 @@ jobs:
           path: ffi/bindings/c/generated
   # Package all the generated bindings
   packaging:
-    needs: [lock, bindings, cross]
+    needs: [lock, bindings, bindings-aarch64, cross]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Next ###
+* Add Linux AArch64 support in Java and .NET.
+  See [#137](https://github.com/stepfunc/dnp3/pull/134).
 * Added support for serial ports on Windows.
   See [#134](https://github.com/stepfunc/dnp3/pull/134).
 

--- a/ffi/dnp3-bindings/Cargo.toml
+++ b/ffi/dnp3-bindings/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Émile Grégoire <emile@stepfunc.io>"]
 edition = "2018"
 
 [dependencies]
-ci-script = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.1.1" }
+ci-script = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.1.3" }
 dnp3-schema = { path = "../dnp3-schema" }
 dnp3-ffi = { path = "../dnp3-ffi" }

--- a/ffi/dnp3-ffi/Cargo.toml
+++ b/ffi/dnp3-ffi/Cargo.toml
@@ -16,4 +16,4 @@ num_cpus = "1"
 
 [build-dependencies]
 dnp3-schema = { path = "../dnp3-schema" }
-rust-oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.1.1" }
+rust-oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.1.3" }

--- a/ffi/dnp3-schema/Cargo.toml
+++ b/ffi/dnp3-schema/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 dnp3 = { path = "../../dnp3" }
-oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.1.1" }
+oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.1.3" }

--- a/guide/docs/languages/java.mdx
+++ b/guide/docs/languages/java.mdx
@@ -7,7 +7,7 @@ slug: /java
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-The Java bindings are distributed as a JAR targeting Java 8. Native libraries for Windows and Linux are embedded in the JAR's `resources` directory. The
+The Java bindings are distributed as a JAR targeting Java 8. Native libraries for Windows x64, Linux x64 and Linux AArch64 are embedded in the JAR's `resources` directory. The
 correct native library will automatically load during static initialization. These native libraries wrap the underlying C API with a thin layer of
 [JNI](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/).
 
@@ -25,12 +25,11 @@ Release artifacts are published to Maven central. Add this dependency to incorpo
 
 ## Dependencies
 
-In addition to the Rust dependencies, the Java bindings depend on these two open source projects:
+In addition to the Rust dependencies, the Java bindings depend on one open source project:
 
 * [joou-java-6](https://github.com/jOOQ/jOOU) - Apache 2.0 - Java Object Oriented Unsigned (JOOU) integer classes
-* [commons-lang3](https://github.com/apache/commons-lang) - Apache 2.0 - Java utility classes
 
-These libraries are not distributed by Step Function I/O directly. They are only declared as a dependency for the package manager to retrieve.
+This library is not distributed by Step Function I/O directly. It is only declared as a dependency for the package manager to retrieve.
 
 ## Unsigned Integers
 


### PR DESCRIPTION
See https://github.com/stepfunc/oo_bindgen/pull/61 for more details.

Close #136.