### PR TITLE
Bug fix + tests for range scans

### DIFF
--- a/dnp3/src/outstation/tests/read_states.rs
+++ b/dnp3/src/outstation/tests/read_states.rs
@@ -6,6 +6,7 @@ use crate::outstation::database::*;
 use crate::outstation::tests::harness::*;
 
 const EMPTY_READ: &[u8] = &[0xC0, 0x01];
+const READ_CLASS_0: &[u8] = &[0xC0, 0x01, 60, 01, 0x06];
 const READ_CLASS_123: &[u8] = &[0xC0, 0x01, 60, 02, 0x06, 60, 03, 0x06, 60, 04, 0x06];
 const CONFIRM_SEQ_0: &[u8] = &[0xC0, 0x00];
 const UNS_CONFIRM_SEQ_0: &[u8] = &[0b11010000, 0x00];
@@ -30,6 +31,59 @@ fn empty_read_yields_empty_response() {
     let mut harness = new_harness(get_default_config());
     harness.test_request_response(EMPTY_READ, EMPTY_RESPONSE);
     harness.check_no_events();
+}
+
+#[test]
+fn can_read_one_byte_range() {
+    let mut harness = new_harness(get_default_config());
+
+    harness.handle.database.transaction(|database| {
+        database.add(0, Some(EventClass::Class1), AnalogConfig::default());
+        database.update(
+            0,
+            &Analog::new(42.0, Flags::ONLINE, Time::Synchronized(Timestamp::new(0))),
+            UpdateOptions::initialize(),
+        );
+    });
+
+    const READ_G30_V1_0_TO_0: &[u8] = &[0xC0, 0x01, 0x1E, 0x01, 0x00, 0x00, 0x00];
+    harness.test_request_response(
+        READ_G30_V1_0_TO_0,
+        &[
+            0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00,
+        ],
+    );
+    harness.check_events(&[]);
+}
+
+#[test]
+fn can_read_two_byte_range() {
+    let mut harness = new_harness(get_default_config());
+
+    harness.handle.database.transaction(|database| {
+        for i in 0..5 {
+            database.add(i, Some(EventClass::Class1), BinaryConfig::default());
+            database.update(
+                i,
+                &Binary::new(
+                    i % 2 == 1,
+                    Flags::ONLINE,
+                    Time::Synchronized(Timestamp::new(0)),
+                ),
+                UpdateOptions::initialize(),
+            );
+        }
+    });
+
+    const READ_G1_V2_1_TO_3: &[u8] = &[0xC0, 0x01, 0x01, 0x02, 0x01, 0x01, 0x00, 0x03, 0x00];
+    harness.test_request_response(
+        READ_G1_V2_1_TO_3,
+        &[
+            0xC0, 0x81, 0x80, 0x00, 0x01, 0x02, 0x01, 0x01, 0x00, 0x03, 0x00, 0x81, 0x01, 0x81,
+        ],
+    );
+    harness.check_events(&[]);
 }
 
 #[test]

--- a/dnp3/src/outstation/tests/read_states.rs
+++ b/dnp3/src/outstation/tests/read_states.rs
@@ -26,6 +26,30 @@ fn create_binary_and_event(database: &mut Database) {
     );
 }
 
