### PR TITLE
fine-grained DB locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.0.0 ###
 * Public API changes (affects both Rust and bindings):
+  * User-controlled DB locking in callbacks. See [#189](https://github.com/stepfunc/dnp3/pull/189).
   * Multiple renamings to more closely follow the spec. See [#164](https://github.com/stepfunc/dnp3/pull/164) and others.
     Notably the following:
     * Binary -> BinaryInput

--- a/conformance/src/main/scala/io/stepfunc/conformance/dnp3/CustomOutstationApplication.scala
+++ b/conformance/src/main/scala/io/stepfunc/conformance/dnp3/CustomOutstationApplication.scala
@@ -30,32 +30,37 @@ class CustomOutstationApplication(val isLocalControl: Boolean) extends Outstatio
 
   override def warmRestart: RestartDelay = RestartDelay.notSupported()
 
-  override def freezeCountersAll(freezeType: FreezeType, database: Database): FreezeResult = {
-    for (i <- 0 to 9) {
-      val currentCounter = database.getCounter(ushort(i))
-      database.updateFrozenCounter(new FrozenCounter(currentCounter.index, currentCounter.value, currentCounter.flags, currentCounter.time), UpdateOptions.detectEvent())
-      if (freezeType == FreezeType.FREEZE_AND_CLEAR) {
-        currentCounter.value = uint(0)
-        database.updateCounter(currentCounter, UpdateOptions.detectEvent())
+  override def freezeCountersAll(freezeType: FreezeType, database: DatabaseHandle): FreezeResult = {
+    database.transaction(db => {
+      for (i <- 0 to 9) {
+        val currentCounter = db.getCounter(ushort(i))
+        db.updateFrozenCounter(new FrozenCounter(currentCounter.index, currentCounter.value, currentCounter.flags, currentCounter.time), UpdateOptions.detectEvent())
+        if (freezeType == FreezeType.FREEZE_AND_CLEAR) {
+          currentCounter.value = uint(0)
+          db.updateCounter(currentCounter, UpdateOptions.detectEvent())
+        }
       }
-    }
+    })
+
 
     FreezeResult.OK
   }
 
-  override def freezeCountersRange(start: UShort, stop: UShort, freezeType: FreezeType, database: Database): FreezeResult = {
-    if (start.intValue() > 9 || stop.intValue() > 9) {
-      return FreezeResult.PARAMETER_ERROR
-    }
-
-    for (i <- start.intValue() to stop.intValue()) {
-      val currentCounter = database.getCounter(ushort(i))
-      database.updateFrozenCounter(new FrozenCounter(currentCounter.index, currentCounter.value, currentCounter.flags, currentCounter.time), UpdateOptions.detectEvent())
-      if (freezeType == FreezeType.FREEZE_AND_CLEAR) {
-        currentCounter.value = uint(0)
-        database.updateCounter(currentCounter, UpdateOptions.detectEvent())
+  override def freezeCountersRange(start: UShort, stop: UShort, freezeType: FreezeType, database: DatabaseHandle): FreezeResult = {
+    database.transaction(db => {
+      if (start.intValue() > 9 || stop.intValue() > 9) {
+        return FreezeResult.PARAMETER_ERROR
       }
-    }
+
+      for (i <- start.intValue() to stop.intValue()) {
+        val currentCounter = db.getCounter(ushort(i))
+        db.updateFrozenCounter(new FrozenCounter(currentCounter.index, currentCounter.value, currentCounter.flags, currentCounter.time), UpdateOptions.detectEvent())
+        if (freezeType == FreezeType.FREEZE_AND_CLEAR) {
+          currentCounter.value = uint(0)
+          db.updateCounter(currentCounter, UpdateOptions.detectEvent())
+        }
+      }
+    })
 
     FreezeResult.OK
   }

--- a/conformance/src/main/scala/io/stepfunc/conformance/dnp3/QueuedControlHandler.scala
+++ b/conformance/src/main/scala/io/stepfunc/conformance/dnp3/QueuedControlHandler.scala
@@ -16,43 +16,43 @@ class QueuedControlHandler(val binaryOutputsDisabled: Boolean, val analogOutputs
 
   override def endFragment(): Unit = {}
 
-  override def selectG12v1(control: Group12Var1, index: UShort, database: Database): CommandStatus = {
+  override def selectG12v1(control: Group12Var1, index: UShort, database: DatabaseHandle): CommandStatus = {
     checkBinaryOutputCommand(control, index, operate = false)
   }
 
-  override def selectG41v1(control: Int, index: UShort, database: Database): CommandStatus = {
+  override def selectG41v1(control: Int, index: UShort, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control.toDouble, index, operate = false, database)
   }
 
-  override def selectG41v2(control: Short, index: UShort, database: Database): CommandStatus = {
+  override def selectG41v2(control: Short, index: UShort, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control.toDouble, index, operate = false, database)
   }
 
-  override def selectG41v3(control: Float, index: UShort, database: Database): CommandStatus = {
+  override def selectG41v3(control: Float, index: UShort, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control.toDouble, index, operate = false, database)
   }
 
-  override def selectG41v4(control: Double, index: UShort, database: Database): CommandStatus = {
+  override def selectG41v4(control: Double, index: UShort, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control, index, operate = false, database)
   }
 
-  override def operateG12v1(control: Group12Var1, index: UShort, opType: OperateType, database: Database): CommandStatus = {
+  override def operateG12v1(control: Group12Var1, index: UShort, opType: OperateType, database: DatabaseHandle): CommandStatus = {
     checkBinaryOutputCommand(control, index, operate = true)
   }
 
-  override def operateG41v1(control: Int, index: UShort, opType: OperateType, database: Database): CommandStatus = {
+  override def operateG41v1(control: Int, index: UShort, opType: OperateType, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control.toDouble, index, operate = true, database)
   }
 
-  override def operateG41v2(control: Short, index: UShort, opType: OperateType, database: Database): CommandStatus = {
+  override def operateG41v2(control: Short, index: UShort, opType: OperateType, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control.toDouble, index, operate = true, database)
   }
 
-  override def operateG41v3(control: Float, index: UShort, opType: OperateType, database: Database): CommandStatus = {
+  override def operateG41v3(control: Float, index: UShort, opType: OperateType, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control.toDouble, index, operate = true, database)
   }
 
-  override def operateG41v4(control: Double, index: UShort, opType: OperateType, database: Database): CommandStatus = {
+  override def operateG41v4(control: Double, index: UShort, opType: OperateType, database: DatabaseHandle): CommandStatus = {
     checkAnalogOutputCommand(control, index, operate = true, database)
   }
 
@@ -233,7 +233,7 @@ class QueuedControlHandler(val binaryOutputsDisabled: Boolean, val analogOutputs
     result
   }
 
-  private def checkAnalogOutputCommand(value: Double, index: UShort, operate: Boolean, database: Database) : CommandStatus = {
+  private def checkAnalogOutputCommand(value: Double, index: UShort, operate: Boolean, database: DatabaseHandle) : CommandStatus = {
     if (analogOutputsDisabled) return CommandStatus.NOT_SUPPORTED
 
     val result = index.intValue() match {
@@ -249,7 +249,7 @@ class QueuedControlHandler(val binaryOutputsDisabled: Boolean, val analogOutputs
 
       // Update the associated Analog Output Status
       val flags = new Flags(Flag.ONLINE)
-      database.updateAnalogOutputStatus(new AnalogOutputStatus(index, value, flags, Timestamp.invalidTimestamp()), UpdateOptions.detectEvent())
+      database.transaction(db => db.updateAnalogOutputStatus(new AnalogOutputStatus(index, value, flags, Timestamp.invalidTimestamp()), UpdateOptions.detectEvent()))
     }
 
     result

--- a/conformance/src/main/scala/io/stepfunc/conformance/dnp3/QueuedControlHandler.scala
+++ b/conformance/src/main/scala/io/stepfunc/conformance/dnp3/QueuedControlHandler.scala
@@ -14,7 +14,7 @@ class QueuedControlHandler(val binaryOutputsDisabled: Boolean, val analogOutputs
 
   override def beginFragment(): Unit = {}
 
-  override def endFragment(): Unit = {}
+  override def endFragment(database: DatabaseHandle): Unit = {}
 
   override def selectG12v1(control: Group12Var1, index: UShort, database: DatabaseHandle): CommandStatus = {
     checkBinaryOutputCommand(control, index, operate = false)

--- a/dnp3/examples/outstation.rs
+++ b/dnp3/examples/outstation.rs
@@ -67,7 +67,7 @@ impl ControlSupport<Group12Var1> for ExampleControlHandler {
         &mut self,
         control: Group12Var1,
         index: u16,
-        _database: &mut Database,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         if index < 10
             && (control.code.op_type == OpType::LatchOn || control.code.op_type == OpType::LatchOff)
@@ -83,17 +83,19 @@ impl ControlSupport<Group12Var1> for ExampleControlHandler {
         control: Group12Var1,
         index: u16,
         _op_type: OperateType,
-        database: &mut Database,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         if index < 10
             && (control.code.op_type == OpType::LatchOn || control.code.op_type == OpType::LatchOff)
         {
             let status = control.code.op_type == OpType::LatchOn;
-            database.update(
-                index,
-                &BinaryOutputStatus::new(status, Flags::ONLINE, get_current_time()),
-                UpdateOptions::detect_event(),
-            );
+            database.transaction(|db| {
+                db.update(
+                    index,
+                    &BinaryOutputStatus::new(status, Flags::ONLINE, get_current_time()),
+                    UpdateOptions::detect_event(),
+                );
+            });
             CommandStatus::Success
         } else {
             CommandStatus::NotSupported
@@ -114,14 +116,16 @@ impl ExampleControlHandler {
         &self,
         value: f64,
         index: u16,
-        database: &mut Database,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         if index < 10 {
-            database.update(
-                index,
-                &AnalogOutputStatus::new(value, Flags::ONLINE, get_current_time()),
-                UpdateOptions::detect_event(),
-            );
+            database.transaction(|db| {
+                db.update(
+                    index,
+                    &AnalogOutputStatus::new(value, Flags::ONLINE, get_current_time()),
+                    UpdateOptions::detect_event(),
+                );
+            });
             CommandStatus::Success
         } else {
             CommandStatus::NotSupported
@@ -134,7 +138,7 @@ impl ControlSupport<Group41Var1> for ExampleControlHandler {
         &mut self,
         _control: Group41Var1,
         index: u16,
-        _database: &mut Database,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.select_analog_output(index)
     }
@@ -144,7 +148,7 @@ impl ControlSupport<Group41Var1> for ExampleControlHandler {
         control: Group41Var1,
         index: u16,
         _op_type: OperateType,
-        database: &mut Database,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.operate_analog_output(control.value as f64, index, database)
     }
@@ -155,7 +159,7 @@ impl ControlSupport<Group41Var2> for ExampleControlHandler {
         &mut self,
         _control: Group41Var2,
         index: u16,
-        _database: &mut Database,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.select_analog_output(index)
     }
@@ -165,7 +169,7 @@ impl ControlSupport<Group41Var2> for ExampleControlHandler {
         control: Group41Var2,
         index: u16,
         _op_type: OperateType,
-        database: &mut Database,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.operate_analog_output(control.value as f64, index, database)
     }
@@ -176,7 +180,7 @@ impl ControlSupport<Group41Var3> for ExampleControlHandler {
         &mut self,
         _control: Group41Var3,
         index: u16,
-        _database: &mut Database,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.select_analog_output(index)
     }
@@ -186,7 +190,7 @@ impl ControlSupport<Group41Var3> for ExampleControlHandler {
         control: Group41Var3,
         index: u16,
         _op_type: OperateType,
-        database: &mut Database,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.operate_analog_output(control.value as f64, index, database)
     }
@@ -197,7 +201,7 @@ impl ControlSupport<Group41Var4> for ExampleControlHandler {
         &mut self,
         _control: Group41Var4,
         index: u16,
-        _database: &mut Database,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.select_analog_output(index)
     }
@@ -207,7 +211,7 @@ impl ControlSupport<Group41Var4> for ExampleControlHandler {
         control: Group41Var4,
         index: u16,
         _op_type: OperateType,
-        database: &mut Database,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.operate_analog_output(control.value, index, database)
     }

--- a/dnp3/src/outstation/control/collection.rs
+++ b/dnp3/src/outstation/control/collection.rs
@@ -7,7 +7,7 @@ use crate::app::parse::traits::{FixedSizeVariation, Index};
 use crate::app::{QualifierCode, Variation};
 use crate::outstation::control::control_type::ControlType;
 use crate::outstation::control::prefix::PrefixWriter;
-use crate::outstation::database::Database;
+use crate::outstation::database::DatabaseHandle;
 use crate::outstation::traits::{ControlHandler, ControlSupport, OperateType};
 use crate::util::cursor::{WriteCursor, WriteError};
 
@@ -48,7 +48,7 @@ impl<'a> ControlSupport<Group12Var1> for ControlTransaction<'a> {
         &mut self,
         control: Group12Var1,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -59,7 +59,7 @@ impl<'a> ControlSupport<Group12Var1> for ControlTransaction<'a> {
         control: Group12Var1,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -71,7 +71,7 @@ impl<'a> ControlSupport<Group41Var1> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var1,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -82,7 +82,7 @@ impl<'a> ControlSupport<Group41Var1> for ControlTransaction<'a> {
         control: Group41Var1,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -94,7 +94,7 @@ impl<'a> ControlSupport<Group41Var2> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var2,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -105,7 +105,7 @@ impl<'a> ControlSupport<Group41Var2> for ControlTransaction<'a> {
         control: Group41Var2,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -117,7 +117,7 @@ impl<'a> ControlSupport<Group41Var3> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var3,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -128,7 +128,7 @@ impl<'a> ControlSupport<Group41Var3> for ControlTransaction<'a> {
         control: Group41Var3,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -140,7 +140,7 @@ impl<'a> ControlSupport<Group41Var4> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var4,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -151,7 +151,7 @@ impl<'a> ControlSupport<Group41Var4> for ControlTransaction<'a> {
         control: Group41Var4,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -277,7 +277,7 @@ impl<'a> ControlCollection<'a> {
         &self,
         cursor: &mut WriteCursor,
         transaction: &mut ControlTransaction,
-        database: &mut Database,
+        database: &DatabaseHandle,
         max_controls_per_request: Option<u16>,
     ) -> Result<CommandStatus, WriteError> {
         let mut num_controls = 0;
@@ -300,7 +300,7 @@ impl<'a> ControlCollection<'a> {
         cursor: &mut WriteCursor,
         operate_type: OperateType,
         transaction: &mut ControlTransaction,
-        database: &mut Database,
+        database: &DatabaseHandle,
         max_controls_per_request: Option<u16>,
     ) -> Result<CommandStatus, WriteError> {
         let mut num_controls = 0;
@@ -322,7 +322,7 @@ impl<'a> ControlCollection<'a> {
     pub(crate) fn operate_no_ack(
         &self,
         transaction: &mut ControlTransaction,
-        database: &mut Database,
+        database: &DatabaseHandle,
         max_controls_per_request: Option<u16>,
     ) {
         let mut num_controls = 0;
@@ -378,7 +378,7 @@ impl<'a> ControlHeader<'a> {
         &self,
         cursor: &mut WriteCursor,
         transaction: &mut ControlTransaction,
-        database: &mut Database,
+        database: &DatabaseHandle,
         max_controls_per_request: Option<u16>,
         num_controls: &mut u16,
     ) -> Result<CommandStatus, WriteError> {
@@ -471,7 +471,7 @@ impl<'a> ControlHeader<'a> {
         operate_type: OperateType,
         cursor: &mut WriteCursor,
         transaction: &mut ControlTransaction,
-        database: &mut Database,
+        database: &DatabaseHandle,
         max_controls_per_request: Option<u16>,
         num_controls: &mut u16,
     ) -> Result<CommandStatus, WriteError> {
@@ -572,7 +572,7 @@ impl<'a> ControlHeader<'a> {
     fn operate_no_ack(
         &self,
         transaction: &mut ControlTransaction,
-        database: &mut Database,
+        database: &DatabaseHandle,
         max_controls_per_request: Option<u16>,
         num_controls: &mut u16,
     ) {
@@ -670,7 +670,7 @@ where
 fn select_header_with_response<I, V>(
     cursor: &mut WriteCursor,
     seq: &CountSequence<Prefix<I, V>>,
-    database: &mut Database,
+    database: &DatabaseHandle,
     transaction: &mut ControlTransaction,
     max_controls_per_request: Option<u16>,
     num_controls: &mut u16,
@@ -698,7 +698,7 @@ where
 fn operate_header_with_response<I, V>(
     cursor: &mut WriteCursor,
     seq: &CountSequence<Prefix<I, V>>,
-    database: &mut Database,
+    database: &DatabaseHandle,
     operate_type: OperateType,
     transaction: &mut ControlTransaction,
     max_controls_per_request: Option<u16>,
@@ -730,7 +730,7 @@ where
 
 fn operate_header_no_ack<I, V>(
     seq: &CountSequence<Prefix<I, V>>,
-    database: &mut Database,
+    database: &DatabaseHandle,
     transaction: &mut ControlTransaction,
     max_controls_per_request: Option<u16>,
     num_controls: &mut u16,

--- a/dnp3/src/outstation/control/collection.rs
+++ b/dnp3/src/outstation/control/collection.rs
@@ -48,7 +48,7 @@ impl<'a> ControlSupport<Group12Var1> for ControlTransaction<'a> {
         &mut self,
         control: Group12Var1,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -59,7 +59,7 @@ impl<'a> ControlSupport<Group12Var1> for ControlTransaction<'a> {
         control: Group12Var1,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -71,7 +71,7 @@ impl<'a> ControlSupport<Group41Var1> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var1,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -82,7 +82,7 @@ impl<'a> ControlSupport<Group41Var1> for ControlTransaction<'a> {
         control: Group41Var1,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -94,7 +94,7 @@ impl<'a> ControlSupport<Group41Var2> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var2,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -105,7 +105,7 @@ impl<'a> ControlSupport<Group41Var2> for ControlTransaction<'a> {
         control: Group41Var2,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -117,7 +117,7 @@ impl<'a> ControlSupport<Group41Var3> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var3,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -128,7 +128,7 @@ impl<'a> ControlSupport<Group41Var3> for ControlTransaction<'a> {
         control: Group41Var3,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -140,7 +140,7 @@ impl<'a> ControlSupport<Group41Var4> for ControlTransaction<'a> {
         &mut self,
         control: Group41Var4,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.select(control, index, database)
@@ -151,7 +151,7 @@ impl<'a> ControlSupport<Group41Var4> for ControlTransaction<'a> {
         control: Group41Var4,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.start();
         self.handler.operate(control, index, op_type, database)
@@ -277,7 +277,7 @@ impl<'a> ControlCollection<'a> {
         &self,
         cursor: &mut WriteCursor,
         transaction: &mut ControlTransaction,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         max_controls_per_request: Option<u16>,
     ) -> Result<CommandStatus, WriteError> {
         let mut num_controls = 0;
@@ -300,7 +300,7 @@ impl<'a> ControlCollection<'a> {
         cursor: &mut WriteCursor,
         operate_type: OperateType,
         transaction: &mut ControlTransaction,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         max_controls_per_request: Option<u16>,
     ) -> Result<CommandStatus, WriteError> {
         let mut num_controls = 0;
@@ -322,7 +322,7 @@ impl<'a> ControlCollection<'a> {
     pub(crate) fn operate_no_ack(
         &self,
         transaction: &mut ControlTransaction,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         max_controls_per_request: Option<u16>,
     ) {
         let mut num_controls = 0;
@@ -378,7 +378,7 @@ impl<'a> ControlHeader<'a> {
         &self,
         cursor: &mut WriteCursor,
         transaction: &mut ControlTransaction,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         max_controls_per_request: Option<u16>,
         num_controls: &mut u16,
     ) -> Result<CommandStatus, WriteError> {
@@ -471,7 +471,7 @@ impl<'a> ControlHeader<'a> {
         operate_type: OperateType,
         cursor: &mut WriteCursor,
         transaction: &mut ControlTransaction,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         max_controls_per_request: Option<u16>,
         num_controls: &mut u16,
     ) -> Result<CommandStatus, WriteError> {
@@ -572,7 +572,7 @@ impl<'a> ControlHeader<'a> {
     fn operate_no_ack(
         &self,
         transaction: &mut ControlTransaction,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         max_controls_per_request: Option<u16>,
         num_controls: &mut u16,
     ) {
@@ -670,7 +670,7 @@ where
 fn select_header_with_response<I, V>(
     cursor: &mut WriteCursor,
     seq: &CountSequence<Prefix<I, V>>,
-    database: &DatabaseHandle,
+    database: &mut DatabaseHandle,
     transaction: &mut ControlTransaction,
     max_controls_per_request: Option<u16>,
     num_controls: &mut u16,
@@ -698,7 +698,7 @@ where
 fn operate_header_with_response<I, V>(
     cursor: &mut WriteCursor,
     seq: &CountSequence<Prefix<I, V>>,
-    database: &DatabaseHandle,
+    database: &mut DatabaseHandle,
     operate_type: OperateType,
     transaction: &mut ControlTransaction,
     max_controls_per_request: Option<u16>,
@@ -730,7 +730,7 @@ where
 
 fn operate_header_no_ack<I, V>(
     seq: &CountSequence<Prefix<I, V>>,
-    database: &DatabaseHandle,
+    database: &mut DatabaseHandle,
     transaction: &mut ControlTransaction,
     max_controls_per_request: Option<u16>,
     num_controls: &mut u16,

--- a/dnp3/src/outstation/control/collection.rs
+++ b/dnp3/src/outstation/control/collection.rs
@@ -17,19 +17,23 @@ pub(crate) struct ControlTransaction<'a> {
 }
 
 impl<'a> ControlTransaction<'a> {
-    pub(crate) async fn execute<F, R>(handler: &'a mut dyn ControlHandler, mut func: F) -> R
+    pub(crate) async fn execute<F, R>(
+        handler: &'a mut dyn ControlHandler,
+        database: &mut DatabaseHandle,
+        mut func: F,
+    ) -> R
     where
-        F: FnMut(&mut Self) -> R,
+        F: FnMut(&mut Self, &mut DatabaseHandle) -> R,
     {
         let mut tx = ControlTransaction {
             started: false,
             handler,
         };
 
-        let ret = func(&mut tx);
+        let ret = func(&mut tx, database);
 
         if tx.started {
-            tx.handler.end_fragment().get().await
+            tx.handler.end_fragment(database).get().await
         }
 
         ret

--- a/dnp3/src/outstation/control/control_type.rs
+++ b/dnp3/src/outstation/control/control_type.rs
@@ -18,7 +18,7 @@ pub(crate) trait ControlType: Debug {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus;
     /// operate a control on a handler
     fn operate(
@@ -26,7 +26,7 @@ pub(crate) trait ControlType: Debug {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus;
 }
 
@@ -43,7 +43,7 @@ impl ControlType for Group12Var1 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -53,7 +53,7 @@ impl ControlType for Group12Var1 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -72,7 +72,7 @@ impl ControlType for Group41Var1 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -82,7 +82,7 @@ impl ControlType for Group41Var1 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -101,7 +101,7 @@ impl ControlType for Group41Var2 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -111,7 +111,7 @@ impl ControlType for Group41Var2 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -130,7 +130,7 @@ impl ControlType for Group41Var3 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -140,7 +140,7 @@ impl ControlType for Group41Var3 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -159,7 +159,7 @@ impl ControlType for Group41Var4 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -169,7 +169,7 @@ impl ControlType for Group41Var4 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }

--- a/dnp3/src/outstation/control/control_type.rs
+++ b/dnp3/src/outstation/control/control_type.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::app::control::*;
 use crate::outstation::control::collection::ControlTransaction;
-use crate::outstation::database::Database;
+use crate::outstation::database::DatabaseHandle;
 use crate::outstation::traits::ControlSupport;
 use crate::outstation::traits::OperateType;
 
@@ -18,7 +18,7 @@ pub(crate) trait ControlType: Debug {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus;
     /// operate a control on a handler
     fn operate(
@@ -26,7 +26,7 @@ pub(crate) trait ControlType: Debug {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus;
 }
 
@@ -43,7 +43,7 @@ impl ControlType for Group12Var1 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -53,7 +53,7 @@ impl ControlType for Group12Var1 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -72,7 +72,7 @@ impl ControlType for Group41Var1 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -82,7 +82,7 @@ impl ControlType for Group41Var1 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -101,7 +101,7 @@ impl ControlType for Group41Var2 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -111,7 +111,7 @@ impl ControlType for Group41Var2 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -130,7 +130,7 @@ impl ControlType for Group41Var3 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -140,7 +140,7 @@ impl ControlType for Group41Var3 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }
@@ -159,7 +159,7 @@ impl ControlType for Group41Var4 {
         self,
         transaction: &mut ControlTransaction,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.select(self, index, database)
     }
@@ -169,7 +169,7 @@ impl ControlType for Group41Var4 {
         transaction: &mut ControlTransaction,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         transaction.operate(self, index, op_type, database)
     }

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -292,14 +292,14 @@ impl Database {
 
 /// Handle type that can be used to perform transactions on an underlying database
 #[derive(Clone)]
-pub(crate) struct DatabaseHandle {
+pub struct DatabaseHandle {
     inner: Arc<Mutex<Database>>,
     notify: Arc<crate::tokio::sync::Notify>,
 }
 
 impl DatabaseHandle {
     /// Perform a transaction on the underlying database using a closure
-    pub(crate) fn transaction<F, R>(&self, mut func: F) -> R
+    pub fn transaction<F, R>(&self, mut func: F) -> R
     where
         F: FnMut(&mut Database) -> R,
     {

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -298,7 +298,7 @@ pub struct DatabaseHandle {
 }
 
 impl DatabaseHandle {
-    /// Perform a transaction on the underlying database using a closure
+    /// Acquire a mutex on the underlying database and apply a set of changes as a transaction
     pub fn transaction<F, R>(&self, mut func: F) -> R
     where
         F: FnMut(&mut Database) -> R,

--- a/dnp3/src/outstation/mod.rs
+++ b/dnp3/src/outstation/mod.rs
@@ -28,7 +28,7 @@ mod traits;
 #[cfg(test)]
 mod tests;
 
-/// Handel used to control a running outstation task
+/// Handle used to control a running outstation task
 #[derive(Clone)]
 pub struct OutstationHandle {
     database: DatabaseHandle,
@@ -41,7 +41,7 @@ impl OutstationHandle {
         self.database.clone()
     }
 
-    /// Perform a transaction on the underlying database using a closure
+    /// Acquire a mutex on the underlying database and apply a set of changes as a transaction
     pub fn transaction<F, R>(&self, func: F) -> R
     where
         F: FnMut(&mut Database) -> R,

--- a/dnp3/src/outstation/mod.rs
+++ b/dnp3/src/outstation/mod.rs
@@ -36,6 +36,11 @@ pub struct OutstationHandle {
 }
 
 impl OutstationHandle {
+    /// Get a handle to the associated database
+    pub fn get_database_handle(&self) -> DatabaseHandle {
+        self.database.clone()
+    }
+
     /// Perform a transaction on the underlying database using a closure
     pub fn transaction<F, R>(&self, func: F) -> R
     where

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -1458,7 +1458,7 @@ impl OutstationSession {
 
     async fn handle_direct_operate_no_ack(
         &mut self,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         controls: ControlCollection<'_>,
     ) {
         let max_controls_per_request = self.config.max_controls_per_request;
@@ -1518,7 +1518,7 @@ impl OutstationSession {
 
     async fn handle_select(
         &mut self,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         seq: Sequence,
         frame_id: u32,
         controls: ControlCollection<'_>,

--- a/dnp3/src/outstation/tests/harness/application.rs
+++ b/dnp3/src/outstation/tests/harness/application.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::app::Timestamp;
-use crate::outstation::database::Database;
+use crate::outstation::database::DatabaseHandle;
 use crate::outstation::tests::harness::{Event, EventHandle};
 use crate::outstation::traits::{OutstationApplication, RequestError, RestartDelay};
 use crate::outstation::{FreezeIndices, FreezeType};
@@ -60,7 +60,7 @@ impl OutstationApplication for MockOutstationApplication {
         &mut self,
         indices: FreezeIndices,
         freeze_type: FreezeType,
-        _db: &mut Database,
+        _db: &mut DatabaseHandle,
     ) -> Result<(), RequestError> {
         self.events.push(Event::Freeze(indices, freeze_type));
         Ok(())

--- a/dnp3/src/outstation/tests/harness/control.rs
+++ b/dnp3/src/outstation/tests/harness/control.rs
@@ -145,7 +145,7 @@ impl ControlHandler for MockControlHandler {
         self.events.push(Event::BeginControls);
     }
 
-    fn end_fragment(&mut self) -> MaybeAsync<()> {
+    fn end_fragment(&mut self, _: &mut DatabaseHandle) -> MaybeAsync<()> {
         self.events.push(Event::EndControls);
         MaybeAsync::ready(())
     }

--- a/dnp3/src/outstation/tests/harness/control.rs
+++ b/dnp3/src/outstation/tests/harness/control.rs
@@ -1,7 +1,7 @@
 use crate::app::control::CommandStatus;
 use crate::app::variations::{Group12Var1, Group41Var1, Group41Var2, Group41Var3, Group41Var4};
 use crate::app::MaybeAsync;
-use crate::outstation::database::Database;
+use crate::outstation::database::DatabaseHandle;
 use crate::outstation::tests::harness::{Control, Event, EventHandle};
 use crate::outstation::traits::{ControlHandler, ControlSupport, OperateType};
 
@@ -16,7 +16,12 @@ impl MockControlHandler {
 }
 
 impl ControlSupport<Group12Var1> for MockControlHandler {
-    fn select(&mut self, control: Group12Var1, index: u16, _: &mut Database) -> CommandStatus {
+    fn select(
+        &mut self,
+        control: Group12Var1,
+        index: u16,
+        _: &mut DatabaseHandle,
+    ) -> CommandStatus {
         self.events
             .push(Event::Select(Control::G12V1(control, index)));
         CommandStatus::Success
@@ -27,7 +32,7 @@ impl ControlSupport<Group12Var1> for MockControlHandler {
         control: Group12Var1,
         index: u16,
         op_type: OperateType,
-        _: &mut Database,
+        _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
             .push(Event::Operate(Control::G12V1(control, index), op_type));
@@ -36,7 +41,12 @@ impl ControlSupport<Group12Var1> for MockControlHandler {
 }
 
 impl ControlSupport<Group41Var1> for MockControlHandler {
-    fn select(&mut self, control: Group41Var1, index: u16, _: &mut Database) -> CommandStatus {
+    fn select(
+        &mut self,
+        control: Group41Var1,
+        index: u16,
+        _: &mut DatabaseHandle,
+    ) -> CommandStatus {
         self.events
             .push(Event::Select(Control::G41V1(control, index)));
         CommandStatus::Success
@@ -47,7 +57,7 @@ impl ControlSupport<Group41Var1> for MockControlHandler {
         control: Group41Var1,
         index: u16,
         op_type: OperateType,
-        _: &mut Database,
+        _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
             .push(Event::Operate(Control::G41V1(control, index), op_type));
@@ -56,7 +66,12 @@ impl ControlSupport<Group41Var1> for MockControlHandler {
 }
 
 impl ControlSupport<Group41Var2> for MockControlHandler {
-    fn select(&mut self, control: Group41Var2, index: u16, _: &mut Database) -> CommandStatus {
+    fn select(
+        &mut self,
+        control: Group41Var2,
+        index: u16,
+        _: &mut DatabaseHandle,
+    ) -> CommandStatus {
         self.events
             .push(Event::Select(Control::G41V2(control, index)));
         CommandStatus::Success
@@ -67,7 +82,7 @@ impl ControlSupport<Group41Var2> for MockControlHandler {
         control: Group41Var2,
         index: u16,
         op_type: OperateType,
-        _: &mut Database,
+        _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
             .push(Event::Operate(Control::G41V2(control, index), op_type));
@@ -76,7 +91,12 @@ impl ControlSupport<Group41Var2> for MockControlHandler {
 }
 
 impl ControlSupport<Group41Var3> for MockControlHandler {
-    fn select(&mut self, control: Group41Var3, index: u16, _: &mut Database) -> CommandStatus {
+    fn select(
+        &mut self,
+        control: Group41Var3,
+        index: u16,
+        _: &mut DatabaseHandle,
+    ) -> CommandStatus {
         self.events
             .push(Event::Select(Control::G41V3(control, index)));
         CommandStatus::Success
@@ -87,7 +107,7 @@ impl ControlSupport<Group41Var3> for MockControlHandler {
         control: Group41Var3,
         index: u16,
         op_type: OperateType,
-        _: &mut Database,
+        _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
             .push(Event::Operate(Control::G41V3(control, index), op_type));
@@ -96,7 +116,12 @@ impl ControlSupport<Group41Var3> for MockControlHandler {
 }
 
 impl ControlSupport<Group41Var4> for MockControlHandler {
-    fn select(&mut self, control: Group41Var4, index: u16, _: &mut Database) -> CommandStatus {
+    fn select(
+        &mut self,
+        control: Group41Var4,
+        index: u16,
+        _: &mut DatabaseHandle,
+    ) -> CommandStatus {
         self.events
             .push(Event::Select(Control::G41V4(control, index)));
         CommandStatus::Success
@@ -107,7 +132,7 @@ impl ControlSupport<Group41Var4> for MockControlHandler {
         control: Group41Var4,
         index: u16,
         op_type: OperateType,
-        _: &mut Database,
+        _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
             .push(Event::Operate(Control::G41V4(control, index), op_type));

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -5,7 +5,7 @@ use crate::app::RequestHeader;
 use crate::app::Sequence;
 use crate::app::{control::*, Timestamp};
 use crate::app::{FunctionCode, MaybeAsync};
-use crate::outstation::database::{Database, DatabaseHandle};
+use crate::outstation::database::DatabaseHandle;
 
 /// Application-controlled IIN bits
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
@@ -106,7 +106,7 @@ pub trait OutstationApplication: Sync + Send + 'static {
         &mut self,
         _indices: FreezeIndices,
         _freeze_type: FreezeType,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> Result<(), RequestError> {
         Err(RequestError::NotSupported)
     }
@@ -185,7 +185,7 @@ pub trait ControlSupport<T> {
     ///
     /// `CommandStatus` enumeration returning either `CommandStatus::Success` if the operation is
     /// supported, or an error variant otherwise.
-    fn select(&mut self, control: T, index: u16, database: &DatabaseHandle) -> CommandStatus;
+    fn select(&mut self, control: T, index: u16, database: &mut DatabaseHandle) -> CommandStatus;
 
     /// Operate a control point
     ///
@@ -205,7 +205,7 @@ pub trait ControlSupport<T> {
         control: T,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus;
 }
 
@@ -277,7 +277,7 @@ impl ControlSupport<Group12Var1> for DefaultControlHandler {
         &mut self,
         _control: Group12Var1,
         _index: u16,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -287,7 +287,7 @@ impl ControlSupport<Group12Var1> for DefaultControlHandler {
         _control: Group12Var1,
         _index: u16,
         _op_type: OperateType,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -298,7 +298,7 @@ impl ControlSupport<Group41Var1> for DefaultControlHandler {
         &mut self,
         _control: Group41Var1,
         _index: u16,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -308,7 +308,7 @@ impl ControlSupport<Group41Var1> for DefaultControlHandler {
         _control: Group41Var1,
         _index: u16,
         _op_type: OperateType,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -319,7 +319,7 @@ impl ControlSupport<Group41Var2> for DefaultControlHandler {
         &mut self,
         _control: Group41Var2,
         _index: u16,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -329,7 +329,7 @@ impl ControlSupport<Group41Var2> for DefaultControlHandler {
         _control: Group41Var2,
         _index: u16,
         _op_type: OperateType,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -340,7 +340,7 @@ impl ControlSupport<Group41Var3> for DefaultControlHandler {
         &mut self,
         _control: Group41Var3,
         _index: u16,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -350,7 +350,7 @@ impl ControlSupport<Group41Var3> for DefaultControlHandler {
         _control: Group41Var3,
         _index: u16,
         _op_type: OperateType,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -361,7 +361,7 @@ impl ControlSupport<Group41Var4> for DefaultControlHandler {
         &mut self,
         _control: Group41Var4,
         _index: u16,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -371,7 +371,7 @@ impl ControlSupport<Group41Var4> for DefaultControlHandler {
         _control: Group41Var4,
         _index: u16,
         _op_type: OperateType,
-        _database: &DatabaseHandle,
+        _database: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -390,7 +390,7 @@ where
         &mut self,
         seq: CountSequence<Prefix<I, T>>,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         mut func: F,
     ) where
         F: FnMut(T, I),
@@ -417,7 +417,7 @@ where
     fn select<I, F>(
         &mut self,
         seq: CountSequence<Prefix<I, T>>,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
         mut func: F,
     ) where
         F: FnMut(T, I),

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -241,10 +241,14 @@ pub trait ControlHandler:
 {
     /// called before any controls are processed
     fn begin_fragment(&mut self) {}
+
     /// called after all controls have been processed
     ///
+    /// The database handle may be used to process any changes accumulated in response
+    /// to controls using a single lock/unlock cycle as opposed to doing it in every callback.
+    ///
     /// note: This operation may be asynchronous if required
-    fn end_fragment(&mut self) -> MaybeAsync<()> {
+    fn end_fragment(&mut self, _database: &mut DatabaseHandle) -> MaybeAsync<()> {
         MaybeAsync::ready(())
     }
 }

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -5,7 +5,7 @@ use crate::app::RequestHeader;
 use crate::app::Sequence;
 use crate::app::{control::*, Timestamp};
 use crate::app::{FunctionCode, MaybeAsync};
-use crate::outstation::database::Database;
+use crate::outstation::database::{Database, DatabaseHandle};
 
 /// Application-controlled IIN bits
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
@@ -106,7 +106,7 @@ pub trait OutstationApplication: Sync + Send + 'static {
         &mut self,
         _indices: FreezeIndices,
         _freeze_type: FreezeType,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> Result<(), RequestError> {
         Err(RequestError::NotSupported)
     }
@@ -185,7 +185,7 @@ pub trait ControlSupport<T> {
     ///
     /// `CommandStatus` enumeration returning either `CommandStatus::Success` if the operation is
     /// supported, or an error variant otherwise.
-    fn select(&mut self, control: T, index: u16, database: &mut Database) -> CommandStatus;
+    fn select(&mut self, control: T, index: u16, database: &DatabaseHandle) -> CommandStatus;
 
     /// Operate a control point
     ///
@@ -205,7 +205,7 @@ pub trait ControlSupport<T> {
         control: T,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus;
 }
 
@@ -277,7 +277,7 @@ impl ControlSupport<Group12Var1> for DefaultControlHandler {
         &mut self,
         _control: Group12Var1,
         _index: u16,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -287,7 +287,7 @@ impl ControlSupport<Group12Var1> for DefaultControlHandler {
         _control: Group12Var1,
         _index: u16,
         _op_type: OperateType,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -298,7 +298,7 @@ impl ControlSupport<Group41Var1> for DefaultControlHandler {
         &mut self,
         _control: Group41Var1,
         _index: u16,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -308,7 +308,7 @@ impl ControlSupport<Group41Var1> for DefaultControlHandler {
         _control: Group41Var1,
         _index: u16,
         _op_type: OperateType,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -319,7 +319,7 @@ impl ControlSupport<Group41Var2> for DefaultControlHandler {
         &mut self,
         _control: Group41Var2,
         _index: u16,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -329,7 +329,7 @@ impl ControlSupport<Group41Var2> for DefaultControlHandler {
         _control: Group41Var2,
         _index: u16,
         _op_type: OperateType,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -340,7 +340,7 @@ impl ControlSupport<Group41Var3> for DefaultControlHandler {
         &mut self,
         _control: Group41Var3,
         _index: u16,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -350,7 +350,7 @@ impl ControlSupport<Group41Var3> for DefaultControlHandler {
         _control: Group41Var3,
         _index: u16,
         _op_type: OperateType,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -361,7 +361,7 @@ impl ControlSupport<Group41Var4> for DefaultControlHandler {
         &mut self,
         _control: Group41Var4,
         _index: u16,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -371,7 +371,7 @@ impl ControlSupport<Group41Var4> for DefaultControlHandler {
         _control: Group41Var4,
         _index: u16,
         _op_type: OperateType,
-        _database: &mut Database,
+        _database: &DatabaseHandle,
     ) -> CommandStatus {
         self.status
     }
@@ -390,7 +390,7 @@ where
         &mut self,
         seq: CountSequence<Prefix<I, T>>,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
         mut func: F,
     ) where
         F: FnMut(T, I),
@@ -417,7 +417,7 @@ where
     fn select<I, F>(
         &mut self,
         seq: CountSequence<Prefix<I, T>>,
-        database: &mut Database,
+        database: &DatabaseHandle,
         mut func: F,
     ) where
         F: FnMut(T, I),

--- a/ffi/bindings/c/outstation_example.c
+++ b/ffi/bindings/c/outstation_example.c
@@ -142,7 +142,7 @@ void update_analog_output_status_from_control(dnp3_database_t *database, void *c
 // ANCHOR: control_handler
 void begin_fragment(void *context) {}
 
-void end_fragment(void *context) {}
+void end_fragment(dnp3_database_handle_t *database, void *context) {}
 
 dnp3_command_status_t select_g12v1(dnp3_group12_var1_t control, uint16_t index, dnp3_database_handle_t *database, void *context)
 {

--- a/ffi/bindings/c/outstation_example.c
+++ b/ffi/bindings/c/outstation_example.c
@@ -33,9 +33,9 @@ dnp3_restart_delay_t cold_restart(void *context) { return dnp3_restart_delay_sec
 
 dnp3_restart_delay_t warm_restart(void *context) { return dnp3_restart_delay_not_supported(); }
 
-dnp3_freeze_result_t freeze_counters_all(dnp3_freeze_type_t freeze_type, dnp3_database_t *database, void *context) { return DNP3_FREEZE_RESULT_NOT_SUPPORTED; }
+dnp3_freeze_result_t freeze_counters_all(dnp3_freeze_type_t freeze_type, dnp3_database_handle_t *database, void *context) { return DNP3_FREEZE_RESULT_NOT_SUPPORTED; }
 
-dnp3_freeze_result_t freeze_counters_range(uint16_t start, uint16_t stop, dnp3_freeze_type_t freeze_type, dnp3_database_t *database, void *context)
+dnp3_freeze_result_t freeze_counters_range(uint16_t start, uint16_t stop, dnp3_freeze_type_t freeze_type, dnp3_database_handle_t *database, void *context)
 {
     return DNP3_FREEZE_RESULT_NOT_SUPPORTED;
 }
@@ -126,13 +126,25 @@ void update_analog_output_status(dnp3_database_t* db, void* context)
     dnp3_database_update_analog_output_status(db, status, dnp3_update_options_detect_event());
 }
 
+void update_binary_output_status_from_control(dnp3_database_t *database, void *ctx)
+{
+    dnp3_binary_output_status_t value = *(dnp3_binary_output_status_t *)ctx;
+    dnp3_database_update_binary_output_status(database, value, dnp3_update_options_detect_event());
+}
+
+void update_analog_output_status_from_control(dnp3_database_t *database, void *ctx)
+{
+    dnp3_analog_output_status_t value = *(dnp3_analog_output_status_t *)ctx;
+    dnp3_database_update_analog_output_status(database, value, dnp3_update_options_detect_event());
+}
+
 // ControlHandler interface
 // ANCHOR: control_handler
 void begin_fragment(void *context) {}
 
 void end_fragment(void *context) {}
 
-dnp3_command_status_t select_g12v1(dnp3_group12_var1_t control, uint16_t index, dnp3_database_t *database, void *context)
+dnp3_command_status_t select_g12v1(dnp3_group12_var1_t control, uint16_t index, dnp3_database_handle_t *database, void *context)
 {
     if (index < 10 && (control.code.op_type == DNP3_OP_TYPE_LATCH_ON || control.code.op_type == DNP3_OP_TYPE_LATCH_OFF))
     {
@@ -144,13 +156,18 @@ dnp3_command_status_t select_g12v1(dnp3_group12_var1_t control, uint16_t index, 
     }
 }
 
-dnp3_command_status_t operate_g12v1(dnp3_group12_var1_t control, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_t *database, void *context)
+dnp3_command_status_t operate_g12v1(dnp3_group12_var1_t control, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_handle_t *database, void *context)
 {
     if (index < 10 && (control.code.op_type == DNP3_OP_TYPE_LATCH_ON || control.code.op_type == DNP3_OP_TYPE_LATCH_OFF))
     {
         bool status = (control.code.op_type == DNP3_OP_TYPE_LATCH_ON);
         dnp3_binary_output_status_t bo = dnp3_binary_output_status_init(index, status, dnp3_flags_init(DNP3_FLAG_ONLINE), now());
-        dnp3_database_update_binary_output_status(database, bo, dnp3_update_options_detect_event());
+        dnp3_database_transaction_t transaction = {
+            .execute = &update_binary_output_status_from_control,
+            .on_destroy = NULL,
+            .ctx = &bo,
+        };
+        dnp3_database_handle_transaction(database, transaction);
         return DNP3_COMMAND_STATUS_SUCCESS;
     }
     else
@@ -164,12 +181,17 @@ dnp3_command_status_t select_analog_output(uint16_t index)
     return (index < 10) ? DNP3_COMMAND_STATUS_SUCCESS : DNP3_COMMAND_STATUS_NOT_SUPPORTED;
 }
 
-dnp3_command_status_t operate_analog_output(double value, uint16_t index, dnp3_database_t *database)
+dnp3_command_status_t operate_analog_output(double value, uint16_t index, dnp3_database_handle_t *database)
 {
     if (index < 10)
     {
         dnp3_analog_output_status_t ao = dnp3_analog_output_status_init(index, value, dnp3_flags_init(DNP3_FLAG_ONLINE), now());
-        dnp3_database_update_analog_output_status(database, ao, dnp3_update_options_detect_event());
+        dnp3_database_transaction_t transaction = {
+            .execute = &update_analog_output_status_from_control,
+            .on_destroy = NULL,
+            .ctx = &ao,
+        };
+        dnp3_database_handle_transaction(database, transaction);
         return DNP3_COMMAND_STATUS_SUCCESS;
     }
     else
@@ -178,42 +200,39 @@ dnp3_command_status_t operate_analog_output(double value, uint16_t index, dnp3_d
     }
 }
 
-dnp3_command_status_t select_g41v1(int32_t value, uint16_t index, dnp3_database_t *database, void *context)
+dnp3_command_status_t select_g41v1(int32_t value, uint16_t index, dnp3_database_handle_t *database, void *context)
 {
     return select_analog_output(index);
 }
 
-dnp3_command_status_t operate_g41v1(int32_t value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_t *database, void *context)
+dnp3_command_status_t operate_g41v1(int32_t value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_handle_t *database, void *context)
 {
     return operate_analog_output((double)value, index, database);
 }
 
-dnp3_command_status_t select_g41v2(int16_t value, uint16_t index, dnp3_database_t *database, void *context)
-{
+dnp3_command_status_t select_g41v2(int16_t value, uint16_t index, dnp3_database_handle_t *database, void *context) {
     return select_analog_output(index);
 }
 
-dnp3_command_status_t operate_g41v2(int16_t value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_t *database, void *context)
+dnp3_command_status_t operate_g41v2(int16_t value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_handle_t *database, void *context)
 {
     return operate_analog_output((double)value, index, database);
 }
 
-dnp3_command_status_t select_g41v3(float value, uint16_t index, dnp3_database_t *database, void *context)
-{
+dnp3_command_status_t select_g41v3(float value, uint16_t index, dnp3_database_handle_t *database, void *context) {
     return select_analog_output(index);
 }
 
-dnp3_command_status_t operate_g41v3(float value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_t *database, void *context)
+dnp3_command_status_t operate_g41v3(float value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_handle_t *database, void *context)
 {
     return operate_analog_output((double)value, index, database);
 }
 
-dnp3_command_status_t select_g41v4(double value, uint16_t index, dnp3_database_t *database, void *context)
-{
+dnp3_command_status_t select_g41v4(double value, uint16_t index, dnp3_database_handle_t *database, void *context) {
     return select_analog_output(index);
 }
 
-dnp3_command_status_t operate_g41v4(double value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_t *database, void *context)
+dnp3_command_status_t operate_g41v4(double value, uint16_t index, dnp3_operate_type_t op_type, dnp3_database_handle_t *database, void *context)
 {
     return operate_analog_output(value, index, database);
 }

--- a/ffi/bindings/c/outstation_example.cpp
+++ b/ffi/bindings/c/outstation_example.cpp
@@ -72,7 +72,7 @@ class MyOutstationInformation : public OutstationInformation {
 // ANCHOR: control_handler
 class MyControlHandler : public ControlHandler {
     void begin_fragment() override {}
-    void end_fragment() override {}
+    void end_fragment(DatabaseHandle& database) override {}
 
     CommandStatus select_g12v1(const Group12Var1& control, uint16_t index, DatabaseHandle& database) override {
         if (index < 10 && (control.code.op_type == OpType::latch_on || control.code.op_type == OpType::latch_off))

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -161,10 +161,10 @@ class MainClass
     // ANCHOR: association_information
     class TestAssociationInformation : IAssociationInformation
     {
-        public void TaskStart(TaskType taskType, FunctionCode fc, byte seq) {}
-        public void TaskSuccess(TaskType taskType, FunctionCode fc, byte seq) {}
-        public void TaskFail(TaskType taskType, TaskError error) {}
-        public void UnsolicitedResponse(bool isDuplicate, byte seq) {}
+        public void TaskStart(TaskType taskType, FunctionCode fc, byte seq) { }
+        public void TaskSuccess(TaskType taskType, FunctionCode fc, byte seq) { }
+        public void TaskFail(TaskType taskType, TaskError error) { }
+        public void UnsolicitedResponse(bool isDuplicate, byte seq) { }
     }
     // ANCHOR_END: association_information
 
@@ -215,10 +215,10 @@ class MainClass
         finally
         {
             channel.Shutdown();
-        }        
+        }
     }
 
-    private static void RunTls (Runtime runtime, TlsClientConfig tlsConfig)
+    private static void RunTls(Runtime runtime, TlsClientConfig tlsConfig)
     {
         // ANCHOR: create_tls_channel
         var channel = MasterChannel.CreateTlsChannel(
@@ -346,7 +346,7 @@ class MainClass
     }
 
     private static void RunChannel(MasterChannel channel)
-    {        
+    {
         // ANCHOR: association_create
         var association = channel.AddAssociation(
             1024,

--- a/ffi/bindings/dotnet/examples/outstation/Program.cs
+++ b/ffi/bindings/dotnet/examples/outstation/Program.cs
@@ -40,9 +40,9 @@ class ExampleOutstation
             return RestartDelay.NotSupported();
         }
 
-        public FreezeResult FreezeCountersAll(FreezeType freezeType, Database database) { return FreezeResult.NotSupported; }
+        public FreezeResult FreezeCountersAll(FreezeType freezeType, DatabaseHandle database) { return FreezeResult.NotSupported; }
 
-        public FreezeResult FreezeCountersRange(ushort start, ushort stop, FreezeType freezeType, Database database) { return FreezeResult.NotSupported; }
+        public FreezeResult FreezeCountersRange(ushort start, ushort stop, FreezeType freezeType, DatabaseHandle database) { return FreezeResult.NotSupported; }
     }
 
     class TestOutstationInformation : IOutstationInformation
@@ -79,7 +79,7 @@ class ExampleOutstation
 
         public void EndFragment() { }
 
-        public CommandStatus SelectG12v1(Group12Var1 control, ushort index, Database database)
+        public CommandStatus SelectG12v1(Group12Var1 control, ushort index, DatabaseHandle database)
         {
             if (index < 10 && (control.Code.OpType == OpType.LatchOn || control.Code.OpType == OpType.LatchOff))
             {
@@ -91,12 +91,14 @@ class ExampleOutstation
             }
         }
 
-        public CommandStatus OperateG12v1(Group12Var1 control, ushort index, OperateType opType, Database database)
+        public CommandStatus OperateG12v1(Group12Var1 control, ushort index, OperateType opType, DatabaseHandle database)
         {
             if (index < 10 && (control.Code.OpType == OpType.LatchOn || control.Code.OpType == OpType.LatchOff))
             {
                 var status = (control.Code.OpType == OpType.LatchOn);
-                database.UpdateBinaryOutputStatus(new BinaryOutputStatus(index, status, new Flags(Flag.Online), Now()), UpdateOptions.DetectEvent());
+                database.Transaction(db =>
+                    db.UpdateBinaryOutputStatus(new BinaryOutputStatus(index, status, new Flags(Flag.Online), Now()), UpdateOptions.DetectEvent())
+                );
                 return CommandStatus.Success;
             }
             else
@@ -105,42 +107,42 @@ class ExampleOutstation
             }
         }
 
-        public CommandStatus SelectG41v1(int value, ushort index, Database database)
+        public CommandStatus SelectG41v1(int value, ushort index, DatabaseHandle database)
         {
             return SelectAnalogOutput(index);
         }
 
-        public CommandStatus OperateG41v1(int value, ushort index, OperateType opType, Database database)
+        public CommandStatus OperateG41v1(int value, ushort index, OperateType opType, DatabaseHandle database)
         {
             return OperateAnalogOutput(value, index, database);
         }
 
-        public CommandStatus SelectG41v2(short value, ushort index, Database database)
+        public CommandStatus SelectG41v2(short value, ushort index, DatabaseHandle database)
         {
             return SelectAnalogOutput(index);
         }
 
-        public CommandStatus OperateG41v2(short value, ushort index, OperateType opType, Database database)
+        public CommandStatus OperateG41v2(short value, ushort index, OperateType opType, DatabaseHandle database)
         {
             return OperateAnalogOutput(value, index, database);
         }
 
-        public CommandStatus SelectG41v3(float value, ushort index, Database database)
+        public CommandStatus SelectG41v3(float value, ushort index, DatabaseHandle database)
         {
             return SelectAnalogOutput(index);
         }
 
-        public CommandStatus OperateG41v3(float value, ushort index, OperateType opType, Database database)
+        public CommandStatus OperateG41v3(float value, ushort index, OperateType opType, DatabaseHandle database)
         {
             return OperateAnalogOutput(value, index, database);
         }
 
-        public CommandStatus SelectG41v4(double value, ushort index, Database database)
+        public CommandStatus SelectG41v4(double value, ushort index, DatabaseHandle database)
         {
             return SelectAnalogOutput(index);
         }
 
-        public CommandStatus OperateG41v4(double value, ushort index, OperateType opType, Database database)
+        public CommandStatus OperateG41v4(double value, ushort index, OperateType opType, DatabaseHandle database)
         {
             return OperateAnalogOutput(value, index, database);
         }
@@ -150,11 +152,13 @@ class ExampleOutstation
             return index < 10 ? CommandStatus.Success : CommandStatus.NotSupported;
         }
 
-        private CommandStatus OperateAnalogOutput(double value, ushort index, Database database)
+        private CommandStatus OperateAnalogOutput(double value, ushort index, DatabaseHandle database)
         {
             if (index < 10)
             {
-                database.UpdateAnalogOutputStatus(new AnalogOutputStatus(index, value, new Flags(Flag.Online), Now()), UpdateOptions.DetectEvent());
+                database.Transaction(db =>
+                    db.UpdateAnalogOutputStatus(new AnalogOutputStatus(index, value, new Flags(Flag.Online), Now()), UpdateOptions.DetectEvent())
+                );
                 return CommandStatus.Success;
             }
             else
@@ -223,7 +227,7 @@ class ExampleOutstation
         );
         // ANCHOR_END: create_serial_server
 
-        
+
         RunOutstation(outstation);
     }
 
@@ -252,7 +256,7 @@ class ExampleOutstation
            "./certs/ca_chain/entity2_cert.pem",
            "./certs/ca_chain/entity2_key.pem",
            "" // no password
-       );        
+       );
         // ANCHOR_END: tls_ca_chain_config
         return config;
     }
@@ -270,7 +274,7 @@ class ExampleOutstation
         // ANCHOR_END: tls_self_signed_config
         return config;
     }
-         
+
     public static void Main(string[] args)
     {
         // Initialize logging with the default configuration
@@ -278,10 +282,10 @@ class ExampleOutstation
             new LoggingConfig(),
             new TestLogger()
         );
-        
+
         var runtime = new Runtime(new RuntimeConfig { NumCoreThreads = 4 });
-       
-        if(args.Length != 1)
+
+        if (args.Length != 1)
         {
             System.Console.WriteLine("You must specify the transport type");
             System.Console.WriteLine("Usage: outstation-example <transport> (tcp, serial, tls-ca, tls-self-signed)");
@@ -291,7 +295,8 @@ class ExampleOutstation
         try
         {
             var type = args[0];
-            switch(type) {
+            switch (type)
+            {
                 case "tcp":
                     RunTcp(runtime);
                     break;

--- a/ffi/bindings/dotnet/examples/outstation/Program.cs
+++ b/ffi/bindings/dotnet/examples/outstation/Program.cs
@@ -77,7 +77,7 @@ class ExampleOutstation
     {
         public void BeginFragment() { }
 
-        public void EndFragment() { }
+        public void EndFragment(DatabaseHandle database) { }
 
         public CommandStatus SelectG12v1(Group12Var1 control, ushort index, DatabaseHandle database)
         {

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/OutstationExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/OutstationExample.java
@@ -106,7 +106,7 @@ class TestControlHandler implements ControlHandler {
   public void beginFragment() {}
 
   @Override
-  public void endFragment() {}
+  public void endFragment(DatabaseHandle database) {}
 
   @Override
   public CommandStatus selectG12v1(Group12Var1 control, UShort index, DatabaseHandle database) {

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/OutstationExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/OutstationExample.java
@@ -49,13 +49,13 @@ class TestOutstationApplication implements OutstationApplication {
   }
 
   @Override
-  public FreezeResult freezeCountersAll(FreezeType freezeType, Database database) {
+  public FreezeResult freezeCountersAll(FreezeType freezeType, DatabaseHandle database) {
     return FreezeResult.NOT_SUPPORTED;
   }
 
   @Override
   public FreezeResult freezeCountersRange(
-      UShort start, UShort stop, FreezeType freezeType, Database database) {
+      UShort start, UShort stop, FreezeType freezeType, DatabaseHandle database) {
     return FreezeResult.NOT_SUPPORTED;
   }
 }
@@ -109,7 +109,7 @@ class TestControlHandler implements ControlHandler {
   public void endFragment() {}
 
   @Override
-  public CommandStatus selectG12v1(Group12Var1 control, UShort index, Database database) {
+  public CommandStatus selectG12v1(Group12Var1 control, UShort index, DatabaseHandle database) {
     if (index.compareTo(ushort(10)) < 0 && (control.code.opType == OpType.LATCH_ON || control.code.opType == OpType.LATCH_OFF)) {
       return CommandStatus.SUCCESS;
     } else {
@@ -118,10 +118,10 @@ class TestControlHandler implements ControlHandler {
   }
 
   @Override
-  public CommandStatus operateG12v1(Group12Var1 control, UShort index, OperateType opType, Database database) {
+  public CommandStatus operateG12v1(Group12Var1 control, UShort index, OperateType opType, DatabaseHandle database) {
     if (index.compareTo(ushort(10)) < 0 && (control.code.opType == OpType.LATCH_ON || control.code.opType == OpType.LATCH_OFF)) {
       boolean status = control.code.opType == OpType.LATCH_ON;
-      database.updateBinaryOutputStatus(new BinaryOutputStatus(index, status, new Flags(Flag.ONLINE), OutstationExample.now()), UpdateOptions.detectEvent());
+      database.transaction(db -> db.updateBinaryOutputStatus(new BinaryOutputStatus(index, status, new Flags(Flag.ONLINE), OutstationExample.now()), UpdateOptions.detectEvent()));
       return CommandStatus.SUCCESS;
     } else {
       return CommandStatus.NOT_SUPPORTED;
@@ -129,46 +129,46 @@ class TestControlHandler implements ControlHandler {
   }
 
   @Override
-  public CommandStatus selectG41v1(int value, UShort index, Database database) {
+  public CommandStatus selectG41v1(int value, UShort index, DatabaseHandle database) {
     return selectAnalogOutput(index);
   }
 
   @Override
   public CommandStatus operateG41v1(
-      int value, UShort index, OperateType opType, Database database) {
+      int value, UShort index, OperateType opType, DatabaseHandle database) {
     return operateAnalogOutput(value, index, database);
   }
 
   @Override
-  public CommandStatus selectG41v2(short value, UShort index, Database database) {
+  public CommandStatus selectG41v2(short value, UShort index, DatabaseHandle database) {
     return selectAnalogOutput(index);
   }
 
   @Override
   public CommandStatus operateG41v2(
-      short value, UShort index, OperateType opType, Database database) {
+      short value, UShort index, OperateType opType, DatabaseHandle database) {
     return operateAnalogOutput(value, index, database);
   }
 
   @Override
-  public CommandStatus selectG41v3(float value, UShort index, Database database) {
+  public CommandStatus selectG41v3(float value, UShort index, DatabaseHandle database) {
     return selectAnalogOutput(index);
   }
 
   @Override
   public CommandStatus operateG41v3(
-      float value, UShort index, OperateType opType, Database database) {
+      float value, UShort index, OperateType opType, DatabaseHandle database) {
     return operateAnalogOutput(value, index, database);
   }
 
   @Override
-  public CommandStatus selectG41v4(double value, UShort index, Database database) {
+  public CommandStatus selectG41v4(double value, UShort index, DatabaseHandle database) {
     return selectAnalogOutput(index);
   }
 
   @Override
   public CommandStatus operateG41v4(
-      double value, UShort index, OperateType opType, Database database) {
+      double value, UShort index, OperateType opType, DatabaseHandle database) {
     return operateAnalogOutput(value, index, database);
   }
 
@@ -176,9 +176,10 @@ class TestControlHandler implements ControlHandler {
     return index.compareTo(ushort(10)) < 0 ? CommandStatus.SUCCESS : CommandStatus.NOT_SUPPORTED;
   }
 
-  private CommandStatus operateAnalogOutput(double value, UShort index, Database database) {
+  private CommandStatus operateAnalogOutput(double value, UShort index, DatabaseHandle database) {
     if (index.compareTo(ushort(10)) < 0) {
-      database.updateAnalogOutputStatus(new AnalogOutputStatus(index, value, new Flags(Flag.ONLINE), OutstationExample.now()), UpdateOptions.detectEvent());
+      database.transaction(db -> db.updateAnalogOutputStatus(new AnalogOutputStatus(index, value, new Flags(Flag.ONLINE), OutstationExample.now()), UpdateOptions.detectEvent()));
+
       return CommandStatus.SUCCESS;
     }
     else

--- a/ffi/dnp3-ffi/src/outstation/adapters.rs
+++ b/ffi/dnp3-ffi/src/outstation/adapters.rs
@@ -1,6 +1,6 @@
 use dnp3::app::control::*;
 use dnp3::app::*;
-use dnp3::outstation::database::Database;
+use dnp3::outstation::database::DatabaseHandle;
 use dnp3::outstation::*;
 
 use crate::ffi;
@@ -34,7 +34,7 @@ impl OutstationApplication for ffi::OutstationApplication {
         &mut self,
         indices: FreezeIndices,
         freeze_type: FreezeType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> Result<(), RequestError> {
         match indices {
             FreezeIndices::All => ffi::OutstationApplication::freeze_counters_all(
@@ -173,7 +173,7 @@ impl ControlSupport<Group12Var1> for ffi::ControlHandler {
         &mut self,
         control: Group12Var1,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g12v1(self, control.into(), index, database as *mut _)
             .map(|e| e.into())
@@ -185,7 +185,7 @@ impl ControlSupport<Group12Var1> for ffi::ControlHandler {
         control: Group12Var1,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g12v1(
             self,
@@ -204,7 +204,7 @@ impl ControlSupport<Group41Var1> for ffi::ControlHandler {
         &mut self,
         control: Group41Var1,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v1(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -216,7 +216,7 @@ impl ControlSupport<Group41Var1> for ffi::ControlHandler {
         control: Group41Var1,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v1(
             self,
@@ -235,7 +235,7 @@ impl ControlSupport<Group41Var2> for ffi::ControlHandler {
         &mut self,
         control: Group41Var2,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v2(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -247,7 +247,7 @@ impl ControlSupport<Group41Var2> for ffi::ControlHandler {
         control: Group41Var2,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v2(
             self,
@@ -266,7 +266,7 @@ impl ControlSupport<Group41Var3> for ffi::ControlHandler {
         &mut self,
         control: Group41Var3,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v3(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -278,7 +278,7 @@ impl ControlSupport<Group41Var3> for ffi::ControlHandler {
         control: Group41Var3,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v3(
             self,
@@ -297,7 +297,7 @@ impl ControlSupport<Group41Var4> for ffi::ControlHandler {
         &mut self,
         control: Group41Var4,
         index: u16,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v4(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -309,7 +309,7 @@ impl ControlSupport<Group41Var4> for ffi::ControlHandler {
         control: Group41Var4,
         index: u16,
         op_type: OperateType,
-        database: &mut Database,
+        database: &DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v4(
             self,

--- a/ffi/dnp3-ffi/src/outstation/adapters.rs
+++ b/ffi/dnp3-ffi/src/outstation/adapters.rs
@@ -34,7 +34,7 @@ impl OutstationApplication for ffi::OutstationApplication {
         &mut self,
         indices: FreezeIndices,
         freeze_type: FreezeType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> Result<(), RequestError> {
         match indices {
             FreezeIndices::All => ffi::OutstationApplication::freeze_counters_all(
@@ -173,7 +173,7 @@ impl ControlSupport<Group12Var1> for ffi::ControlHandler {
         &mut self,
         control: Group12Var1,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g12v1(self, control.into(), index, database as *mut _)
             .map(|e| e.into())
@@ -185,7 +185,7 @@ impl ControlSupport<Group12Var1> for ffi::ControlHandler {
         control: Group12Var1,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g12v1(
             self,
@@ -204,7 +204,7 @@ impl ControlSupport<Group41Var1> for ffi::ControlHandler {
         &mut self,
         control: Group41Var1,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v1(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -216,7 +216,7 @@ impl ControlSupport<Group41Var1> for ffi::ControlHandler {
         control: Group41Var1,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v1(
             self,
@@ -235,7 +235,7 @@ impl ControlSupport<Group41Var2> for ffi::ControlHandler {
         &mut self,
         control: Group41Var2,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v2(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -247,7 +247,7 @@ impl ControlSupport<Group41Var2> for ffi::ControlHandler {
         control: Group41Var2,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v2(
             self,
@@ -266,7 +266,7 @@ impl ControlSupport<Group41Var3> for ffi::ControlHandler {
         &mut self,
         control: Group41Var3,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v3(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -278,7 +278,7 @@ impl ControlSupport<Group41Var3> for ffi::ControlHandler {
         control: Group41Var3,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v3(
             self,
@@ -297,7 +297,7 @@ impl ControlSupport<Group41Var4> for ffi::ControlHandler {
         &mut self,
         control: Group41Var4,
         index: u16,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::select_g41v4(self, control.value, index, database as *mut _)
             .map(|e| e.into())
@@ -309,7 +309,7 @@ impl ControlSupport<Group41Var4> for ffi::ControlHandler {
         control: Group41Var4,
         index: u16,
         op_type: OperateType,
-        database: &DatabaseHandle,
+        database: &mut DatabaseHandle,
     ) -> CommandStatus {
         ffi::ControlHandler::operate_g41v4(
             self,

--- a/ffi/dnp3-ffi/src/outstation/adapters.rs
+++ b/ffi/dnp3-ffi/src/outstation/adapters.rs
@@ -153,8 +153,8 @@ impl ControlHandler for ffi::ControlHandler {
         ffi::ControlHandler::begin_fragment(self);
     }
 
-    fn end_fragment(&mut self) -> MaybeAsync<()> {
-        ffi::ControlHandler::end_fragment(self);
+    fn end_fragment(&mut self, database: &mut DatabaseHandle) -> MaybeAsync<()> {
+        ffi::ControlHandler::end_fragment(self, database as *mut _);
         MaybeAsync::ready(())
     }
 }

--- a/ffi/dnp3-ffi/src/outstation/database.rs
+++ b/ffi/dnp3-ffi/src/outstation/database.rs
@@ -563,3 +563,12 @@ impl From<ffi::AnalogOutputStatus> for AnalogOutputStatus {
         }
     }
 }
+
+pub(crate) unsafe fn database_handle_transaction(
+    instance: *mut crate::DatabaseHandle,
+    callback: crate::ffi::DatabaseTransaction,
+) {
+    if let Some(db) = instance.as_mut() {
+        db.transaction(|db| callback.execute(db))
+    }
+}

--- a/ffi/dnp3-ffi/src/outstation/database.rs
+++ b/ffi/dnp3-ffi/src/outstation/database.rs
@@ -1,6 +1,7 @@
 use dnp3::app::measurement::*;
 use dnp3::app::Timestamp;
 pub use dnp3::outstation::database::Database;
+pub use dnp3::outstation::database::DatabaseHandle;
 use dnp3::outstation::database::*;
 
 use crate::ffi;

--- a/ffi/dnp3-schema/src/database.rs
+++ b/ffi/dnp3-schema/src/database.rs
@@ -450,7 +450,34 @@ fn define_analog_output_status_config(
     Ok(config)
 }
 
-pub fn define(lib: &mut LibraryBuilder, shared_def: &SharedDefinitions) -> BackTraced<ClassHandle> {
+pub(crate) struct DatabaseTypes {
+    pub(crate) database: ClassHandle,
+    pub(crate) database_handle: ClassHandle,
+}
+
+pub(crate) fn define(
+    lib: &mut LibraryBuilder,
+    shared_def: &SharedDefinitions,
+) -> BackTraced<DatabaseTypes> {
+    let database = define_database(lib, shared_def)?;
+
+    let database_handle = lib.declare_class("database_handle")?;
+
+    let database_handle = lib
+        .define_class(&database_handle)?
+        .doc("handle used to perform transactions on the database")?
+        .build()?;
+
+    Ok(DatabaseTypes {
+        database,
+        database_handle,
+    })
+}
+
+pub(crate) fn define_database(
+    lib: &mut LibraryBuilder,
+    shared_def: &SharedDefinitions,
+) -> BackTraced<ClassHandle> {
     let database = lib.declare_class("database")?;
 
     let event_class = lib

--- a/ffi/dnp3-schema/src/database.rs
+++ b/ffi/dnp3-schema/src/database.rs
@@ -478,7 +478,7 @@ pub(crate) fn define(
             database_transaction.clone(),
             "callback interface",
         )?
-        .doc("Execute a transaction on the underlying database")?
+        .doc("Acquire a mutex on the underlying database and apply a set of changes as a transaction")?
         .build()?;
 
     let database_handle = lib

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -789,6 +789,7 @@ fn define_control_handler(
         .begin_callback("begin_fragment", "Notifies the start of a command fragment")?
         .end_callback()?
         .begin_callback("end_fragment", "Notifies the end of a command fragment")?
+        .param("database", database_handle.declaration(), "Database handle")?
         .end_callback()?
         //------
         .begin_callback("select_g12v1", select_g12_doc)?

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -189,7 +189,7 @@ fn define_outstation(
             types.database_transaction.clone(),
             "Interface on which to execute the transaction",
         )?
-        .doc("Execute transaction to modify the internal database of the outstation")?
+        .doc("Acquire a mutex on the underlying database and apply a set of changes as a transaction")?
         .build()?;
 
     let set_decode_level = lib

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -1,3 +1,4 @@
+use crate::database::DatabaseTypes;
 use crate::shared::SharedDefinitions;
 use oo_bindgen::model::*;
 use std::time::Duration;
@@ -13,14 +14,17 @@ struct OutstationTypes {
 
 impl OutstationTypes {
     fn define(lib: &mut LibraryBuilder, shared_def: &SharedDefinitions) -> BackTraced<Self> {
-        let database = crate::database::define(lib, shared_def)?;
+        let DatabaseTypes {
+            database,
+            database_handle,
+        } = crate::database::define(lib, shared_def)?;
 
         Ok(Self {
-            database: database.clone(),
+            database,
             outstation_config: define_outstation_config(lib, shared_def)?,
-            outstation_application: define_outstation_application(lib, &database)?,
+            outstation_application: define_outstation_application(lib, &database_handle)?,
             outstation_information: define_outstation_information(lib, shared_def)?,
-            control_handler: define_control_handler(lib, &database, shared_def)?,
+            control_handler: define_control_handler(lib, &database_handle, shared_def)?,
             connection_state_listener: define_connection_state_listener(lib)?,
         })
     }
@@ -600,7 +604,7 @@ fn define_restart_delay(lib: &mut LibraryBuilder) -> BackTraced<UniversalStructH
 
 fn define_outstation_application(
     lib: &mut LibraryBuilder,
-    database: &ClassHandle,
+    database_handle: &ClassHandle,
 ) -> BackTraced<AsynchronousInterface> {
     let restart_delay = define_restart_delay(lib)?;
 
@@ -654,14 +658,14 @@ fn define_outstation_application(
             .end_callback()?
         .begin_callback("freeze_counters_all", "Freeze all the counters")?
             .param("freeze_type", freeze_type.clone(), "Type of freeze operation")?
-            .param("database",database.declaration(), "Database")?
+            .param("database_handle",database_handle.declaration(), "Database handle")?
             .returns(freeze_result.clone(), "Result of the freeze operation")?
             .end_callback()?
         .begin_callback("freeze_counters_range", "Freeze a range of counters")?
             .param("start", Primitive::U16, "Start index to freeze (inclusive)")?
             .param("stop", Primitive::U16, "Stop index to freeze (inclusive)")?
             .param("freeze_type", freeze_type, "Type of freeze operation")?
-            .param("database",database.declaration(), "Database")?
+            .param("database_handle",database_handle.declaration(), "Database handle")?
             .returns(freeze_result, "Result of the freeze operation")?
             .end_callback()?
         .build_async()?;
@@ -756,7 +760,7 @@ fn define_outstation_information(
 
 fn define_control_handler(
     lib: &mut LibraryBuilder,
-    database: &ClassHandle,
+    database_handle: &ClassHandle,
     shared_def: &SharedDefinitions,
 ) -> BackTraced<AsynchronousInterface> {
     let command_status = define_command_status(lib)?;
@@ -798,7 +802,11 @@ fn define_control_handler(
         .begin_callback("select_g12v1", select_g12_doc)?
         .param("value", shared_def.g12v1_struct.clone(), "Received CROB")?
         .param("index", Primitive::U16, "Index of the point")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
@@ -806,14 +814,22 @@ fn define_control_handler(
         .param("value", shared_def.g12v1_struct.clone(), "Received CROB")?
         .param("index", Primitive::U16, "Index of the point")?
         .param("op_type", operate_type.clone(), "Operate type")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
         .begin_callback("select_g41v1", select_g40_doc.clone())?
         .param("value", Primitive::S32, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
@@ -821,14 +837,22 @@ fn define_control_handler(
         .param("value", Primitive::S32, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
         .param("op_type", operate_type.clone(), "Operate type")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
         .begin_callback("select_g41v2", select_g40_doc.clone())?
         .param("value", Primitive::S16, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
@@ -836,14 +860,22 @@ fn define_control_handler(
         .param("value", Primitive::S16, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
         .param("op_type", operate_type.clone(), "Operate type")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
         .begin_callback("select_g41v3", select_g40_doc.clone())?
         .param("value", Primitive::Float, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
@@ -851,14 +883,22 @@ fn define_control_handler(
         .param("value", Primitive::Float, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
         .param("op_type", operate_type.clone(), "Operate type")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
         .begin_callback("select_g41v4", select_g40_doc)?
         .param("value", Primitive::Double, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status.clone(), "Command status")?
         .end_callback()?
         //------
@@ -866,7 +906,11 @@ fn define_control_handler(
         .param("value", Primitive::Double, "Received analog output value")?
         .param("index", Primitive::U16, "Index of the point")?
         .param("op_type", operate_type, "Operate type")?
-        .param("database", database.declaration(), "Database")?
+        .param(
+            "database_handle",
+            database_handle.declaration(),
+            "Database handle",
+        )?
         .returns(command_status, "Command status")?
         .end_callback()?
         //------


### PR DESCRIPTION
`OutstationApplication` and `ControlHandler` now take a `DatabaseHandle` in callbacks instead of the locked database.

Users can now chose when they lock the database. Locks are no longer pre-acquired to reduce possibility of dead-lock.

`ControlHandler::end_fragment` may be used to update multiple points with a single lock/unlock cycle



