### PR TITLE
Make response timeout associaton-specific

### DIFF
--- a/dnp3/examples/master_serial.rs
+++ b/dnp3/examples/master_serial.rs
@@ -22,7 +22,6 @@ fn get_serial_port_path() -> String {
 fn get_master_channel_config() -> Result<MasterChannelConfig, Box<dyn std::error::Error>> {
     let mut config = MasterChannelConfig::new(EndpointAddress::from(1)?);
     config.decode_level = AppDecodeLevel::ObjectValues.into();
-    config.response_timeout = Timeout::from_secs(1)?;
     Ok(config)
 }
 
@@ -45,6 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create the association
     let mut config = AssociationConfig::default();
+    config.response_timeout = Timeout::from_secs(1)?;
     config.auto_time_sync = Some(TimeSyncProcedure::Lan);
     config.keep_alive_timeout = Some(Duration::from_secs(60));
     let mut association = master

--- a/dnp3/src/master/association.rs
+++ b/dnp3/src/master/association.rs
@@ -27,7 +27,7 @@ use crate::util::Smallest;
 /// Configuration for a master association
 #[derive(Debug, Copy, Clone)]
 pub struct AssociationConfig {
-    /// timeouts for response on this association
+    /// timeout for responses on this association
     pub response_timeout: Timeout,
     /// The event classes to disable on startup
     pub disable_unsol_classes: EventClasses,

--- a/dnp3/src/master/association.rs
+++ b/dnp3/src/master/association.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use xxhash_rust::xxh64::xxh64;
 
 use crate::app::parse::parser::{HeaderCollection, Response};
-use crate::app::Sequence;
 use crate::app::Timestamp;
 use crate::app::{ExponentialBackOff, RetryStrategy};
 use crate::app::{Iin, ResponseHeader};
+use crate::app::{Sequence, Timeout};
 use crate::link::EndpointAddress;
 use crate::master::error::{AssociationError, TaskError, TimeSyncError};
 use crate::master::extract::extract_measurements;
@@ -27,6 +27,8 @@ use crate::util::Smallest;
 /// Configuration for a master association
 #[derive(Debug, Copy, Clone)]
 pub struct AssociationConfig {
+    /// timeouts for response on this association
+    pub response_timeout: Timeout,
     /// The event classes to disable on startup
     pub disable_unsol_classes: EventClasses,
     /// The event classes to enable on startup
@@ -66,6 +68,7 @@ impl AssociationConfig {
         event_scan_on_events_available: EventClasses,
     ) -> Self {
         Self {
+            response_timeout: Timeout::default(),
             disable_unsol_classes,
             enable_unsol_classes,
             startup_integrity_classes,
@@ -82,6 +85,7 @@ impl AssociationConfig {
     /// at the beginning of the communications session.
     pub fn quiet() -> Self {
         Self {
+            response_timeout: Timeout::default(),
             disable_unsol_classes: EventClasses::none(),
             enable_unsol_classes: EventClasses::none(),
             startup_integrity_classes: Classes::none(),
@@ -98,6 +102,7 @@ impl AssociationConfig {
 impl Default for AssociationConfig {
     fn default() -> Self {
         Self {
+            response_timeout: Timeout::default(),
             disable_unsol_classes: EventClasses::all(),
             enable_unsol_classes: EventClasses::all(),
             startup_integrity_classes: Classes::all(),
@@ -270,6 +275,7 @@ impl LastUnsolFragment {
 /// and responses for multiple associations (i.e. multi-drop).
 pub(crate) struct Association {
     address: EndpointAddress,
+    response_timeout: Timeout,
     seq: Sequence,
     last_unsol_frag: Option<LastUnsolFragment>,
     request_queue: VecDeque<Task>,
@@ -292,6 +298,7 @@ impl Association {
         assoc_handler: Box<dyn AssociationHandler>,
     ) -> Self {
         Self {
+            response_timeout: config.response_timeout,
             address,
             seq: Sequence::default(),
             last_unsol_frag: None,
@@ -662,6 +669,13 @@ impl AssociationMap {
         Self {
             map: BTreeMap::new(),
             priority: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn get_timeout(&self, address: EndpointAddress) -> Result<Timeout, TaskError> {
+        match self.map.get(&address) {
+            Some(x) => Ok(x.response_timeout),
+            None => Err(TaskError::NoSuchAssociation(address)),
         }
     }
 

--- a/dnp3/src/master/handler.rs
+++ b/dnp3/src/master/handler.rs
@@ -42,8 +42,6 @@ pub struct MasterChannelConfig {
     pub master_address: EndpointAddress,
     /// Decode-level for DNP3 objects
     pub decode_level: DecodeLevel,
-    /// Response timeout
-    pub response_timeout: Timeout,
     /// TX buffer size
     ///
     /// Must be at least 249.
@@ -60,7 +58,6 @@ impl MasterChannelConfig {
         Self {
             master_address,
             decode_level: DecodeLevel::nothing(),
-            response_timeout: Timeout::default(),
             tx_buffer_size: MasterSession::DEFAULT_TX_BUFFER_SIZE,
             rx_buffer_size: MasterSession::DEFAULT_RX_BUFFER_SIZE,
         }

--- a/dnp3/src/master/session.rs
+++ b/dnp3/src/master/session.rs
@@ -9,7 +9,6 @@ use crate::app::parse::parser::Response;
 use crate::app::ControlField;
 use crate::app::Sequence;
 use crate::app::Shutdown;
-use crate::app::Timeout;
 use crate::decode::DecodeLevel;
 use crate::link::error::LinkError;
 use crate::link::EndpointAddress;
@@ -28,7 +27,6 @@ use crate::util::phys::PhysLayer;
 pub(crate) struct MasterSession {
     enabled: bool,
     decode_level: DecodeLevel,
-    timeout: Timeout,
     associations: AssociationMap,
     messages: Receiver<Message>,
     tx_buffer: Buffer,
@@ -86,7 +84,6 @@ impl MasterSession {
     pub(crate) fn new(
         enabled: bool,
         decode_level: DecodeLevel,
-        response_timeout: Timeout,
         tx_buffer_size: usize,
         messages: Receiver<Message>,
     ) -> Self {
@@ -100,7 +97,6 @@ impl MasterSession {
         Self {
             enabled,
             decode_level,
-            timeout: response_timeout,
             associations: AssociationMap::new(),
             messages,
             tx_buffer: Buffer::new(tx_buffer_size),
@@ -365,12 +361,13 @@ impl MasterSession {
                 }
             };
 
-            let deadline = self.timeout.deadline_from_now();
+            let timeout = self.associations.get_timeout(destination)?;
+            let deadline = timeout.deadline_from_now();
 
             loop {
                 crate::tokio::select! {
                     _ = crate::tokio::time::sleep_until(deadline) => {
-                        tracing::warn!("no response within timeout: {}", self.timeout);
+                        tracing::warn!("no response within timeout: {}", timeout);
                         task.on_task_error(self.associations.get_mut(destination).ok(), TaskError::ResponseTimeout);
                         return Err(TaskError::ResponseTimeout);
                     }
@@ -519,12 +516,13 @@ impl MasterSession {
 
         // read responses until we get a FIN or an error occurs
         loop {
-            let deadline = self.timeout.deadline_from_now();
+            let timeout = self.associations.get_timeout(destination)?;
+            let deadline = timeout.deadline_from_now();
 
             loop {
                 crate::tokio::select! {
                     _ = crate::tokio::time::sleep_until(deadline) => {
-                            tracing::warn!("no response within timeout: {}", self.timeout);
+                            tracing::warn!("no response within timeout: {}", timeout);
                             return Err(TaskError::ResponseTimeout);
                     }
                     x = reader.read(io, self.decode_level) => {
@@ -756,10 +754,11 @@ impl MasterSession {
             .await?;
 
         loop {
+            let timeout = self.associations.get_timeout(destination)?;
             // Wait for something on the link
             crate::tokio::select! {
-                _ = crate::tokio::time::sleep_until(self.timeout.deadline_from_now()) => {
-                    tracing::warn!("no response within timeout: {}", self.timeout);
+                _ = crate::tokio::time::sleep_until(timeout.deadline_from_now()) => {
+                    tracing::warn!("no response within timeout: {}", timeout);
                     return Err(TaskError::ResponseTimeout);
                 }
                 x = reader.read(io, self.decode_level) => {

--- a/dnp3/src/master/tests/harness/mod.rs
+++ b/dnp3/src/master/tests/harness/mod.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::task::Poll;
 
-use crate::app::MaybeAsync;
+use crate::app::{MaybeAsync, Timeout};
 use crate::decode::AppDecodeLevel;
 use crate::link::header::{FrameInfo, FrameType};
 use crate::link::{EndpointAddress, LinkErrorMode};
@@ -18,8 +18,11 @@ use crate::util::phys::PhysLayer;
 pub(crate) mod requests;
 
 pub(crate) fn create_association(
-    config: AssociationConfig,
+    mut config: AssociationConfig,
 ) -> TestHarness<impl Future<Output = RunError>> {
+    // use a 1 second timeout for all tests
+    config.response_timeout = Timeout::from_secs(1).unwrap();
+
     let (io, io_handle) = io::mock();
 
     let mut io = PhysLayer::Mock(io);
@@ -31,7 +34,6 @@ pub(crate) fn create_association(
     let mut runner = MasterSession::new(
         true,
         AppDecodeLevel::ObjectValues.into(),
-        crate::app::Timeout::from_secs(1).unwrap(),
         MasterSession::MIN_TX_BUFFER_SIZE,
         rx,
     );

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -75,13 +75,7 @@ impl MasterTask {
         listener: Box<dyn Listener<PortState>>,
     ) -> (Self, MasterChannel) {
         let (tx, rx) = crate::util::channel::request_channel();
-        let session = MasterSession::new(
-            false,
-            config.decode_level,
-            config.response_timeout,
-            config.tx_buffer_size,
-            rx,
-        );
+        let session = MasterSession::new(false, config.decode_level, config.tx_buffer_size, rx);
         let (reader, writer) = crate::transport::create_master_transport_layer(
             // serial ports always discard link parsing errors
             LinkErrorMode::Discard,

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -111,13 +111,7 @@ impl MasterTask {
         listener: Box<dyn Listener<ClientState>>,
     ) -> (Self, MasterChannel) {
         let (tx, rx) = crate::util::channel::request_channel();
-        let session = MasterSession::new(
-            false,
-            config.decode_level,
-            config.response_timeout,
-            config.tx_buffer_size,
-            rx,
-        );
+        let session = MasterSession::new(false, config.decode_level, config.tx_buffer_size, rx);
         let (reader, writer) = crate::transport::create_master_transport_layer(
             link_error_mode,
             config.master_address,

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -529,11 +529,17 @@ fn define_association_config(
     let auto_integrity_scan_on_buffer_overflow =
         Name::create("auto_integrity_scan_on_buffer_overflow")?;
     let max_queued_user_requests = Name::create("max_queued_user_requests")?;
+    let response_timeout = Name::create("response_timeout")?;
     let association_config = lib.declare_function_argument_struct("association_config")?;
 
     let association_config = lib
         .define_function_argument_struct(association_config)?
         .doc("Association configuration")?
+        .add(
+            response_timeout.clone(),
+            DurationType::Milliseconds,
+            "Timeout for receiving a response on this association"
+        )?
         .add(
             "disable_unsol_classes",
           event_classes.clone(),
@@ -577,6 +583,7 @@ fn define_association_config(
         )?
         .end_fields()?
         .begin_initializer("init", InitializerType::Normal, "Initialize the configuration with the specified values")?
+        .default(&response_timeout, Duration::from_secs(5))?
         .default_variant(&auto_time_sync, "none")?
         .default_struct(&auto_tasks_retry_strategy)?
         .default(&keep_alive_timeout, Duration::from_secs(60))?
@@ -632,7 +639,7 @@ fn define_master_channel_config(
     let config = lib.declare_function_argument_struct("master_channel_config")?;
 
     let decode_level = Name::create("decode_level")?;
-    let response_timeout = Name::create("response_timeout")?;
+
     let tx_buffer_size = Name::create("tx_buffer_size")?;
     let rx_buffer_size = Name::create("rx_buffer_size")?;
 
@@ -640,17 +647,11 @@ fn define_master_channel_config(
         .doc("Generic configuration for a MasterChannel")?
         .add("address", Primitive::U16, "Local DNP3 data-link address")?
         .add(decode_level.clone(), shared.decode_level.clone(), "Decoding level for this master. You can modify this later on with {class:master_channel.set_decode_level()}.")?
-        .add(
-            response_timeout.clone(),
-            DurationType::Milliseconds,
-            "Timeout for receiving a response"
-        )?
         .add(tx_buffer_size.clone(), Primitive::U16, doc("TX buffer size").details("Must be at least 249"))?
         .add(rx_buffer_size.clone(), Primitive::U16, doc("RX buffer size").details("Must be at least 2048"))?
         .end_fields()?
         .begin_initializer("init", InitializerType::Normal, "Initialize {struct:master_channel_config} to default values")?
         .default_struct(&decode_level)?
-        .default(&response_timeout, Duration::from_secs(5))?
         .default(&tx_buffer_size, NumberValue::U16(2048))?
         .default(&rx_buffer_size, NumberValue::U16(2048))?
         .end_initializer()?

--- a/ffi/dnp3-schema/src/shared.rs
+++ b/ffi/dnp3-schema/src/shared.rs
@@ -40,6 +40,10 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<SharedDefinitions> {
             "param_exception",
             ExceptionType::UncheckedException,
         )?
+        .add_error(
+            "invalid_timeout",
+            "The supplied timeout value is too small or too large",
+        )?
         .add_error("null_parameter", "Null parameter")?
         .add_error(
             "association_does_not_exist",

--- a/guide/docs/api/master/association_config.mdx
+++ b/guide/docs/api/master/association_config.mdx
@@ -10,6 +10,7 @@ import TabItem from '@theme/TabItem';
 
 The `AssociationConfig` struct provides the configuration information you need to communicate with a particular outstation on the communication channel, including:
 
+* Timeout for responses on this association
 * Startup handshaking
 * If and how to perform time synchronization
 * Per-association task queue size

--- a/guide/docs/api/master/channel_config.mdx
+++ b/guide/docs/api/master/channel_config.mdx
@@ -12,8 +12,11 @@ The `MasterChannelConfig` struct contains the following generic settings that ar
 
 * Master station address (different addresses may be used for different channels)
 * Initial decoding level
-* Timeout for responses from each outstation
 * Transmit and receive buffer sizes
+
+:::note
+The timeout for responses is configured for each association individually. This is useful if the outstation is a gateway services with varying latency.
+:::
 
 The constructor takes the master address and has reasonable defaults for all other settings. The default response timeout is 5 seconds; you may need to increase it for high-latency communication links. You should only need to adjust the default buffer size of 2,048 bytes if an outstation has a non-standard configuration.
 


### PR DESCRIPTION
Moves this timeout parameter from `MasterChannelConfig` to `AssociationConfig`.

This makes it possible to use different timeouts for different associations.

Resolves https://github.com/stepfunc/dnp3/issues/145