+fn create_one_analog_with_value_42(database: &mut Database) {
+    database.add(0, Some(EventClass::Class1), AnalogConfig::default());
+    database.update(
+        0,
+        &Analog::new(42.0, Flags::ONLINE, Time::Synchronized(Timestamp::new(0))),
+        UpdateOptions::initialize(),
+    );
+}
+
+fn create_five_binary_inputs_with_odd_indices_true(database: &mut Database) {
+    for i in 0..5 {
+        database.add(i, Some(EventClass::Class1), BinaryConfig::default());
+        database.update(
+            i,
+            &Binary::new(
+                i % 2 == 1,
+                Flags::ONLINE,
+                Time::Synchronized(Timestamp::new(0)),
+            ),
+            UpdateOptions::initialize(),
+        );
+    }
+}
+
 #[test]
 fn empty_read_yields_empty_response() {
     let mut harness = new_harness(get_default_config());
@@ -34,23 +58,19 @@ fn empty_read_yields_empty_response() {
 }
 
 #[test]
-fn can_read_one_byte_range() {
+fn can_read_one_byte_range_for_specific_variation() {
     let mut harness = new_harness(get_default_config());
 
-    harness.handle.database.transaction(|database| {
-        database.add(0, Some(EventClass::Class1), AnalogConfig::default());
-        database.update(
-            0,
-            &Analog::new(42.0, Flags::ONLINE, Time::Synchronized(Timestamp::new(0))),
-            UpdateOptions::initialize(),
-        );
-    });
+    harness
+        .handle
+        .database
+        .transaction(create_one_analog_with_value_42);
 
     const READ_G30_V1_0_TO_0: &[u8] = &[0xC0, 0x01, 0x1E, 0x01, 0x00, 0x00, 0x00];
     harness.test_request_response(
         READ_G30_V1_0_TO_0,
         &[
-            0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2A, 0x00,
             0x00, 0x00,
         ],
     );
@@ -58,29 +78,59 @@ fn can_read_one_byte_range() {
 }
 
 #[test]
-fn can_read_two_byte_range() {
+fn can_read_one_byte_range_for_default_variation() {
     let mut harness = new_harness(get_default_config());
 
-    harness.handle.database.transaction(|database| {
-        for i in 0..5 {
-            database.add(i, Some(EventClass::Class1), BinaryConfig::default());
-            database.update(
-                i,
-                &Binary::new(
-                    i % 2 == 1,
-                    Flags::ONLINE,
-                    Time::Synchronized(Timestamp::new(0)),
-                ),
-                UpdateOptions::initialize(),
-            );
-        }
-    });
+    harness
+        .handle
+        .database
+        .transaction(create_one_analog_with_value_42);
+
+    const READ_G30_V0_0_TO_0: &[u8] = &[0xC0, 0x01, 0x1E, 0x00, 0x00, 0x00, 0x00];
+    harness.test_request_response(
+        READ_G30_V0_0_TO_0,
+        &[
+            0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2A, 0x00,
+            0x00, 0x00,
+        ],
+    );
+    harness.check_events(&[]);
+}
+
+#[test]
+fn can_read_two_byte_range_for_specific_variation() {
+    let mut harness = new_harness(get_default_config());
+
+    harness
+        .handle
+        .database
+        .transaction(create_five_binary_inputs_with_odd_indices_true);
 
     const READ_G1_V2_1_TO_3: &[u8] = &[0xC0, 0x01, 0x01, 0x02, 0x01, 0x01, 0x00, 0x03, 0x00];
     harness.test_request_response(
         READ_G1_V2_1_TO_3,
         &[
             0xC0, 0x81, 0x80, 0x00, 0x01, 0x02, 0x01, 0x01, 0x00, 0x03, 0x00, 0x81, 0x01, 0x81,
+        ],
+    );
+    harness.check_events(&[]);
+}
+
+#[test]
+fn can_read_two_byte_range_for_default_variation() {
+    let mut harness = new_harness(get_default_config());
+
+    harness
+        .handle
+        .database
+        .transaction(create_five_binary_inputs_with_odd_indices_true);
+
+    const READ_G1_V0_1_TO_3: &[u8] = &[0xC0, 0x01, 0x01, 0x00, 0x01, 0x01, 0x00, 0x03, 0x00];
+    harness.test_request_response(
+        READ_G1_V0_1_TO_3,
+        // the response here is g1v1, packed format, the bit pattern is 0b101 == 0x05
+        &[
+            0xC0, 0x81, 0x80, 0x00, 0x01, 0x01, 0x01, 0x01, 0x00, 0x03, 0x00, 0x05,
         ],
     );
     harness.check_events(&[]);


### PR DESCRIPTION
Responding to range scans is subset level 3, so the conformance test suite does NOT test qualifiers 0x00 and 0x01.

When processing a range scan, the outstation was not copying the `current` value into the `selected` value.  This caused the outstation to respond to ranges with whatever value was previously in the `selected` cell.

This PR adds:

1) Unit tests that prove the issue existed
2) Uniform way of processing "all objects" and "ranges" so that they always use the same code path.