### PR TITLE
Remove tokio-mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
  "rand",
  "rasn",
  "tokio",
- "tokio-mock",
+ "tokio-mock-io",
  "tokio-rustls",
  "tokio-serial",
  "tokio-stream",
@@ -1537,9 +1537,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-mock"
-version = "0.2.0"
-source = "git+https://github.com/stepfunc/tokio-mock.git?tag=0.2.0#53467dabf52c0e6da41523e4c1ff5c1d81f5d83f"
+name = "tokio-mock-io"
+version = "0.1.0"
+source = "git+https://github.com/stepfunc/tokio-mock-io.git?tag=0.1.0#de25fecc0972f9ff5ec42e98ef936ef8fc8d79d7"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,8 +1544,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-mock-io"
-version = "0.1.0"
-source = "git+https://github.com/stepfunc/tokio-mock-io.git?branch=main#ec185ddcce3939bb4c850abbb4a7bab2d0b2ba4d"
+version = "0.2.0"
+source = "git+https://github.com/stepfunc/tokio-mock-io.git?tag=0.2.0#8bac8f7be852fba655becc8b1d4157a55bb2b9fc"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -200,6 +200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,12 +300,12 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
- "cast",
+ "cast 0.3.0",
  "clap",
  "criterion-plot",
  "csv",
@@ -324,7 +330,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
- "cast",
+ "cast 0.2.7",
  "itertools",
 ]
 
@@ -365,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -375,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
 dependencies = [
  "generic-array",
  "typenum",
@@ -525,9 +531,9 @@ checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "futures"
@@ -900,18 +906,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "oo-bindgen"
@@ -1040,9 +1046,9 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1053,15 +1059,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
 dependencies = [
  "plotters-backend",
 ]
@@ -1074,18 +1080,18 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53dc8cf16a769a6f677e09e7ff2cd4be1ea0f48754aac39520536962011de0d"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -1151,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1171,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ring"
@@ -1211,7 +1217,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.10",
+ "semver 1.0.12",
 ]
 
 [[package]]
@@ -1288,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "semver-parser"
@@ -1303,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
 
 [[package]]
 name = "serde_cbor"
@@ -1319,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1330,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
@@ -1396,9 +1402,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -1539,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "tokio-mock-io"
 version = "0.1.0"
-source = "git+https://github.com/stepfunc/tokio-mock-io.git?branch=main#694e0d8aafccece042bdc25a4f85bf43c598adf4"
+source = "git+https://github.com/stepfunc/tokio-mock-io.git?branch=main#ec185ddcce3939bb4c850abbb4a7bab2d0b2ba4d"
 dependencies = [
  "tokio",
 ]
@@ -1607,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1618,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1677,9 +1683,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicode-ident"
@@ -1902,6 +1908,6 @@ checksum = "074914ea4eec286eb8d1fd745768504f420a1f7b7919185682a4a267bed7d2e7"
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "tokio-mock-io"
 version = "0.1.0"
-source = "git+https://github.com/stepfunc/tokio-mock-io.git?tag=0.1.0#de25fecc0972f9ff5ec42e98ef936ef8fc8d79d7"
+source = "git+https://github.com/stepfunc/tokio-mock-io.git?branch=main#694e0d8aafccece042bdc25a4f85bf43c598adf4"
 dependencies = [
  "tokio",
 ]

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -25,6 +25,7 @@ tokio-util = { version = "0.6", features = ["codec"] }
 tokio-stream = { version = "0.1.1" }
 criterion = "0.3"
 rand = "0.8"
+tokio = { version = "1", features = ["test-util"] }
 
 [features]
 default = ["tls"]

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 tracing = "0.1"
 chrono = "0.4"
-tokio-mock = { git = "https://github.com/stepfunc/tokio-mock.git", tag = "0.2.0" }
+tokio = { version = "1", features = ["net", "sync", "io-util", "io-std", "time", "rt", "rt-multi-thread", "macros"] }
 tokio-serial = "5.4"
 xxhash-rust = { version = "0.8.2", features = ["xxh64"] }
 
@@ -18,9 +18,9 @@ rasn = { git = "https://github.com/stepfunc/rasn", tag = "0.1.2", optional = tru
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration", "tls12"], default-features = false, optional = true }
 
 [dev-dependencies]
+tokio-mock-io = { git = "https://github.com/stepfunc/tokio-mock-io.git", tag = "0.1.0" }
 assert_matches = "1.2"
 tracing-subscriber = "0.2"
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 tokio-stream = { version = "0.1.1" }
 criterion = "0.3"

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -18,7 +18,7 @@ rasn = { git = "https://github.com/stepfunc/rasn", tag = "0.1.2", optional = tru
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration", "tls12"], default-features = false, optional = true }
 
 [dev-dependencies]
-tokio-mock-io = { git = "https://github.com/stepfunc/tokio-mock-io.git", branch = "main" }
+tokio-mock-io = { git = "https://github.com/stepfunc/tokio-mock-io.git", tag = "0.2.0" }
 assert_matches = "1.2"
 tracing-subscriber = "0.2"
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -18,7 +18,7 @@ rasn = { git = "https://github.com/stepfunc/rasn", tag = "0.1.2", optional = tru
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration", "tls12"], default-features = false, optional = true }
 
 [dev-dependencies]
-tokio-mock-io = { git = "https://github.com/stepfunc/tokio-mock-io.git", tag = "0.1.0" }
+tokio-mock-io = { git = "https://github.com/stepfunc/tokio-mock-io.git", branch = "main" }
 assert_matches = "1.2"
 tracing-subscriber = "0.2"
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/dnp3/src/app/header.rs
+++ b/dnp3/src/app/header.rs
@@ -467,7 +467,7 @@ impl std::fmt::Display for Iin2 {
 
 impl Iin {
     /// construct an IIN from `IIN1` and `IIN2`
-    pub fn new(iin1: Iin1, iin2: Iin2) -> Self {
+    pub const fn new(iin1: Iin1, iin2: Iin2) -> Self {
         Self { iin1, iin2 }
     }
 

--- a/dnp3/src/app/timeout.rs
+++ b/dnp3/src/app/timeout.rs
@@ -59,10 +59,10 @@ impl Timeout {
         Ok(Self { value })
     }
 
-    pub(crate) fn deadline_from_now(self) -> crate::tokio::time::Instant {
+    pub(crate) fn deadline_from_now(self) -> tokio::time::Instant {
         // if this panics due to overflow we have bigger problems than the panic
         // it means the tim value being returned by now() is WAAAY too big
-        crate::tokio::time::Instant::now() + self.value
+        tokio::time::Instant::now() + self.value
     }
 }
 

--- a/dnp3/src/lib.rs
+++ b/dnp3/src/lib.rs
@@ -68,6 +68,5 @@ pub mod serial;
 /// Entry points and types for TCP
 pub mod tcp;
 
-pub(crate) mod tokio;
 pub(crate) mod transport;
 pub(crate) mod util;

--- a/dnp3/src/lib.rs
+++ b/dnp3/src/lib.rs
@@ -49,6 +49,7 @@ clippy::all
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
+extern crate core;
 
 /// Current version of the library
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/dnp3/src/master/association.rs
+++ b/dnp3/src/master/association.rs
@@ -21,8 +21,9 @@ use crate::master::tasks::time::TimeSyncTask;
 use crate::master::tasks::NonReadTask::TimeSync;
 use crate::master::tasks::{AssociationTask, ReadTask, Task};
 use crate::master::{AssociationInformation, ReadHandler, ReadType, TaskType};
-use crate::tokio::time::Instant;
 use crate::util::Smallest;
+
+use tokio::time::Instant;
 
 /// Configuration for a master association
 #[derive(Debug, Copy, Clone)]

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -7,10 +7,11 @@ use crate::link::error::LinkError;
 use crate::link::EndpointAddress;
 use crate::master::association::NoAssociation;
 use crate::master::session::{RunError, StateChange};
-use crate::tokio::sync::mpsc::error::SendError;
-use crate::tokio::sync::oneshot::error::RecvError;
 use crate::transport::TransportResponseError;
 use crate::util::cursor::WriteError;
+
+use tokio::sync::mpsc::error::SendError;
+use tokio::sync::oneshot::error::RecvError;
 
 /// Errors that can occur when adding an association
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/dnp3/src/master/handler.rs
+++ b/dnp3/src/master/handler.rs
@@ -91,7 +91,7 @@ impl MasterChannel {
 
     /// Get the current decoding level used by this master
     pub async fn get_decode_level(&mut self) -> Result<DecodeLevel, Shutdown> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<DecodeLevel, Shutdown>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<DecodeLevel, Shutdown>>();
         self.send_master_message(MasterMsg::GetDecodeLevel(Promise::OneShot(tx)))
             .await?;
         rx.await?
@@ -109,7 +109,7 @@ impl MasterChannel {
         assoc_handler: Box<dyn AssociationHandler>,
         assoc_information: Box<dyn AssociationInformation>,
     ) -> Result<AssociationHandle, AssociationError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<(), AssociationError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), AssociationError>>();
         self.send_master_message(MasterMsg::AddAssociation(
             address,
             config,
@@ -175,7 +175,7 @@ impl AssociationHandle {
         request: ReadRequest,
         period: Duration,
     ) -> Result<PollHandle, PollError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<PollHandle, PollError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<PollHandle, PollError>>();
         self.send_poll_message(PollMsg::AddPoll(
             self.clone(),
             request,
@@ -198,7 +198,7 @@ impl AssociationHandle {
     ///
     /// If successful, the [ReadHandler](crate::master::ReadHandler) will process the received measurement data
     pub async fn read(&mut self, request: ReadRequest) -> Result<(), TaskError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<(), TaskError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), TaskError>>();
         let task = SingleReadTask::new(request, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?
@@ -212,7 +212,7 @@ impl AssociationHandle {
         request: ReadRequest,
         handler: Box<dyn ReadHandler>,
     ) -> Result<(), TaskError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<(), TaskError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), TaskError>>();
         let task = SingleReadTask::new_with_custom_handler(request, handler, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?
@@ -226,7 +226,7 @@ impl AssociationHandle {
         mode: CommandMode,
         headers: CommandHeaders,
     ) -> Result<(), CommandError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<(), CommandError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), CommandError>>();
         let task = CommandTask::from_mode(mode, headers, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?
@@ -236,7 +236,7 @@ impl AssociationHandle {
     ///
     /// Returns the delay from the outstation's response as a [Duration](std::time::Duration)
     pub async fn warm_restart(&mut self) -> Result<Duration, TaskError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<Duration, TaskError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Duration, TaskError>>();
         let task = RestartTask::new(RestartType::WarmRestart, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?
@@ -246,7 +246,7 @@ impl AssociationHandle {
     ///
     /// Returns the delay from the outstation's response as a [Duration](std::time::Duration)
     pub async fn cold_restart(&mut self) -> Result<Duration, TaskError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<Duration, TaskError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Duration, TaskError>>();
         let task = RestartTask::new(RestartType::ColdRestart, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?
@@ -257,7 +257,7 @@ impl AssociationHandle {
         &mut self,
         procedure: TimeSyncProcedure,
     ) -> Result<(), TimeSyncError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<(), TimeSyncError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), TimeSyncError>>();
         let task = TimeSyncTask::get_procedure(procedure, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?
@@ -271,7 +271,7 @@ impl AssociationHandle {
     /// If a [`TaskError::UnexpectedResponseHeaders`] is returned, the link might be alive
     /// but it didn't answer with the expected `LINK_STATUS`.
     pub async fn check_link_status(&mut self) -> Result<(), TaskError> {
-        let (tx, rx) = crate::tokio::sync::oneshot::channel::<Result<(), TaskError>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), TaskError>>();
         self.send_task(Task::LinkStatus(Promise::OneShot(tx)))
             .await?;
         rx.await?
@@ -297,7 +297,7 @@ pub(crate) enum Promise<T> {
     /// nothing happens when the promise is completed
     None,
     /// one-shot reply channel is consumed when the promise is completed
-    OneShot(crate::tokio::sync::oneshot::Sender<T>),
+    OneShot(tokio::sync::oneshot::Sender<T>),
 }
 
 impl<T> Promise<T> {

--- a/dnp3/src/master/mod.rs
+++ b/dnp3/src/master/mod.rs
@@ -16,5 +16,7 @@ pub(crate) mod poll;
 pub(crate) mod session;
 pub(crate) mod tasks;
 
+/* TODO
 #[cfg(test)]
 mod tests;
+ */

--- a/dnp3/src/master/mod.rs
+++ b/dnp3/src/master/mod.rs
@@ -16,7 +16,5 @@ pub(crate) mod poll;
 pub(crate) mod session;
 pub(crate) mod tasks;
 
-/* TODO
 #[cfg(test)]
 mod tests;
- */

--- a/dnp3/src/master/poll.rs
+++ b/dnp3/src/master/poll.rs
@@ -7,9 +7,10 @@ use crate::master::association::Next;
 use crate::master::error::PollError;
 use crate::master::handler::{AssociationHandle, Promise};
 use crate::master::request::ReadRequest;
-use crate::tokio::time::Instant;
 use crate::util::cursor::WriteError;
 use crate::util::Smallest;
+
+use tokio::time::Instant;
 
 /// Periodic poll representation
 #[derive(Clone)]

--- a/dnp3/src/master/request.rs
+++ b/dnp3/src/master/request.rs
@@ -112,7 +112,7 @@ impl EventClasses {
     }
 
     /// construct an `EventClasses` with all three classes enabled
-    pub fn all() -> Self {
+    pub const fn all() -> Self {
         Self {
             class1: true,
             class2: true,
@@ -121,7 +121,7 @@ impl EventClasses {
     }
 
     /// construct an `EventClasses` with all three classes disabled
-    pub fn none() -> Self {
+    pub const fn none() -> Self {
         Self {
             class1: false,
             class2: false,
@@ -157,12 +157,12 @@ impl BitAnd for EventClasses {
 
 impl Classes {
     /// construct a `Classes` from its fields
-    pub fn new(class0: bool, events: EventClasses) -> Self {
+    pub const fn new(class0: bool, events: EventClasses) -> Self {
         Self { class0, events }
     }
 
     /// construct a `Classes` with everything enabled
-    pub fn all() -> Self {
+    pub const fn all() -> Self {
         Self::new(true, EventClasses::all())
     }
 

--- a/dnp3/src/master/session.rs
+++ b/dnp3/src/master/session.rs
@@ -487,7 +487,7 @@ impl MasterSession {
 
         if response.header.control.seq != seq {
             tracing::warn!(
-                "unexpected sequence number is response: {}",
+                "unexpected sequence number in response: {}",
                 response.header.control.seq.value()
             );
             return Ok(None);

--- a/dnp3/src/master/tasks/restart.rs
+++ b/dnp3/src/master/tasks/restart.rs
@@ -137,7 +137,7 @@ mod tests {
             Box::new(DefaultAssociationHandler),
             Box::new(NullAssociationInformation),
         );
-        let (tx, mut rx) = crate::tokio::sync::oneshot::channel();
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
         let task = NonReadTask::Restart(RestartTask::new(
             RestartType::ColdRestart,
             Promise::OneShot(tx),
@@ -185,7 +185,7 @@ mod tests {
             Box::new(DefaultAssociationHandler),
             Box::new(NullAssociationInformation),
         );
-        let (tx, mut rx) = crate::tokio::sync::oneshot::channel();
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
         let task = NonReadTask::Restart(RestartTask::new(
             RestartType::WarmRestart,
             Promise::OneShot(tx),

--- a/dnp3/src/master/tests/auto_tasks.rs
+++ b/dnp3/src/master/tests/auto_tasks.rs
@@ -1,127 +1,121 @@
-use crate::app::format::write::start_request;
-use crate::app::variations::Variation;
-use crate::app::FunctionCode;
 use crate::app::Sequence;
-use crate::app::{ControlField, Iin, Iin1, Iin2};
+use crate::app::{Iin, Iin1, Iin2};
 use crate::master::association::AssociationConfig;
 use crate::master::request::EventClasses;
-use crate::util::cursor::WriteCursor;
+use crate::master::Classes;
 
 use super::harness::create_association;
 use super::harness::requests::*;
 
-#[test]
-fn auto_integrity_scan_on_buffer_overflow() {
+const BUFFER_OVERFLOW: Iin = Iin::new(Iin1::new(0x00), Iin2::new(0x08));
+const CLASS_1_EVENTS: Iin = Iin::new(Iin1::new(0x02), Iin2::new(0x00));
+
+#[tokio::test]
+async fn auto_integrity_scan_on_buffer_overflow() {
     let mut config = AssociationConfig::default();
     config.auto_integrity_scan_on_buffer_overflow = true;
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
     // Unsolicited with IIN2.3 EVENT_BUFFER_OVERFLOW set
-    unsol_null_custom_iin(
-        &mut harness.io,
-        seq,
-        Iin::new(Iin1::new(0x00), Iin2::new(0x08)),
-    );
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_null_custom_iin(seq, BUFFER_OVERFLOW),
+            unsol_confirm(seq),
+        )
+        .await;
 
     // Send integrity poll
-    integrity_poll_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(integrity_poll_request(seq), empty_response(seq.increment()))
+        .await;
+
+    assert_eq!(harness.io.pop_event(), None);
 }
 
-#[test]
-fn auto_integrity_scan_on_buffer_overflow_disabled() {
+#[tokio::test]
+async fn auto_integrity_scan_on_buffer_overflow_disabled() {
     let mut config = AssociationConfig::default();
     config.auto_integrity_scan_on_buffer_overflow = false;
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
     // Unsolicited with IIN2.3 EVENT_BUFFER_OVERFLOW set
-    unsol_null_custom_iin(
-        &mut harness.io,
-        seq,
-        Iin::new(Iin1::new(0x00), Iin2::new(0x08)),
-    );
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_null_custom_iin(seq, BUFFER_OVERFLOW),
+            unsol_confirm(seq),
+        )
+        .await;
+
+    assert_eq!(harness.io.pop_event(), None);
 }
 
-#[test]
-fn auto_event_class_scan() {
+#[tokio::test]
+async fn auto_event_class_scan() {
     let mut config = AssociationConfig::default();
     config.event_scan_on_events_available = EventClasses::all();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
-    // Unsolicited with IIN2.3 EVENT_BUFFER_OVERFLOW set
-    unsol_null_custom_iin(
-        &mut harness.io,
-        seq,
-        Iin::new(Iin1::new(0x02), Iin2::new(0x00)), // Class 1 events
-    );
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    // notify that class 1 events are available
+    harness
+        .read_and_expect_write(
+            unsol_null_custom_iin(seq, CLASS_1_EVENTS),
+            unsol_confirm(seq),
+        )
+        .await;
 
-    {
-        // Read class 1 events
-        let mut buffer = [0; 20];
-        let mut cursor = WriteCursor::new(&mut buffer);
-        let mut request =
-            start_request(ControlField::request(seq), FunctionCode::Read, &mut cursor).unwrap();
+    let class1 = Classes::new(false, EventClasses::new(true, false, false));
+    harness
+        .expect_write_and_respond(class_scan_request(class1, seq), empty_response(seq))
+        .await;
 
-        request
-            .write_all_objects_header(Variation::Group60Var2)
-            .unwrap();
-
-        harness.io.write(cursor.written());
-    }
-    empty_response(&mut harness.io, seq);
-    harness.flush_io();
+    assert_eq!(harness.io.pop_event(), None);
 }
 
-#[test]
-fn auto_event_class_ignore_one_class_scan() {
+#[tokio::test]
+async fn auto_event_class_ignore_one_class_scan() {
     let mut config = AssociationConfig::default();
     config.event_scan_on_events_available = EventClasses::new(false, true, true);
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
     // Unsolicited with IIN2.3 EVENT_BUFFER_OVERFLOW set
-    unsol_null_custom_iin(
-        &mut harness.io,
-        seq,
-        Iin::new(Iin1::new(0x02), Iin2::new(0x00)), // Class 1 events
-    );
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_null_custom_iin(seq, CLASS_1_EVENTS),
+            unsol_confirm(seq),
+        )
+        .await;
+    // make sure this does not result in a write
+    assert_eq!(harness.io.pop_event(), None);
 }
 
-#[test]
-fn auto_event_class_scan_disabled() {
+#[tokio::test]
+async fn auto_event_class_scan_disabled() {
     let mut config = AssociationConfig::default();
     config.event_scan_on_events_available = EventClasses::none();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
     // Unsolicited with IIN2.3 EVENT_BUFFER_OVERFLOW set
-    unsol_null_custom_iin(
-        &mut harness.io,
-        seq,
-        Iin::new(Iin1::new(0x02), Iin2::new(0x00)), // Class 1 events
-    );
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_null_custom_iin(seq, CLASS_1_EVENTS),
+            unsol_confirm(seq),
+        )
+        .await;
+    // make sure this does not result in a write
+    assert_eq!(harness.io.pop_event(), None);
 }

--- a/dnp3/src/master/tests/harness/mod.rs
+++ b/dnp3/src/master/tests/harness/mod.rs
@@ -239,8 +239,25 @@ pub(crate) struct TestHarness {
 }
 
 impl TestHarness {
-    pub(crate) async fn process_response(&mut self, data: &[u8]) {
-        self.io.read(data);
+    pub(crate) async fn expect_write(&mut self, expected: Vec<u8>) {
+        assert_eq!(
+            self.io.next_event().await,
+            tokio_mock_io::Event::Write(expected)
+        );
+    }
+
+    pub(crate) async fn expect_write_and_respond(&mut self, expected: Vec<u8>, response: Vec<u8>) {
+        self.expect_write(expected).await;
+        self.process_response(response).await;
+    }
+
+    pub(crate) async fn read_and_expect_write(&mut self, read: Vec<u8>, expected: Vec<u8>) {
+        self.process_response(read).await;
+        self.expect_write(expected).await;
+    }
+
+    pub(crate) async fn process_response(&mut self, data: Vec<u8>) {
+        self.io.read(&data);
         assert_eq!(self.io.next_event().await, tokio_mock_io::Event::Read);
     }
 

--- a/dnp3/src/master/tests/harness/mod.rs
+++ b/dnp3/src/master/tests/harness/mod.rs
@@ -11,7 +11,6 @@ use crate::master::association::AssociationConfig;
 use crate::master::handler::{AssociationHandle, HeaderInfo, MasterChannel, ReadHandler};
 use crate::master::session::{MasterSession, RunError};
 use crate::master::{AssociationHandler, AssociationInformation, ReadType};
-use crate::tokio::test::*;
 use crate::transport::create_master_transport_layer;
 use crate::util::phys::PhysLayer;
 

--- a/dnp3/src/master/tests/harness/requests.rs
+++ b/dnp3/src/master/tests/harness/requests.rs
@@ -12,7 +12,7 @@ pub(crate) async fn startup_procedure(harness: &mut super::TestHarness, seq: &mu
         Event::Write(disable_unsol_request(*seq))
     );
     harness
-        .process_response(&empty_response(seq.increment()))
+        .process_response(empty_response(seq.increment()))
         .await;
 
     // Integrity poll
@@ -21,7 +21,7 @@ pub(crate) async fn startup_procedure(harness: &mut super::TestHarness, seq: &mu
         Event::Write(integrity_poll_request(*seq))
     );
     harness
-        .process_response(&empty_response(seq.increment()))
+        .process_response(empty_response(seq.increment()))
         .await;
 
     // Enable unsolicited
@@ -30,7 +30,7 @@ pub(crate) async fn startup_procedure(harness: &mut super::TestHarness, seq: &mu
         Event::Write(enable_unsol_request(*seq))
     );
     harness
-        .process_response(&empty_response(seq.increment()))
+        .process_response(empty_response(seq.increment()))
         .await;
 }
 
@@ -125,17 +125,17 @@ pub(crate) fn empty_response_custom_iin(seq: Sequence, iin: Iin) -> Vec<u8> {
 
 // Unsolicited stuff
 
-pub(crate) fn unsol_null(io: &mut tokio_mock_io::Handle, seq: Sequence, restart_iin: bool) {
+pub(crate) fn unsol_null(seq: Sequence, restart_iin: bool) -> Vec<u8> {
     let iin = if restart_iin {
         Iin::new(Iin1::new(0x80), Iin2::new(0x00))
     } else {
         Iin::default()
     };
 
-    unsol_null_custom_iin(io, seq, iin);
+    unsol_null_custom_iin(seq, iin)
 }
 
-pub(crate) fn unsol_null_custom_iin(io: &mut tokio_mock_io::Handle, seq: Sequence, iin: Iin) {
+pub(crate) fn unsol_null_custom_iin(seq: Sequence, iin: Iin) -> Vec<u8> {
     let mut buffer = [0; 4];
     let mut cursor = WriteCursor::new(&mut buffer);
     start_response(
@@ -146,7 +146,7 @@ pub(crate) fn unsol_null_custom_iin(io: &mut tokio_mock_io::Handle, seq: Sequenc
     )
     .unwrap();
 
-    io.read(cursor.written());
+    cursor.written().to_vec()
 }
 
 pub(crate) fn unsol_confirm(seq: Sequence) -> Vec<u8> {
@@ -161,12 +161,7 @@ pub(crate) fn unsol_confirm(seq: Sequence) -> Vec<u8> {
     cursor.written().to_vec()
 }
 
-pub(crate) fn unsol_with_data(
-    io: &mut tokio_mock_io::Handle,
-    seq: Sequence,
-    data: i16,
-    restart_iin: bool,
-) {
+pub(crate) fn unsol_with_data(seq: Sequence, data: i16, restart_iin: bool) -> Vec<u8> {
     let iin = if restart_iin {
         Iin::new(Iin1::new(0x80), Iin2::new(0x00))
     } else {
@@ -196,5 +191,5 @@ pub(crate) fn unsol_with_data(
         )
         .unwrap();
 
-    io.read(cursor.written());
+    cursor.written().to_vec()
 }

--- a/dnp3/src/master/tests/harness/requests.rs
+++ b/dnp3/src/master/tests/harness/requests.rs
@@ -5,7 +5,6 @@ use crate::app::variations::{Group32Var2, Variation};
 use crate::app::Sequence;
 use crate::app::{ControlField, FunctionCode, Iin, Iin1, Iin2, ResponseFunction};
 use crate::master::session::RunError;
-use crate::tokio::test::*;
 use crate::util::cursor::WriteCursor;
 
 pub(crate) fn startup_procedure<F: Future<Output = RunError>>(

--- a/dnp3/src/master/tests/harness/requests.rs
+++ b/dnp3/src/master/tests/harness/requests.rs
@@ -2,6 +2,7 @@ use crate::app::format::write::{start_request, start_response};
 use crate::app::variations::{Group32Var2, Variation};
 use crate::app::Sequence;
 use crate::app::{ControlField, FunctionCode, Iin, Iin1, Iin2, ResponseFunction};
+use crate::master::Classes;
 use crate::util::cursor::WriteCursor;
 use tokio_mock_io::Event;
 
@@ -54,6 +55,40 @@ pub(crate) fn disable_unsol_request(seq: Sequence) -> Vec<u8> {
     request
         .write_all_objects_header(Variation::Group60Var4)
         .unwrap();
+
+    cursor.written().to_vec()
+}
+
+pub(crate) fn class_scan_request(classes: Classes, seq: Sequence) -> Vec<u8> {
+    // Integrity poll
+    let mut buffer = [0; 20];
+    let mut cursor = WriteCursor::new(&mut buffer);
+    let mut request =
+        start_request(ControlField::request(seq), FunctionCode::Read, &mut cursor).unwrap();
+
+    if classes.class0 {
+        request
+            .write_all_objects_header(Variation::Group60Var1)
+            .unwrap();
+    }
+
+    if classes.events.class1 {
+        request
+            .write_all_objects_header(Variation::Group60Var2)
+            .unwrap();
+    }
+
+    if classes.events.class2 {
+        request
+            .write_all_objects_header(Variation::Group60Var3)
+            .unwrap();
+    }
+
+    if classes.events.class3 {
+        request
+            .write_all_objects_header(Variation::Group60Var4)
+            .unwrap();
+    }
 
     cursor.written().to_vec()
 }

--- a/dnp3/src/master/tests/mod.rs
+++ b/dnp3/src/master/tests/mod.rs
@@ -1,4 +1,4 @@
 mod harness;
 
 //mod auto_tasks;
-//mod startup;
+mod startup;

--- a/dnp3/src/master/tests/mod.rs
+++ b/dnp3/src/master/tests/mod.rs
@@ -1,4 +1,4 @@
 mod harness;
 
-mod auto_tasks;
-mod startup;
+//mod auto_tasks;
+//mod startup;

--- a/dnp3/src/master/tests/mod.rs
+++ b/dnp3/src/master/tests/mod.rs
@@ -1,4 +1,4 @@
 mod harness;
 
-//mod auto_tasks;
+mod auto_tasks;
 mod startup;

--- a/dnp3/src/master/tests/startup.rs
+++ b/dnp3/src/master/tests/startup.rs
@@ -1,357 +1,305 @@
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use crate::app::format::write::start_request;
-use crate::app::variations::Variation;
-use crate::app::FunctionCode;
 use crate::app::RetryStrategy;
 use crate::app::Sequence;
-use crate::app::{ControlField, Iin, Iin1, Iin2};
+use crate::app::{Iin, Iin1, Iin2};
 use crate::master::association::AssociationConfig;
 use crate::master::request::{Classes, EventClasses};
 use crate::master::ReadRequest;
-use crate::util::cursor::WriteCursor;
-
-use tokio::time;
 
 use super::harness::create_association;
 use super::harness::requests::*;
 
-#[test]
-fn master_startup_procedure() {
+#[tokio::test]
+async fn master_startup_procedure() {
     let config = AssociationConfig::default();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    // Disable unsolicited
-    disable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Integrity poll
-    integrity_poll_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Enable unsolicited
-    enable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(disable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
+    harness
+        .expect_write_and_respond(integrity_poll_request(seq), empty_response(seq.increment()))
+        .await;
+    harness
+        .expect_write_and_respond(enable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 }
 
-#[test]
-fn master_startup_procedure_skips_unsolicited_if_none() {
+#[tokio::test]
+async fn master_startup_procedure_skips_integrity_poll_if_none() {
     let mut config = AssociationConfig::default();
     config.startup_integrity_classes = Classes::none();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
     // Disable unsolicited
-    disable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(disable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 
     // NO Integrity poll
 
     // Enable unsolicited
-    enable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(enable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 
     // Unsolicited NULL response with RESTART IIN
-    unsol_null(&mut harness.io, seq, true);
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(unsol_null(seq, true), unsol_confirm(seq))
+        .await;
 
     // Clear the restart flag
-    clear_restart_iin(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(clear_restart_iin(seq), empty_response(seq.increment()))
+        .await;
 
     // NO Integrity poll
 
     // Enable unsolicited
-    enable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(enable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 }
 
-#[test]
-fn master_startup_procedure_skips_integrity_poll_if_none() {
+#[tokio::test]
+async fn master_startup_procedure_skips_disable_unsol_if_none() {
     let mut config = AssociationConfig::default();
     config.disable_unsol_classes = EventClasses::none();
     config.enable_unsol_classes = EventClasses::none();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    // Only integrity poll is needed
-    integrity_poll_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(integrity_poll_request(seq), empty_response(seq.increment()))
+        .await;
 }
 
-#[test]
-fn clear_restart_iin_is_higher_priority() {
+#[tokio::test]
+async fn clear_restart_iin_is_higher_priority() {
     let config = AssociationConfig::default();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
     // Disable unsolicited
-    disable_unsol_request(&mut harness.io, seq);
-    harness.flush_io();
+    harness.expect_write(disable_unsol_request(seq)).await;
 
     // Never respond to it, send unsolicited NULL response with RESTART IIN
-    unsol_null(&mut harness.io, seq, true);
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(unsol_null(seq, true), unsol_confirm(seq))
+        .await;
 
     // Respond to the DISABLE_UNSOLICITED
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .process_response(empty_response(seq.increment()))
+        .await;
 
     // Now clear the restart flag
-    clear_restart_iin(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(clear_restart_iin(seq), empty_response(seq.increment()))
+        .await;
 
     // Proceed with the rest of the startup sequence
-
-    // Integrity poll
-    integrity_poll_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Enable unsolicited
-    enable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(integrity_poll_request(seq), empty_response(seq.increment()))
+        .await;
+    harness
+        .expect_write_and_respond(enable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 }
 
-#[test]
-fn outstation_restart_procedure() {
+#[tokio::test]
+async fn outstation_restart_procedure() {
     let config = AssociationConfig::default();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
     // Unsolicited NULL response with DEVICE_RESTART IIN
-    unsol_null(&mut harness.io, seq, true);
-    unsol_confirm(&mut harness.io, seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(unsol_null(seq, true), unsol_confirm(seq))
+        .await;
 
     // Clear the restart flag
-    clear_restart_iin(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(clear_restart_iin(seq), empty_response(seq.increment()))
+        .await;
 
     // Integrity poll
-    integrity_poll_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
+    harness
+        .expect_write_and_respond(integrity_poll_request(seq), empty_response(seq.increment()))
+        .await;
     // Enable unsolicited
-    enable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(enable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 }
 
-#[test]
-fn detect_restart_in_read_response() {
+#[tokio::test]
+async fn detect_restart_in_read_response() {
     let config = AssociationConfig::default();
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
-    // Send Class 0 read request
-    {
-        let mut read_task = spawn(
-            harness
-                .association
-                .read(ReadRequest::ClassScan(Classes::class0())),
-        );
-        assert_pending!(read_task.poll());
-    }
-    harness.flush_io();
+    // Spawn a task that sends an integrity scan
+    let mut assoc = harness.association.clone();
+    let read_task =
+        tokio::spawn(async move { assoc.read(ReadRequest::ClassScan(Classes::all())).await });
 
-    {
-        // Read class 0 data
-        let mut buffer = [0; 20];
-        let mut cursor = WriteCursor::new(&mut buffer);
-        let mut request =
-            start_request(ControlField::request(seq), FunctionCode::Read, &mut cursor).unwrap();
+    // expect the integrity scan and respond with DEVICE_RESTART
+    harness
+        .expect_write_and_respond(
+            integrity_poll_request(seq),
+            empty_response_custom_iin(seq.increment(), Iin::new(Iin1::new(0x80), Iin2::new(0x00))),
+        )
+        .await;
 
-        request
-            .write_all_objects_header(Variation::Group60Var1)
-            .unwrap();
+    assert_eq!(read_task.await.unwrap(), Ok(()));
 
-        harness.io.write(cursor.written());
-    }
-
-    // Response with DEVICE_RESTART IIN bit set
-    empty_response_custom_iin(
-        &mut harness.io,
-        seq.increment(),
-        Iin::new(Iin1::new(0x80), Iin2::new(0x00)),
-    );
-    harness.flush_io();
-
-    // Clear the restart flag
-    clear_restart_iin(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(clear_restart_iin(seq), empty_response(seq.increment()))
+        .await;
 }
 
-#[test]
-fn ignore_unsolicited_response_with_data_before_first_integrity_poll() {
+#[tokio::test]
+async fn ignore_unsolicited_response_with_data_before_first_integrity_poll() {
     let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut unsol_seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
     // Unsolicited NULL response with DEVICE_RESTART IIN
-    unsol_null(&mut harness.io, unsol_seq, true);
-    unsol_confirm(&mut harness.io, unsol_seq.increment());
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_null(unsol_seq, true),
+            unsol_confirm(unsol_seq.increment()),
+        )
+        .await;
 
     // Clear the restart flag
-    clear_restart_iin(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(clear_restart_iin(seq), empty_response(seq.increment()))
+        .await;
 
     // Integrity poll (never respond to)
-    integrity_poll_request(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write(integrity_poll_request(seq.increment()))
+        .await;
 
     // Send unsolicited with data
-    unsol_with_data(&mut harness.io, unsol_seq, 42, true);
-    harness.flush_io();
+    harness
+        .process_response(unsol_with_data(unsol_seq, 42, true))
+        .await;
 
     // DO NOT CONFIRM AND IGNORE PAYLOAD
     assert_eq!(harness.num_requests.fetch_add(0, Ordering::Relaxed), 0);
 
-    // Instead, wait for the integrity poll to timeout then
-    // restart the outstation startup procedure
-    time::advance(Duration::from_secs(1));
-    assert_pending!(harness.poll());
-
-    clear_restart_iin(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Integrity poll
-    time::advance(Duration::from_secs(1));
-    assert_pending!(harness.poll());
-
-    integrity_poll_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Enable unsolicited
-    enable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    tokio::time::pause(); // auto advance time
+    harness
+        .expect_write_and_respond(clear_restart_iin(seq), empty_response(seq.increment()))
+        .await;
+    harness
+        .expect_write_and_respond(integrity_poll_request(seq), empty_response(seq.increment()))
+        .await;
+    harness
+        .expect_write_and_respond(enable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 }
 
-#[test]
-fn ignore_duplicate_unsolicited_response() {
+#[tokio::test]
+async fn ignore_duplicate_unsolicited_response() {
     let config = AssociationConfig::default();
     let mut seq = Sequence::default();
     let mut unsol_seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
-    startup_procedure(&mut harness, &mut seq);
+    startup_procedure(&mut harness, &mut seq).await;
 
     // Send unsolicited with data
-    unsol_with_data(&mut harness.io, unsol_seq, 42, false);
-    unsol_confirm(&mut harness.io, unsol_seq);
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_with_data(unsol_seq, 42, false),
+            unsol_confirm(unsol_seq),
+        )
+        .await;
     assert_eq!(harness.num_requests(), 1);
 
     // Send exact same unsolicited response
-    unsol_with_data(&mut harness.io, unsol_seq, 42, false);
-    unsol_confirm(&mut harness.io, unsol_seq.increment());
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_with_data(unsol_seq, 42, false),
+            unsol_confirm(unsol_seq.increment()),
+        )
+        .await;
     assert_eq!(harness.num_requests(), 1);
 
     // Send different data
-    unsol_with_data(&mut harness.io, unsol_seq, 43, false);
-    unsol_confirm(&mut harness.io, unsol_seq.increment());
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_with_data(unsol_seq, 43, false),
+            unsol_confirm(unsol_seq.increment()),
+        )
+        .await;
     assert_eq!(harness.num_requests(), 2);
 
     // Send different sequence number
-    unsol_with_data(&mut harness.io, unsol_seq, 43, false);
-    unsol_confirm(&mut harness.io, unsol_seq.increment());
-    harness.flush_io();
+    harness
+        .read_and_expect_write(
+            unsol_with_data(unsol_seq, 43, false),
+            unsol_confirm(unsol_seq.increment()),
+        )
+        .await;
     assert_eq!(harness.num_requests(), 3);
 }
 
-#[test]
-fn master_startup_retry_procedure() {
+#[tokio::test]
+async fn master_startup_retry_procedure() {
     let mut config = AssociationConfig::default();
     config.auto_tasks_retry_strategy =
         RetryStrategy::new(Duration::from_secs(1), Duration::from_secs(3));
     let mut seq = Sequence::default();
-    let mut harness = create_association(config);
+    let mut harness = create_association(config).await;
 
     // First disable unsolicited
-    disable_unsol_request(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write(disable_unsol_request(seq.increment()))
+        .await;
 
     // Wait for the timeout
-    time::advance(Duration::from_secs(1));
-    assert_pending!(harness.poll());
+    let first_attempt = tokio::time::Instant::now();
+    tokio::time::pause();
+    harness
+        .expect_write(disable_unsol_request(seq.increment()))
+        .await;
+    let second_attempt = tokio::time::Instant::now();
 
-    // Wait before retransmitting
-    time::advance(Duration::from_millis(999));
-    harness.flush_io();
+    let elapsed = second_attempt - first_attempt;
+    assert!(elapsed >= Duration::from_secs(2));
 
-    // First retransmit
-    time::advance(Duration::from_millis(1));
-    disable_unsol_request(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(disable_unsol_request(seq), empty_response(seq))
+        .await;
+    let third_attempt = tokio::time::Instant::now();
+    let elapsed = third_attempt - second_attempt;
+    assert!(elapsed >= Duration::from_secs(3));
+    tokio::time::resume();
 
-    // Wait for the timeout
-    time::advance(Duration::from_secs(1));
-    harness.flush_io();
+    seq.increment();
 
-    // Wait before retransmitting
-    time::advance(Duration::from_millis(1999));
-    harness.flush_io();
+    // continues on with the rest of the procedure
+    harness
+        .expect_write_and_respond(integrity_poll_request(seq), empty_response(seq.increment()))
+        .await;
 
-    // Second retransmit
-    time::advance(Duration::from_millis(1));
-    disable_unsol_request(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Wait for the timeout
-    time::advance(Duration::from_secs(1));
-    harness.flush_io();
-
-    // Wait before retransmitting (reaching max delay)
-    time::advance(Duration::from_millis(2999));
-    harness.flush_io();
-
-    // Third retransmit
-    time::advance(Duration::from_millis(1));
-    disable_unsol_request(&mut harness.io, seq);
-    harness.flush_io();
-
-    // Actually answer it and complete the startup procedure
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Integrity poll
-    integrity_poll_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
-
-    // Enable unsolicited
-    enable_unsol_request(&mut harness.io, seq);
-    empty_response(&mut harness.io, seq.increment());
-    harness.flush_io();
+    harness
+        .expect_write_and_respond(enable_unsol_request(seq), empty_response(seq.increment()))
+        .await;
 }

--- a/dnp3/src/master/tests/startup.rs
+++ b/dnp3/src/master/tests/startup.rs
@@ -10,9 +10,9 @@ use crate::app::{ControlField, Iin, Iin1, Iin2};
 use crate::master::association::AssociationConfig;
 use crate::master::request::{Classes, EventClasses};
 use crate::master::ReadRequest;
-use crate::tokio::test::*;
-use crate::tokio::time;
 use crate::util::cursor::WriteCursor;
+
+use tokio::time;
 
 use super::harness::create_association;
 use super::harness::requests::*;

--- a/dnp3/src/outstation/adapter.rs
+++ b/dnp3/src/outstation/adapter.rs
@@ -47,7 +47,7 @@ impl OutstationTaskAdapter {
 
     async fn wait_for_session(&mut self) -> Result<NewSession, Shutdown> {
         loop {
-            crate::tokio::select! {
+            tokio::select! {
                 session = self.receiver.receive() => {
                     return session;
                 }
@@ -59,7 +59,7 @@ impl OutstationTaskAdapter {
     }
 
     async fn run_one_session(&mut self, io: &mut PhysLayer) -> Result<NewSession, RunError> {
-        crate::tokio::select! {
+        tokio::select! {
             res = self.task.run(io) => {
                 Err(res)
             }

--- a/dnp3/src/outstation/control/select.rs
+++ b/dnp3/src/outstation/control/select.rs
@@ -10,7 +10,7 @@ pub(crate) struct SelectState {
     /// without requests in between
     frame_id: u32,
     /// time at which the SELECT occurred
-    time: crate::tokio::time::Instant,
+    time: tokio::time::Instant,
     /// the hash of the object headers
     object_hash: u64,
 }
@@ -19,7 +19,7 @@ impl SelectState {
     pub(crate) fn new(
         seq: Sequence,
         frame_id: u32,
-        time: crate::tokio::time::Instant,
+        time: tokio::time::Instant,
         object_hash: u64,
     ) -> Self {
         Self {
@@ -41,7 +41,7 @@ impl SelectState {
         frame_id: u32,
         object_hash: u64,
     ) -> Result<(), CommandStatus> {
-        let elapsed = crate::tokio::time::Instant::now().checked_duration_since(self.time);
+        let elapsed = tokio::time::Instant::now().checked_duration_since(self.time);
 
         // check the sequence number
         if self.seq.next() != seq.value() {

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -294,7 +294,7 @@ impl Database {
 #[derive(Clone)]
 pub struct DatabaseHandle {
     inner: Arc<Mutex<Database>>,
-    notify: Arc<crate::tokio::sync::Notify>,
+    notify: Arc<tokio::sync::Notify>,
 }
 
 impl DatabaseHandle {
@@ -323,7 +323,7 @@ impl DatabaseHandle {
                 class_zero_config,
                 event_config,
             ))),
-            notify: Arc::new(crate::tokio::sync::Notify::new()),
+            notify: Arc::new(tokio::sync::Notify::new()),
         }
     }
 

--- a/dnp3/src/outstation/mod.rs
+++ b/dnp3/src/outstation/mod.rs
@@ -25,10 +25,8 @@ pub(crate) mod session;
 pub(crate) mod task;
 mod traits;
 
-/* TODO
 #[cfg(test)]
 mod tests;
-*/
 
 /// Handle used to control a running outstation task
 #[derive(Clone)]

--- a/dnp3/src/outstation/mod.rs
+++ b/dnp3/src/outstation/mod.rs
@@ -25,8 +25,10 @@ pub(crate) mod session;
 pub(crate) mod task;
 mod traits;
 
+/* TODO
 #[cfg(test)]
 mod tests;
+*/
 
 /// Handle used to control a running outstation task
 #[derive(Clone)]

--- a/dnp3/src/outstation/tests/controls.rs
+++ b/dnp3/src/outstation/tests/controls.rs
@@ -185,7 +185,7 @@ fn select_can_time_out() {
         Event::EndControls,
     ]);
 
-    crate::tokio::time::advance(
+    tokio::time::advance(
         get_default_config().select_timeout.value + Duration::from_millis(1),
     );
 

--- a/dnp3/src/outstation/tests/freeze.rs
+++ b/dnp3/src/outstation/tests/freeze.rs
@@ -5,11 +5,13 @@ const EMPTY_RESPONSE: &[u8] = &[0xC0, 0x81, 0x80, 0x00];
 const EMPTY_RESPONSE_PARAM_ERROR: &[u8] = &[0xC0, 0x81, 0x80, 0x04];
 const EMPTY_RESPONSE_NO_FUNC_SUPPORTED: &[u8] = &[0xC0, 0x81, 0x80, 0x01];
 
-#[test]
-fn immediate_freeze_all_counters() {
+#[tokio::test]
+async fn immediate_freeze_all_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(&[0xC0, 0x07, 20, 0, 0x06], EMPTY_RESPONSE);
+    harness
+        .test_request_response(&[0xC0, 0x07, 20, 0, 0x06], EMPTY_RESPONSE)
+        .await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::All,
@@ -17,11 +19,13 @@ fn immediate_freeze_all_counters() {
     )]);
 }
 
-#[test]
-fn immediate_freeze_range_of_counters() {
+#[tokio::test]
+async fn immediate_freeze_range_of_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(&[0xC0, 0x07, 20, 0, 0x00, 0, 10], EMPTY_RESPONSE);
+    harness
+        .test_request_response(&[0xC0, 0x07, 20, 0, 0x00, 0, 10], EMPTY_RESPONSE)
+        .await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::Range(0, 10),
@@ -29,11 +33,11 @@ fn immediate_freeze_range_of_counters() {
     )]);
 }
 
-#[test]
-fn immediate_freeze_no_response_all_counters() {
+#[tokio::test]
+async fn immediate_freeze_no_response_all_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_no_response(&[0xC0, 0x08, 20, 0, 0x06]);
+    harness.send_and_process(&[0xC0, 0x08, 20, 0, 0x06]).await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::All,
@@ -41,11 +45,13 @@ fn immediate_freeze_no_response_all_counters() {
     )]);
 }
 
-#[test]
-fn immediate_freeze_no_response_range_of_counters() {
+#[tokio::test]
+async fn immediate_freeze_no_response_range_of_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_no_response(&[0xC0, 0x08, 20, 0, 0x00, 0, 10]);
+    harness
+        .send_and_process(&[0xC0, 0x08, 20, 0, 0x00, 0, 10])
+        .await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::Range(0, 10),
@@ -53,11 +59,13 @@ fn immediate_freeze_no_response_range_of_counters() {
     )]);
 }
 
-#[test]
-fn freeze_and_clear_all_counters() {
+#[tokio::test]
+async fn freeze_and_clear_all_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(&[0xC0, 0x09, 20, 0, 0x06], EMPTY_RESPONSE);
+    harness
+        .test_request_response(&[0xC0, 0x09, 20, 0, 0x06], EMPTY_RESPONSE)
+        .await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::All,
@@ -65,11 +73,13 @@ fn freeze_and_clear_all_counters() {
     )]);
 }
 
-#[test]
-fn freeze_and_clear_range_of_counters() {
+#[tokio::test]
+async fn freeze_and_clear_range_of_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(&[0xC0, 0x09, 20, 0, 0x00, 0, 10], EMPTY_RESPONSE);
+    harness
+        .test_request_response(&[0xC0, 0x09, 20, 0, 0x00, 0, 10], EMPTY_RESPONSE)
+        .await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::Range(0, 10),
@@ -77,11 +87,11 @@ fn freeze_and_clear_range_of_counters() {
     )]);
 }
 
-#[test]
-fn freeze_and_clear_no_response_all_counters() {
+#[tokio::test]
+async fn freeze_and_clear_no_response_all_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_no_response(&[0xC0, 0x0A, 20, 0, 0x06]);
+    harness.send_and_process(&[0xC0, 0x0A, 20, 0, 0x06]).await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::All,
@@ -89,11 +99,13 @@ fn freeze_and_clear_no_response_all_counters() {
     )]);
 }
 
-#[test]
-fn freeze_and_clear_no_response_range_of_counters() {
+#[tokio::test]
+async fn freeze_and_clear_no_response_range_of_counters() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_no_response(&[0xC0, 0x0A, 20, 0, 0x00, 0, 10]);
+    harness
+        .send_and_process(&[0xC0, 0x0A, 20, 0, 0x00, 0, 10])
+        .await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::Range(0, 10),
@@ -101,14 +113,16 @@ fn freeze_and_clear_no_response_range_of_counters() {
     )]);
 }
 
-#[test]
-fn freeze_invalid_object() {
+#[tokio::test]
+async fn freeze_invalid_object() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(
-        &[0xC0, 0x07, 22, 0, 0x06, 20, 0, 0x06],
-        EMPTY_RESPONSE_NO_FUNC_SUPPORTED,
-    );
+    harness
+        .test_request_response(
+            &[0xC0, 0x07, 22, 0, 0x06, 20, 0, 0x06],
+            EMPTY_RESPONSE_NO_FUNC_SUPPORTED,
+        )
+        .await;
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::All,

--- a/dnp3/src/outstation/tests/harness/control.rs
+++ b/dnp3/src/outstation/tests/harness/control.rs
@@ -2,15 +2,15 @@ use crate::app::control::CommandStatus;
 use crate::app::variations::{Group12Var1, Group41Var1, Group41Var2, Group41Var3, Group41Var4};
 use crate::app::MaybeAsync;
 use crate::outstation::database::DatabaseHandle;
-use crate::outstation::tests::harness::{Control, Event, EventHandle};
+use crate::outstation::tests::harness::{Control, Event, EventSender};
 use crate::outstation::traits::{ControlHandler, ControlSupport, OperateType};
 
 pub(crate) struct MockControlHandler {
-    events: EventHandle,
+    events: EventSender,
 }
 
 impl MockControlHandler {
-    pub(crate) fn new(events: EventHandle) -> Box<dyn ControlHandler> {
+    pub(crate) fn new(events: EventSender) -> Box<dyn ControlHandler> {
         Box::new(Self { events })
     }
 }
@@ -23,7 +23,7 @@ impl ControlSupport<Group12Var1> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Select(Control::G12V1(control, index)));
+            .send(Event::Select(Control::G12V1(control, index)));
         CommandStatus::Success
     }
 
@@ -35,7 +35,7 @@ impl ControlSupport<Group12Var1> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Operate(Control::G12V1(control, index), op_type));
+            .send(Event::Operate(Control::G12V1(control, index), op_type));
         CommandStatus::Success
     }
 }
@@ -48,7 +48,7 @@ impl ControlSupport<Group41Var1> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Select(Control::G41V1(control, index)));
+            .send(Event::Select(Control::G41V1(control, index)));
         CommandStatus::Success
     }
 
@@ -60,7 +60,7 @@ impl ControlSupport<Group41Var1> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Operate(Control::G41V1(control, index), op_type));
+            .send(Event::Operate(Control::G41V1(control, index), op_type));
         CommandStatus::Success
     }
 }
@@ -73,7 +73,7 @@ impl ControlSupport<Group41Var2> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Select(Control::G41V2(control, index)));
+            .send(Event::Select(Control::G41V2(control, index)));
         CommandStatus::Success
     }
 
@@ -85,7 +85,7 @@ impl ControlSupport<Group41Var2> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Operate(Control::G41V2(control, index), op_type));
+            .send(Event::Operate(Control::G41V2(control, index), op_type));
         CommandStatus::Success
     }
 }
@@ -98,7 +98,7 @@ impl ControlSupport<Group41Var3> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Select(Control::G41V3(control, index)));
+            .send(Event::Select(Control::G41V3(control, index)));
         CommandStatus::Success
     }
 
@@ -110,7 +110,7 @@ impl ControlSupport<Group41Var3> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Operate(Control::G41V3(control, index), op_type));
+            .send(Event::Operate(Control::G41V3(control, index), op_type));
         CommandStatus::Success
     }
 }
@@ -123,7 +123,7 @@ impl ControlSupport<Group41Var4> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Select(Control::G41V4(control, index)));
+            .send(Event::Select(Control::G41V4(control, index)));
         CommandStatus::Success
     }
 
@@ -135,18 +135,18 @@ impl ControlSupport<Group41Var4> for MockControlHandler {
         _: &mut DatabaseHandle,
     ) -> CommandStatus {
         self.events
-            .push(Event::Operate(Control::G41V4(control, index), op_type));
+            .send(Event::Operate(Control::G41V4(control, index), op_type));
         CommandStatus::Success
     }
 }
 
 impl ControlHandler for MockControlHandler {
     fn begin_fragment(&mut self) {
-        self.events.push(Event::BeginControls);
+        self.events.send(Event::BeginControls);
     }
 
     fn end_fragment(&mut self, _: &mut DatabaseHandle) -> MaybeAsync<()> {
-        self.events.push(Event::EndControls);
+        self.events.send(Event::EndControls);
         MaybeAsync::ready(())
     }
 }

--- a/dnp3/src/outstation/tests/harness/harness.rs
+++ b/dnp3/src/outstation/tests/harness/harness.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use tokio::task::JoinHandle;
 
 use crate::decode::AppDecodeLevel;
 use crate::link::header::{BroadcastConfirmMode, FrameInfo, FrameType};
@@ -8,8 +9,8 @@ use crate::outstation::database::EventBufferConfig;
 use crate::outstation::session::RunError;
 use crate::outstation::task::OutstationTask;
 use crate::outstation::tests::harness::{
-    ApplicationData, Event, EventHandle, MockControlHandler, MockOutstationApplication,
-    MockOutstationInformation,
+    event_handlers, ApplicationData, Event, EventReceiver, MockControlHandler,
+    MockOutstationApplication, MockOutstationInformation,
 };
 use crate::outstation::OutstationHandle;
 use crate::util::phys::PhysLayer;
@@ -32,111 +33,82 @@ pub(crate) fn get_default_unsolicited_config() -> OutstationConfig {
     config
 }
 
-pub(crate) struct OutstationTestHarness<T>
-where
-    T: std::future::Future<Output = RunError>,
-{
+pub(crate) struct OutstationHarness {
     pub(crate) handle: OutstationHandle,
-    io: io::ScriptHandle,
-    task: Spawn<T>,
-    events: EventHandle,
+    pub(crate) io: tokio_mock_io::Handle,
+    task: JoinHandle<RunError>,
+    events: EventReceiver,
     pub(crate) application_data: Arc<Mutex<ApplicationData>>,
 }
 
-impl<T> OutstationTestHarness<T>
-where
-    T: std::future::Future<Output = RunError>,
-{
-    pub(crate) fn poll_pending(&mut self) {
-        assert_pending!(self.task.poll());
-    }
-
-    pub(crate) fn flush_io(&mut self) {
-        self.poll_pending();
-        let len = self.io.len();
-        if len != 0 {
-            panic!("i/o script has {} actions remaining", len)
-        }
-    }
-
-    pub(crate) fn test_request_response(&mut self, request: &[u8], response: &[u8]) {
+impl OutstationHarness {
+    pub(crate) async fn test_request_response(&mut self, request: &[u8], response: &[u8]) {
         self.io.read(request);
-        self.io.write(response);
-        self.flush_io();
+        assert_eq!(self.io.next_event().await, tokio_mock_io::Event::Read);
+        self.expect_response(response).await;
     }
 
-    pub(crate) fn expect_response(&mut self, response: &[u8]) {
-        self.io.write(response);
-        self.flush_io();
+    pub(crate) async fn expect_response(&mut self, response: &[u8]) {
+        assert_eq!(
+            self.io.next_event().await,
+            tokio_mock_io::Event::Write(response.to_vec())
+        );
     }
 
-    pub(crate) fn send(&mut self, request: &[u8]) {
+    pub(crate) async fn send_and_process(&mut self, request: &[u8]) {
         self.io.read(request);
-        self.flush_io();
+        assert_eq!(self.io.next_event().await, tokio_mock_io::Event::Read);
     }
 
     pub(crate) fn test_request_no_response(&mut self, request: &[u8]) {
         self.io.read(request);
-        self.poll_pending();
-        self.flush_io();
     }
 
-    pub(crate) fn check_events(&mut self, events: &[Event]) {
-        for event in events {
-            match self.events.pop() {
-                None => {
-                    panic!("Expected {:?} but there are no more events", event);
-                }
-                Some(x) => {
-                    if *event != x {
-                        panic!("Expected {:?} but next event is {:?}", event, x);
-                    }
-                }
+    pub(crate) async fn check_events(&mut self, expected: &[Event]) {
+        for event in expected {
+            let next = self.events.next().await;
+            if next != *event {
+                panic!("Expected {:?} but next event is {:?}", event, next);
             }
         }
-        self.check_no_events();
     }
 
     pub(crate) fn check_no_events(&mut self) {
-        if let Some(x) = self.events.pop() {
+        if let Some(x) = self.events.poll() {
             panic!("expected no events, but next event is: {:?}", x)
         }
     }
 }
 
-pub(crate) fn new_harness(
-    config: OutstationConfig,
-) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
+pub(crate) fn new_harness(config: OutstationConfig) -> OutstationHarness {
     new_harness_impl(config, None)
 }
 
-pub(crate) fn new_harness_with_custom_event_buffers(
-    config: OutstationConfig,
-) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
+pub(crate) fn new_harness_with_custom_event_buffers(config: OutstationConfig) -> OutstationHarness {
     new_harness_impl(config, None)
 }
 
 pub(crate) fn new_harness_for_broadcast(
     config: OutstationConfig,
     broadcast: BroadcastConfirmMode,
-) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
+) -> OutstationHarness {
     new_harness_impl(config, Some(broadcast))
 }
 
 fn new_harness_impl(
     config: OutstationConfig,
     broadcast: Option<BroadcastConfirmMode>,
-) -> OutstationTestHarness<impl std::future::Future<Output = RunError>> {
-    let events = EventHandle::new();
+) -> OutstationHarness {
+    let (sender, receiver) = event_handlers();
 
-    let (data, application) = MockOutstationApplication::new(events.clone());
+    let (data, application) = MockOutstationApplication::new(sender.clone());
 
     let (task, handle) = OutstationTask::create(
         LinkErrorMode::Close,
         config,
         application,
-        MockOutstationInformation::new(events.clone()),
-        MockControlHandler::new(events.clone()),
+        MockOutstationInformation::new(sender.clone()),
+        MockControlHandler::new(sender.clone()),
     );
 
     let mut task = Box::new(task);
@@ -149,15 +121,15 @@ fn new_harness_impl(
             FrameType::Data,
         ));
 
-    let (io, io_handle) = io::mock();
+    let (io, io_handle) = tokio_mock_io::mock();
 
     let mut io = PhysLayer::Mock(io);
 
-    OutstationTestHarness {
+    OutstationHarness {
         handle,
         io: io_handle,
-        task: spawn(async move { task.run(&mut io).await }),
-        events,
+        task: tokio::spawn(async move { task.run(&mut io).await }),
+        events: receiver,
         application_data: data,
     }
 }

--- a/dnp3/src/outstation/tests/harness/harness.rs
+++ b/dnp3/src/outstation/tests/harness/harness.rs
@@ -60,15 +60,24 @@ impl OutstationHarness {
         assert_eq!(self.io.next_event().await, tokio_mock_io::Event::Read);
     }
 
-    pub(crate) fn test_request_no_response(&mut self, request: &[u8]) {
-        self.io.read(request);
-    }
-
-    pub(crate) async fn check_events(&mut self, expected: &[Event]) {
+    pub(crate) async fn wait_for_events(&mut self, expected: &[Event]) {
         for event in expected {
             let next = self.events.next().await;
             if next != *event {
                 panic!("Expected {:?} but next event is {:?}", event, next);
+            }
+        }
+    }
+
+    pub(crate) fn check_events(&mut self, expected: &[Event]) {
+        for event in expected {
+            match self.events.poll() {
+                Some(next) => {
+                    if next != *event {
+                        panic!("Expected {:?} but next event is {:?}", event, next)
+                    }
+                }
+                None => panic!("Expected {:?} but no event ready", event),
             }
         }
     }

--- a/dnp3/src/outstation/tests/harness/harness.rs
+++ b/dnp3/src/outstation/tests/harness/harness.rs
@@ -12,7 +12,6 @@ use crate::outstation::tests::harness::{
     MockOutstationInformation,
 };
 use crate::outstation::OutstationHandle;
-use crate::tokio::test::*;
 use crate::util::phys::PhysLayer;
 
 pub(crate) fn get_default_config() -> OutstationConfig {

--- a/dnp3/src/outstation/tests/harness/harness.rs
+++ b/dnp3/src/outstation/tests/harness/harness.rs
@@ -43,8 +43,7 @@ pub(crate) struct OutstationHarness {
 
 impl OutstationHarness {
     pub(crate) async fn test_request_response(&mut self, request: &[u8], response: &[u8]) {
-        self.io.read(request);
-        assert_eq!(self.io.next_event().await, tokio_mock_io::Event::Read);
+        self.send_and_process(request).await;
         self.expect_response(response).await;
     }
 

--- a/dnp3/src/outstation/tests/harness/info.rs
+++ b/dnp3/src/outstation/tests/harness/info.rs
@@ -1,15 +1,15 @@
 use crate::app::FunctionCode;
 use crate::app::RequestHeader;
 use crate::app::Sequence;
-use crate::outstation::tests::harness::{Event, EventHandle};
+use crate::outstation::tests::harness::{Event, EventSender};
 use crate::outstation::traits::{BroadcastAction, OutstationInformation};
 
 pub(crate) struct MockOutstationInformation {
-    events: EventHandle,
+    events: EventSender,
 }
 
 impl MockOutstationInformation {
-    pub(crate) fn new(events: EventHandle) -> Box<dyn OutstationInformation> {
+    pub(crate) fn new(events: EventSender) -> Box<dyn OutstationInformation> {
         Box::new(Self { events })
     }
 }
@@ -20,54 +20,54 @@ impl OutstationInformation for MockOutstationInformation {
     }
 
     fn broadcast_received(&mut self, function: FunctionCode, action: BroadcastAction) {
-        self.events.push(Event::BroadcastReceived(function, action))
+        self.events.send(Event::BroadcastReceived(function, action))
     }
 
     fn enter_solicited_confirm_wait(&mut self, ecsn: Sequence) {
         self.events
-            .push(Event::EnterSolicitedConfirmWait(ecsn.value()))
+            .send(Event::EnterSolicitedConfirmWait(ecsn.value()))
     }
 
     fn solicited_confirm_timeout(&mut self, ecsn: Sequence) {
         self.events
-            .push(Event::SolicitedConfirmTimeout(ecsn.value()))
+            .send(Event::SolicitedConfirmTimeout(ecsn.value()))
     }
 
     fn solicited_confirm_received(&mut self, ecsn: Sequence) {
         self.events
-            .push(Event::SolicitedConfirmReceived(ecsn.value()))
+            .send(Event::SolicitedConfirmReceived(ecsn.value()))
     }
 
     fn solicited_confirm_wait_new_request(&mut self) {
-        self.events.push(Event::SolicitedConfirmWaitNewRequest)
+        self.events.send(Event::SolicitedConfirmWaitNewRequest)
     }
 
     fn unexpected_confirm(&mut self, unsolicited: bool, seq: Sequence) {
         self.events
-            .push(Event::UnexpectedConfirm(unsolicited, seq.value()))
+            .send(Event::UnexpectedConfirm(unsolicited, seq.value()))
     }
 
     fn wrong_solicited_confirm_seq(&mut self, ecsn: Sequence, seq: Sequence) {
         self.events
-            .push(Event::WrongSolicitedConfirmSeq(ecsn.value(), seq.value()))
+            .send(Event::WrongSolicitedConfirmSeq(ecsn.value(), seq.value()))
     }
 
     fn clear_restart_iin(&mut self) {
-        self.events.push(Event::ClearRestartIIN)
+        self.events.send(Event::ClearRestartIIN)
     }
 
     fn enter_unsolicited_confirm_wait(&mut self, ecsn: Sequence) {
         self.events
-            .push(Event::EnterUnsolicitedConfirmWait(ecsn.value()))
+            .send(Event::EnterUnsolicitedConfirmWait(ecsn.value()))
     }
 
     fn unsolicited_confirm_timeout(&mut self, ecsn: Sequence, retry: bool) {
         self.events
-            .push(Event::UnsolicitedConfirmTimeout(ecsn.value(), retry))
+            .send(Event::UnsolicitedConfirmTimeout(ecsn.value(), retry))
     }
 
     fn unsolicited_confirmed(&mut self, ecsn: Sequence) {
         self.events
-            .push(Event::UnsolicitedConfirmReceived(ecsn.value()))
+            .send(Event::UnsolicitedConfirmReceived(ecsn.value()))
     }
 }

--- a/dnp3/src/outstation/tests/iin.rs
+++ b/dnp3/src/outstation/tests/iin.rs
@@ -13,47 +13,57 @@ const RESPONSE_WITH_OVERFLOW: &[u8] = &[
 const CONFIRM_SEQ_0: &[u8] = &[0xC0, 0x00];
 const EMPTY_RESPONSE: &[u8] = &[0xC0, 0x81, 0x80, 0x00];
 
-#[test]
-fn incomplete_request() {
+#[tokio::test]
+async fn incomplete_request() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_no_response(
-        &[0xC0], // Incomplete request
-    );
+    harness
+        .send_and_process(
+            &[0xC0], // Incomplete request
+        )
+        .await;
+
+    harness.check_no_events();
 }
 
-#[test]
-fn function_code_does_not_exist() {
+#[tokio::test]
+async fn function_code_does_not_exist() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(
-        &[0xC0, 0x70],             // Invalid function code 0x70
-        &[0xC0, 0x81, 0x80, 0x01], // IIN2.0 NO_FUNC_CODE_SUPPORT set
-    );
+    harness
+        .test_request_response(
+            &[0xC0, 0x70],             // Invalid function code 0x70
+            &[0xC0, 0x81, 0x80, 0x01], // IIN2.0 NO_FUNC_CODE_SUPPORT set
+        )
+        .await;
 }
 
-#[test]
-fn function_code_not_supported() {
+#[tokio::test]
+async fn function_code_not_supported() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(
-        &[0xC0, 0x13],             // Function code SAVE_CONFIG (0x13) is not supported
-        &[0xC0, 0x81, 0x80, 0x01], // IIN2.0 NO_FUNC_CODE_SUPPORT set
-    );
+    harness
+        .test_request_response(
+            &[0xC0, 0x13],             // Function code SAVE_CONFIG (0x13) is not supported
+            &[0xC0, 0x81, 0x80, 0x01], // IIN2.0 NO_FUNC_CODE_SUPPORT set
+        )
+        .await;
 }
 
-#[test]
-fn object_unknown() {
+#[tokio::test]
+async fn object_unknown() {
     let mut harness = new_harness(get_default_config());
 
-    harness.test_request_response(
-        &[0xC0, 0x01, 0x00, 0x00], // Read g0v0
-        &[0xC0, 0x81, 0x80, 0x02], // IIN2.1 OBJECT_UNKNOWN set
-    );
+    harness
+        .test_request_response(
+            &[0xC0, 0x01, 0x00, 0x00], // Read g0v0
+            &[0xC0, 0x81, 0x80, 0x02], // IIN2.1 OBJECT_UNKNOWN set
+        )
+        .await;
 }
 
-#[test]
-fn buffer_overflow() {
+#[tokio::test]
+async fn buffer_overflow() {
     let mut harness = new_harness(get_default_config());
 
     // Generate a buffer overflow
@@ -72,12 +82,18 @@ fn buffer_overflow() {
             );
         }
     });
-    harness.test_request_response(READ_CLASS_123, RESPONSE_WITH_OVERFLOW);
+    harness
+        .test_request_response(READ_CLASS_123, RESPONSE_WITH_OVERFLOW)
+        .await;
 
     // Do NOT send confirm, should still set the overflow bit
-    harness.test_request_response(READ_CLASS_1, RESPONSE_WITH_OVERFLOW);
+    harness
+        .test_request_response(READ_CLASS_1, RESPONSE_WITH_OVERFLOW)
+        .await;
 
     // Send confirmation, check that overflow bit is NOT set
-    harness.test_request_no_response(CONFIRM_SEQ_0);
-    harness.test_request_response(READ_CLASS_123, EMPTY_RESPONSE);
+    harness.send_and_process(CONFIRM_SEQ_0).await;
+    harness
+        .test_request_response(READ_CLASS_123, EMPTY_RESPONSE)
+        .await;
 }

--- a/dnp3/src/outstation/tests/mod.rs
+++ b/dnp3/src/outstation/tests/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod harness;
 
-/*
 /// control functionality
 mod controls;
+/*
 /// freeze counters tests
 mod freeze;
 /// various IIN bit tests

--- a/dnp3/src/outstation/tests/mod.rs
+++ b/dnp3/src/outstation/tests/mod.rs
@@ -12,10 +12,8 @@ mod read_states;
 mod restart;
 /// time synchronization
 mod time;
-/*
 /// unsolicited responses
 mod unsolicited;
- */
 
 /// test data for use in multiple tests
 mod data {

--- a/dnp3/src/outstation/tests/mod.rs
+++ b/dnp3/src/outstation/tests/mod.rs
@@ -10,9 +10,9 @@ mod iin;
 mod read_states;
 /// clear restart IIN + cold/warm restart
 mod restart;
-/*
 /// time synchronization
 mod time;
+/*
 /// unsolicited responses
 mod unsolicited;
  */

--- a/dnp3/src/outstation/tests/mod.rs
+++ b/dnp3/src/outstation/tests/mod.rs
@@ -2,9 +2,9 @@ pub(crate) mod harness;
 
 /// control functionality
 mod controls;
-/*
 /// freeze counters tests
 mod freeze;
+/*
 /// various IIN bit tests
 mod iin;
 */

--- a/dnp3/src/outstation/tests/mod.rs
+++ b/dnp3/src/outstation/tests/mod.rs
@@ -8,9 +8,9 @@ mod freeze;
 mod iin;
 /// state machine for READ requests
 mod read_states;
-/*
 /// clear restart IIN + cold/warm restart
 mod restart;
+/*
 /// time synchronization
 mod time;
 /// unsolicited responses

--- a/dnp3/src/outstation/tests/mod.rs
+++ b/dnp3/src/outstation/tests/mod.rs
@@ -1,19 +1,23 @@
 pub(crate) mod harness;
 
+/*
 /// control functionality
 mod controls;
 /// freeze counters tests
 mod freeze;
 /// various IIN bit tests
 mod iin;
+*/
 /// state machine for READ requests
 mod read_states;
+/*
 /// clear restart IIN + cold/warm restart
 mod restart;
 /// time synchronization
 mod time;
 /// unsolicited responses
 mod unsolicited;
+ */
 
 /// test data for use in multiple tests
 mod data {

--- a/dnp3/src/outstation/tests/mod.rs
+++ b/dnp3/src/outstation/tests/mod.rs
@@ -4,10 +4,8 @@ pub(crate) mod harness;
 mod controls;
 /// freeze counters tests
 mod freeze;
-/*
 /// various IIN bit tests
 mod iin;
-*/
 /// state machine for READ requests
 mod read_states;
 /*

--- a/dnp3/src/outstation/tests/read_states.rs
+++ b/dnp3/src/outstation/tests/read_states.rs
@@ -180,7 +180,7 @@ fn confirm_can_time_out() {
 
     harness.test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE);
     harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
-    crate::tokio::time::advance(
+    tokio::time::advance(
         get_default_config().confirm_timeout.value + Duration::from_millis(1),
     );
     harness.poll_pending();

--- a/dnp3/src/outstation/tests/read_states.rs
+++ b/dnp3/src/outstation/tests/read_states.rs
@@ -1,5 +1,3 @@
-use tokio::time::Duration;
-
 use crate::app::measurement::*;
 use crate::app::*;
 use crate::outstation::database::*;
@@ -50,15 +48,16 @@ fn create_five_binary_inputs_with_odd_indices_true(database: &mut Database) {
     }
 }
 
-#[test]
-fn empty_read_yields_empty_response() {
+#[tokio::test]
+async fn empty_read_yields_empty_response() {
     let mut harness = new_harness(get_default_config());
-    harness.test_request_response(EMPTY_READ, EMPTY_RESPONSE);
-    harness.check_no_events();
+    harness
+        .test_request_response(EMPTY_READ, EMPTY_RESPONSE)
+        .await;
 }
 
-#[test]
-fn can_read_one_byte_range_for_specific_variation() {
+#[tokio::test]
+async fn can_read_one_byte_range_for_specific_variation() {
     let mut harness = new_harness(get_default_config());
 
     harness
@@ -67,18 +66,20 @@ fn can_read_one_byte_range_for_specific_variation() {
         .transaction(create_one_analog_with_value_42);
 
     const READ_G30_V1_0_TO_0: &[u8] = &[0xC0, 0x01, 0x1E, 0x01, 0x00, 0x00, 0x00];
-    harness.test_request_response(
-        READ_G30_V1_0_TO_0,
-        &[
-            0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2A, 0x00,
-            0x00, 0x00,
-        ],
-    );
-    harness.check_events(&[]);
+    harness
+        .test_request_response(
+            READ_G30_V1_0_TO_0,
+            &[
+                0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2A, 0x00,
+                0x00, 0x00,
+            ],
+        )
+        .await;
+    harness.check_no_events();
 }
 
-#[test]
-fn can_read_one_byte_range_for_default_variation() {
+#[tokio::test]
+async fn can_read_one_byte_range_for_default_variation() {
     let mut harness = new_harness(get_default_config());
 
     harness
@@ -87,18 +88,20 @@ fn can_read_one_byte_range_for_default_variation() {
         .transaction(create_one_analog_with_value_42);
 
     const READ_G30_V0_0_TO_0: &[u8] = &[0xC0, 0x01, 0x1E, 0x00, 0x00, 0x00, 0x00];
-    harness.test_request_response(
-        READ_G30_V0_0_TO_0,
-        &[
-            0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2A, 0x00,
-            0x00, 0x00,
-        ],
-    );
-    harness.check_events(&[]);
+    harness
+        .test_request_response(
+            READ_G30_V0_0_TO_0,
+            &[
+                0xC0, 0x81, 0x80, 0x00, 0x1E, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2A, 0x00,
+                0x00, 0x00,
+            ],
+        )
+        .await;
+    harness.check_no_events();
 }
 
-#[test]
-fn can_read_two_byte_range_for_specific_variation() {
+#[tokio::test]
+async fn can_read_two_byte_range_for_specific_variation() {
     let mut harness = new_harness(get_default_config());
 
     harness
@@ -107,17 +110,19 @@ fn can_read_two_byte_range_for_specific_variation() {
         .transaction(create_five_binary_inputs_with_odd_indices_true);
 
     const READ_G1_V2_1_TO_3: &[u8] = &[0xC0, 0x01, 0x01, 0x02, 0x01, 0x01, 0x00, 0x03, 0x00];
-    harness.test_request_response(
-        READ_G1_V2_1_TO_3,
-        &[
-            0xC0, 0x81, 0x80, 0x00, 0x01, 0x02, 0x01, 0x01, 0x00, 0x03, 0x00, 0x81, 0x01, 0x81,
-        ],
-    );
-    harness.check_events(&[]);
+    harness
+        .test_request_response(
+            READ_G1_V2_1_TO_3,
+            &[
+                0xC0, 0x81, 0x80, 0x00, 0x01, 0x02, 0x01, 0x01, 0x00, 0x03, 0x00, 0x81, 0x01, 0x81,
+            ],
+        )
+        .await;
+    harness.check_no_events();
 }
 
-#[test]
-fn can_read_two_byte_range_for_default_variation() {
+#[tokio::test]
+async fn can_read_two_byte_range_for_default_variation() {
     let mut harness = new_harness(get_default_config());
 
     harness
@@ -126,67 +131,93 @@ fn can_read_two_byte_range_for_default_variation() {
         .transaction(create_five_binary_inputs_with_odd_indices_true);
 
     const READ_G1_V0_1_TO_3: &[u8] = &[0xC0, 0x01, 0x01, 0x00, 0x01, 0x01, 0x00, 0x03, 0x00];
-    harness.test_request_response(
-        READ_G1_V0_1_TO_3,
-        // the response here is g1v1, packed format, the bit pattern is 0b101 == 0x05
-        &[
-            0xC0, 0x81, 0x80, 0x00, 0x01, 0x01, 0x01, 0x01, 0x00, 0x03, 0x00, 0x05,
-        ],
-    );
-    harness.check_events(&[]);
+    harness
+        .test_request_response(
+            READ_G1_V0_1_TO_3,
+            // the response here is g1v1, packed format, the bit pattern is 0b101 == 0x05
+            &[
+                0xC0, 0x81, 0x80, 0x00, 0x01, 0x01, 0x01, 0x01, 0x00, 0x03, 0x00, 0x05,
+            ],
+        )
+        .await;
+    harness.check_no_events();
 }
 
-#[test]
-fn can_read_and_confirm_events() {
+#[tokio::test]
+async fn can_read_and_confirm_events() {
     let mut harness = new_harness(get_default_config());
 
     harness.handle.database.transaction(create_binary_and_event);
 
-    harness.test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE);
-    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
-    harness.send(CONFIRM_SEQ_0);
-    harness.check_events(&[Event::SolicitedConfirmReceived(0)]);
+    harness
+        .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
+        .await;
+    harness
+        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
+        .await;
+    harness.send_and_process(CONFIRM_SEQ_0).await;
+    harness
+        .check_events(&[Event::SolicitedConfirmReceived(0)])
+        .await;
 }
 
-#[test]
-fn ignores_confirm_with_wrong_seq() {
+#[tokio::test]
+async fn ignores_confirm_with_wrong_seq() {
     let mut harness = new_harness(get_default_config());
 
     harness.handle.database.transaction(create_binary_and_event);
 
-    harness.test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE);
-    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
-    harness.send(CONFIRM_SEQ_1);
-    harness.check_events(&[Event::WrongSolicitedConfirmSeq(0, 1)]);
+    harness
+        .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
+        .await;
+    harness
+        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
+        .await;
+    harness.send_and_process(CONFIRM_SEQ_1).await;
+    harness
+        .check_events(&[Event::WrongSolicitedConfirmSeq(0, 1)])
+        .await;
 }
 
-#[test]
-fn ignores_unsolicited_confirm_with_correct_seq() {
+#[tokio::test]
+async fn ignores_unsolicited_confirm_with_correct_seq() {
     let mut harness = new_harness(get_default_config());
 
     harness.handle.database.transaction(create_binary_and_event);
 
-    harness.test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE);
-    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
-    harness.send(UNS_CONFIRM_SEQ_0);
-    harness.check_events(&[Event::UnexpectedConfirm(true, 0)]);
+    harness
+        .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
+        .await;
+    harness
+        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
+        .await;
+    harness.send_and_process(UNS_CONFIRM_SEQ_0).await;
+    harness
+        .check_events(&[Event::UnexpectedConfirm(true, 0)])
+        .await;
 }
 
-#[test]
-fn confirm_can_time_out() {
+#[tokio::test]
+async fn confirm_can_time_out() {
     let mut harness = new_harness(get_default_config());
 
     harness.handle.database.transaction(create_binary_and_event);
 
-    harness.test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE);
-    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
-    tokio::time::advance(
-        get_default_config().confirm_timeout.value + Duration::from_millis(1),
-    );
-    harness.poll_pending();
-    harness.check_events(&[Event::SolicitedConfirmTimeout(0)])
+    harness
+        .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
+        .await;
+    harness
+        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
+        .await;
+
+    tokio::time::pause(); // auto advance timers
+
+    harness
+        .check_events(&[Event::SolicitedConfirmTimeout(0)])
+        .await;
 }
 
+/*
 #[test]
 fn sol_confirm_wait_goes_back_to_idle_with_new_request() {
     let mut harness = new_harness(get_default_config());
@@ -212,3 +243,4 @@ fn sol_confirm_wait_goes_back_to_idle_with_new_invalid_request() {
     );
     harness.check_events(&[Event::SolicitedConfirmWaitNewRequest]);
 }
+*/

--- a/dnp3/src/outstation/tests/read_states.rs
+++ b/dnp3/src/outstation/tests/read_states.rs
@@ -152,13 +152,10 @@ async fn can_read_and_confirm_events() {
     harness
         .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
         .await;
-    harness
-        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
-        .await;
+
+    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
     harness.send_and_process(CONFIRM_SEQ_0).await;
-    harness
-        .check_events(&[Event::SolicitedConfirmReceived(0)])
-        .await;
+    harness.check_events(&[Event::SolicitedConfirmReceived(0)]);
 }
 
 #[tokio::test]
@@ -170,13 +167,10 @@ async fn ignores_confirm_with_wrong_seq() {
     harness
         .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
         .await;
-    harness
-        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
-        .await;
+    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
+
     harness.send_and_process(CONFIRM_SEQ_1).await;
-    harness
-        .check_events(&[Event::WrongSolicitedConfirmSeq(0, 1)])
-        .await;
+    harness.check_events(&[Event::WrongSolicitedConfirmSeq(0, 1)]);
 }
 
 #[tokio::test]
@@ -188,13 +182,9 @@ async fn ignores_unsolicited_confirm_with_correct_seq() {
     harness
         .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
         .await;
-    harness
-        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
-        .await;
+    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
     harness.send_and_process(UNS_CONFIRM_SEQ_0).await;
-    harness
-        .check_events(&[Event::UnexpectedConfirm(true, 0)])
-        .await;
+    harness.check_events(&[Event::UnexpectedConfirm(true, 0)]);
 }
 
 #[tokio::test]
@@ -206,14 +196,12 @@ async fn confirm_can_time_out() {
     harness
         .test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE)
         .await;
-    harness
-        .check_events(&[Event::EnterSolicitedConfirmWait(0)])
-        .await;
+    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
 
     tokio::time::pause(); // auto advance timers
 
     harness
-        .check_events(&[Event::SolicitedConfirmTimeout(0)])
+        .wait_for_events(&[Event::SolicitedConfirmTimeout(0)])
         .await;
 }
 

--- a/dnp3/src/outstation/tests/restart.rs
+++ b/dnp3/src/outstation/tests/restart.rs
@@ -11,57 +11,71 @@ const RESPONSE_TIME_DELAY_FINE: &[u8] =
 const RESPONSE_TIME_DELAY_COARSE: &[u8] =
     &[0xC0, 0x81, 0x80, 0x00, 0x34, 0x01, 0x07, 0x01, 0xFE, 0xCA];
 
-#[test]
-fn can_clear_the_restart_iin_bit() {
+#[tokio::test]
+async fn can_clear_the_restart_iin_bit() {
     let mut harness = new_harness(get_default_config());
-    harness.test_request_response(CLEAR_RESTART_IIN, RESPONSE_NO_RESTART_IIN);
+    harness
+        .test_request_response(CLEAR_RESTART_IIN, RESPONSE_NO_RESTART_IIN)
+        .await;
     harness.check_events(&[Event::ClearRestartIIN])
 }
 
-#[test]
-fn handles_cold_restart_when_not_supported() {
+#[tokio::test]
+async fn handles_cold_restart_when_not_supported() {
     let mut harness = new_harness(get_default_config());
-    harness.test_request_response(COLD_RESTART, RESPONSE_NO_FUNCTION_SUPPORT);
+    harness
+        .test_request_response(COLD_RESTART, RESPONSE_NO_FUNCTION_SUPPORT)
+        .await;
     harness.check_events(&[Event::ColdRestart(None)])
 }
 
-#[test]
-fn handles_cold_restart_when_supported_via_time_delay_fine() {
+#[tokio::test]
+async fn handles_cold_restart_when_supported_via_time_delay_fine() {
     let mut harness = new_harness(get_default_config());
     harness.application_data.lock().unwrap().restart_delay =
         Some(RestartDelay::Milliseconds(0xCAFE));
-    harness.test_request_response(COLD_RESTART, RESPONSE_TIME_DELAY_FINE);
+    harness
+        .test_request_response(COLD_RESTART, RESPONSE_TIME_DELAY_FINE)
+        .await;
     harness.check_events(&[Event::ColdRestart(Some(RestartDelay::Milliseconds(0xCAFE)))])
 }
 
-#[test]
-fn handles_cold_restart_when_supported_via_time_delay_coarse() {
+#[tokio::test]
+async fn handles_cold_restart_when_supported_via_time_delay_coarse() {
     let mut harness = new_harness(get_default_config());
     harness.application_data.lock().unwrap().restart_delay = Some(RestartDelay::Seconds(0xCAFE));
-    harness.test_request_response(COLD_RESTART, RESPONSE_TIME_DELAY_COARSE);
+    harness
+        .test_request_response(COLD_RESTART, RESPONSE_TIME_DELAY_COARSE)
+        .await;
     harness.check_events(&[Event::ColdRestart(Some(RestartDelay::Seconds(0xCAFE)))])
 }
 
-#[test]
-fn handles_warm_restart_when_not_supported() {
+#[tokio::test]
+async fn handles_warm_restart_when_not_supported() {
     let mut harness = new_harness(get_default_config());
-    harness.test_request_response(WARM_RESTART, RESPONSE_NO_FUNCTION_SUPPORT);
+    harness
+        .test_request_response(WARM_RESTART, RESPONSE_NO_FUNCTION_SUPPORT)
+        .await;
     harness.check_events(&[Event::WarmRestart(None)])
 }
 
-#[test]
-fn handles_warm_restart_when_supported_via_time_delay_fine() {
+#[tokio::test]
+async fn handles_warm_restart_when_supported_via_time_delay_fine() {
     let mut harness = new_harness(get_default_config());
     harness.application_data.lock().unwrap().restart_delay =
         Some(RestartDelay::Milliseconds(0xCAFE));
-    harness.test_request_response(WARM_RESTART, RESPONSE_TIME_DELAY_FINE);
+    harness
+        .test_request_response(WARM_RESTART, RESPONSE_TIME_DELAY_FINE)
+        .await;
     harness.check_events(&[Event::WarmRestart(Some(RestartDelay::Milliseconds(0xCAFE)))])
 }
 
-#[test]
-fn handles_warm_restart_when_supported_via_time_delay_coarse() {
+#[tokio::test]
+async fn handles_warm_restart_when_supported_via_time_delay_coarse() {
     let mut harness = new_harness(get_default_config());
     harness.application_data.lock().unwrap().restart_delay = Some(RestartDelay::Seconds(0xCAFE));
-    harness.test_request_response(WARM_RESTART, RESPONSE_TIME_DELAY_COARSE);
+    harness
+        .test_request_response(WARM_RESTART, RESPONSE_TIME_DELAY_COARSE)
+        .await;
     harness.check_events(&[Event::WarmRestart(Some(RestartDelay::Seconds(0xCAFE)))])
 }

--- a/dnp3/src/outstation/tests/time.rs
+++ b/dnp3/src/outstation/tests/time.rs
@@ -22,7 +22,9 @@ async fn responds_to_delay_measure() {
 
     harness.application_data.lock().unwrap().processing_delay = 0xCAFE;
 
-    harness.test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE).await;
+    harness
+        .test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE)
+        .await;
 }
 
 #[tokio::test]
@@ -31,8 +33,12 @@ async fn non_lan_procedure() {
 
     harness.application_data.lock().unwrap().processing_delay = 0xCAFE;
 
-    harness.test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE).await;
-    harness.test_request_response(WRITE_ABSOLUTE_TIME, EMPTY_RESPONSE_SEQ1).await;
+    harness
+        .test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE)
+        .await;
+    harness
+        .test_request_response(WRITE_ABSOLUTE_TIME, EMPTY_RESPONSE_SEQ1)
+        .await;
 
     harness.check_events(&[Event::WriteAbsoluteTime(Timestamp::new(1614271096000))]);
 }
@@ -43,8 +49,12 @@ async fn lan_procedure() {
 
     harness.application_data.lock().unwrap().processing_delay = 0xCAFE;
 
-    harness.test_request_response(RECORD_CURRENT_TIME, EMPTY_RESPONSE_SEQ0).await;
-    harness.test_request_response(WRITE_LAST_RECORDED_TIME, EMPTY_RESPONSE_SEQ1).await;
+    harness
+        .test_request_response(RECORD_CURRENT_TIME, EMPTY_RESPONSE_SEQ0)
+        .await;
+    harness
+        .test_request_response(WRITE_LAST_RECORDED_TIME, EMPTY_RESPONSE_SEQ1)
+        .await;
 
     harness.check_events(&[Event::WriteAbsoluteTime(Timestamp::new(0 + 0xCAFE))]);
 }

--- a/dnp3/src/outstation/tests/time.rs
+++ b/dnp3/src/outstation/tests/time.rs
@@ -16,35 +16,35 @@ const WRITE_LAST_RECORDED_TIME: &[u8] = &[
 const EMPTY_RESPONSE_SEQ0: &[u8] = &[0xC0, 0x81, 0x80, 0x00];
 const EMPTY_RESPONSE_SEQ1: &[u8] = &[0xC1, 0x81, 0x80, 0x00];
 
-#[test]
-fn responds_to_delay_measure() {
+#[tokio::test]
+async fn responds_to_delay_measure() {
     let mut harness = new_harness(get_default_config());
 
     harness.application_data.lock().unwrap().processing_delay = 0xCAFE;
 
-    harness.test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE);
+    harness.test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE).await;
 }
 
-#[test]
-fn non_lan_procedure() {
+#[tokio::test]
+async fn non_lan_procedure() {
     let mut harness = new_harness(get_default_config());
 
     harness.application_data.lock().unwrap().processing_delay = 0xCAFE;
 
-    harness.test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE);
-    harness.test_request_response(WRITE_ABSOLUTE_TIME, EMPTY_RESPONSE_SEQ1);
+    harness.test_request_response(super::data::DELAY_MEASURE, RESPONSE_TIME_DELAY_FINE_CAFE).await;
+    harness.test_request_response(WRITE_ABSOLUTE_TIME, EMPTY_RESPONSE_SEQ1).await;
 
     harness.check_events(&[Event::WriteAbsoluteTime(Timestamp::new(1614271096000))]);
 }
 
-#[test]
-fn lan_procedure() {
+#[tokio::test]
+async fn lan_procedure() {
     let mut harness = new_harness(get_default_config());
 
     harness.application_data.lock().unwrap().processing_delay = 0xCAFE;
 
-    harness.test_request_response(RECORD_CURRENT_TIME, EMPTY_RESPONSE_SEQ0);
-    harness.test_request_response(WRITE_LAST_RECORDED_TIME, EMPTY_RESPONSE_SEQ1);
+    harness.test_request_response(RECORD_CURRENT_TIME, EMPTY_RESPONSE_SEQ0).await;
+    harness.test_request_response(WRITE_LAST_RECORDED_TIME, EMPTY_RESPONSE_SEQ1).await;
 
     harness.check_events(&[Event::WriteAbsoluteTime(Timestamp::new(0 + 0xCAFE))]);
 }

--- a/dnp3/src/outstation/tests/unsolicited.rs
+++ b/dnp3/src/outstation/tests/unsolicited.rs
@@ -1,7 +1,6 @@
 use crate::app::{measurement::*, Timestamp};
 use crate::outstation::config::OutstationConfig;
 use crate::outstation::database::*;
-use crate::outstation::session::RunError;
 
 use super::harness::*;
 
@@ -46,18 +45,12 @@ fn generate_binary_event(handle: &mut DatabaseHandle) {
     });
 }
 
-fn enable_unsolicited<T>(harness: &mut OutstationTestHarness<T>)
-where
-    T: std::future::Future<Output = RunError>,
-{
-    harness.test_request_response(ENABLE_UNSOLICITED_SEQ0, EMPTY_RESPONSE_SEQ0);
+async fn enable_unsolicited(harness: &mut OutstationHarness) {
+    harness.test_request_response(ENABLE_UNSOLICITED_SEQ0, EMPTY_RESPONSE_SEQ0).await;
 }
 
-fn confirm_null_unsolicited<T>(harness: &mut OutstationTestHarness<T>)
-where
-    T: std::future::Future<Output = RunError>,
-{
-    harness.expect_response(NULL_UNSOL_SEQ_0);
+async fn confirm_null_unsolicited(harness: &mut OutstationHarness) {
+    harness.expect_response(NULL_UNSOL_SEQ_0).await;
     harness.send(UNS_CONFIRM_SEQ_0);
     harness.check_events(&[
         Event::EnterUnsolicitedConfirmWait(0),
@@ -71,6 +64,7 @@ fn config_with_limited_retries(retries: usize) -> OutstationConfig {
     config
 }
 
+/*
 #[test]
 fn null_unsolicited_always_retries() {
     let mut harness = new_harness(get_default_unsolicited_config());
@@ -334,3 +328,4 @@ fn buffer_overflow_issue() {
         ],
     );
 }
+*/

--- a/dnp3/src/outstation/tests/unsolicited.rs
+++ b/dnp3/src/outstation/tests/unsolicited.rs
@@ -77,7 +77,7 @@ fn null_unsolicited_always_retries() {
     harness.expect_response(NULL_UNSOL_SEQ_0);
     harness.check_events(&[Event::EnterUnsolicitedConfirmWait(0)]);
 
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
+    tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
     harness.poll_pending();
     harness.check_events(&[Event::UnsolicitedConfirmTimeout(0, false)]);
 
@@ -98,7 +98,7 @@ fn unsolicited_can_time_out_and_retry() {
 
     // this would go on forever, but let's just test 3 iterations
     for _ in 0..3 {
-        crate::tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
+        tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
         harness.expect_response(UNSOL_G2V1_SEQ1);
         harness.check_events(&[Event::UnsolicitedConfirmTimeout(1, true)]);
     }
@@ -116,22 +116,22 @@ fn unsolicited_can_timeout_and_not_retry() {
     harness.check_events(&[Event::EnterUnsolicitedConfirmWait(1)]);
 
     // first retry
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
+    tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
     harness.expect_response(UNSOL_G2V1_SEQ1);
     harness.check_events(&[Event::UnsolicitedConfirmTimeout(1, true)]);
 
     // second retry
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
+    tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
     harness.expect_response(UNSOL_G2V1_SEQ1);
     harness.check_events(&[Event::UnsolicitedConfirmTimeout(1, true)]);
 
     // timeout
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
+    tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
     harness.flush_io();
     harness.check_events(&[Event::UnsolicitedConfirmTimeout(1, false)]);
 
     // new series
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_UNSOLICITED_RETRY_DELAY);
+    tokio::time::advance(OutstationConfig::DEFAULT_UNSOLICITED_RETRY_DELAY);
     harness.expect_response(UNSOL_G2V1_SEQ2);
     harness.check_events(&[Event::EnterUnsolicitedConfirmWait(2)]);
 }
@@ -146,12 +146,12 @@ fn unsolicited_can_timeout_series_wait_and_start_another_series() {
     // first response series
     harness.expect_response(UNSOL_G2V1_SEQ1);
     harness.check_events(&[Event::EnterUnsolicitedConfirmWait(1)]);
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
+    tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
     harness.flush_io();
     harness.check_events(&[Event::UnsolicitedConfirmTimeout(1, false)]);
 
     // we're now back in IDLE, and need to wait to attempt a new series
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_UNSOLICITED_RETRY_DELAY);
+    tokio::time::advance(OutstationConfig::DEFAULT_UNSOLICITED_RETRY_DELAY);
     harness.expect_response(UNSOL_G2V1_SEQ2);
     harness.check_events(&[Event::EnterUnsolicitedConfirmWait(2)]);
 }
@@ -202,7 +202,7 @@ fn defers_read_during_unsol_confirm_wait_timeout() {
     harness.send(READ_CLASS_0);
     harness.check_no_events();
     // expire the unsolicited response
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
+    tokio::time::advance(OutstationConfig::DEFAULT_CONFIRM_TIMEOUT);
     harness.poll_pending();
     harness.check_events(&[Event::UnsolicitedConfirmTimeout(1, false)]);
     harness.expect_response(CLASS_0_RESPONSE_SEQ0_WITH_PENDING_EVENTS);
@@ -267,7 +267,7 @@ fn handles_disable_unsolicited_during_unsolicited_confirm_wait() {
     harness.check_no_events();
 
     // check that no other unsolicited responses are sent
-    crate::tokio::time::advance(OutstationConfig::DEFAULT_UNSOLICITED_RETRY_DELAY);
+    tokio::time::advance(OutstationConfig::DEFAULT_UNSOLICITED_RETRY_DELAY);
     harness.poll_pending();
     harness.check_no_events();
 }

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -48,8 +48,7 @@ pub fn create_master_serial(
     let log_path = path.to_owned();
     let (mut task, handle) = MasterTask::new(path, settings, config, retry_delay, listener);
     let future = async move {
-        let _ = task
-            .run()
+        task.run()
             .instrument(tracing::info_span!("dnp3-master-serial", "port" = ?log_path))
             .await;
     };

--- a/dnp3/src/serial/master.rs
+++ b/dnp3/src/serial/master.rs
@@ -26,7 +26,7 @@ pub fn spawn_master_serial(
 ) -> MasterChannel {
     let (future, handle) =
         create_master_serial(config, path, serial_settings, retry_delay, listener);
-    crate::tokio::spawn(future);
+    tokio::spawn(future);
     handle
 }
 

--- a/dnp3/src/serial/outstation.rs
+++ b/dnp3/src/serial/outstation.rs
@@ -32,7 +32,7 @@ pub fn spawn_outstation_serial(
         information,
         control_handler,
     )?;
-    crate::tokio::spawn(future);
+    tokio::spawn(future);
     Ok(handle)
 }
 

--- a/dnp3/src/tcp/endpoint_list.rs
+++ b/dnp3/src/tcp/endpoint_list.rs
@@ -61,9 +61,7 @@ impl EndpointList {
             self.current_endpoint = (self.current_endpoint + 1) % self.endpoints.len();
 
             // Resolve the name
-            if let Ok(endpoints) =
-                crate::tokio::net::lookup_host(&self.endpoints[endpoint_idx]).await
-            {
+            if let Ok(endpoints) = tokio::net::lookup_host(&self.endpoints[endpoint_idx]).await {
                 self.pending_endpoints = endpoints.collect();
 
                 if let Some(endpoint) = self.pending_endpoints.pop_front() {

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -11,10 +11,11 @@ use crate::master::session::{MasterSession, RunError, StateChange};
 use crate::master::{MasterChannel, MasterChannelConfig};
 use crate::tcp::ClientState;
 use crate::tcp::EndpointList;
-use crate::tokio::net::TcpStream;
 use crate::transport::TransportReader;
 use crate::transport::TransportWriter;
 use crate::util::phys::PhysLayer;
+
+use tokio::net::TcpStream;
 
 /// Spawn a task onto the `Tokio` runtime. The task runs until the returned handle, and any
 /// `AssociationHandle` created from it, are dropped.
@@ -35,7 +36,7 @@ pub fn spawn_master_tcp_client(
         connect_strategy,
         listener,
     );
-    crate::tokio::spawn(future);
+    tokio::spawn(future);
     handle
 }
 

--- a/dnp3/src/tcp/tls/master.rs
+++ b/dnp3/src/tcp/tls/master.rs
@@ -5,18 +5,18 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 
-use tokio_rustls::{rustls, webpki};
-use tracing::Instrument;
-
 use crate::app::{ConnectStrategy, Listener};
 use crate::link::LinkErrorMode;
 use crate::master::{MasterChannel, MasterChannelConfig};
 use crate::tcp::tls::{load_certs, load_private_key, CertificateMode, MinTlsVersion, TlsError};
 use crate::tcp::EndpointList;
 use crate::tcp::{ClientState, MasterTask, MasterTaskConnectionHandler};
-use crate::tokio::net::TcpStream;
 use crate::util::phys::PhysLayer;
+
 use rasn;
+use tokio::net::TcpStream;
+use tokio_rustls::{rustls, webpki};
+use tracing::Instrument;
 
 /// TLS configuration
 pub struct TlsClientConfig {
@@ -45,7 +45,7 @@ pub fn spawn_master_tls_client(
         listener,
         tls_config,
     );
-    crate::tokio::spawn(future);
+    tokio::spawn(future);
     handle
 }
 

--- a/dnp3/src/tcp/tls/outstation.rs
+++ b/dnp3/src/tcp/tls/outstation.rs
@@ -7,9 +7,9 @@ use tokio_rustls::rustls;
 use tokio_rustls::rustls::server::AllowAnyAuthenticatedClient;
 
 use crate::tcp::tls::{load_certs, load_private_key, CertificateMode, MinTlsVersion, TlsError};
-use crate::tokio::net::TcpStream;
 use crate::util::phys::PhysLayer;
 use rasn;
+use tokio::net::TcpStream;
 
 /// TLS configuration
 pub struct TlsServerConfig {

--- a/dnp3/src/tokio.rs
+++ b/dnp3/src/tokio.rs
@@ -1,5 +1,0 @@
-// When testing, we replace all the tokio components with mocks
-#[cfg(test)]
-pub(crate) use tokio_mock::mock::*;
-#[cfg(not(test))]
-pub(crate) use tokio_mock::real::*;

--- a/dnp3/src/util/channel.rs
+++ b/dnp3/src/util/channel.rs
@@ -1,11 +1,11 @@
 use crate::app::Shutdown;
 
 pub(crate) struct Receiver<T> {
-    inner: crate::tokio::sync::mpsc::Receiver<T>,
+    inner: tokio::sync::mpsc::Receiver<T>,
 }
 
 pub(crate) struct Sender<T> {
-    inner: crate::tokio::sync::mpsc::Sender<T>,
+    inner: tokio::sync::mpsc::Sender<T>,
 }
 
 impl<T> Clone for Sender<T> {
@@ -25,12 +25,12 @@ impl<T> std::fmt::Debug for Sender<T> {
 }
 
 pub(crate) fn request_channel<T>() -> (Sender<T>, Receiver<T>) {
-    let (tx, rx) = crate::tokio::sync::mpsc::channel(16); // default size for all request channels
+    let (tx, rx) = tokio::sync::mpsc::channel(16); // default size for all request channels
     (Sender::new(tx), Receiver::new(rx))
 }
 
 impl<T> Receiver<T> {
-    fn new(inner: crate::tokio::sync::mpsc::Receiver<T>) -> Self {
+    fn new(inner: tokio::sync::mpsc::Receiver<T>) -> Self {
         Receiver { inner }
     }
 
@@ -47,7 +47,7 @@ impl<T> Receiver<T> {
 }
 
 impl<T> Sender<T> {
-    fn new(inner: crate::tokio::sync::mpsc::Sender<T>) -> Self {
+    fn new(inner: tokio::sync::mpsc::Sender<T>) -> Self {
         Sender { inner }
     }
 
@@ -56,8 +56,8 @@ impl<T> Sender<T> {
     }
 }
 
-impl From<crate::tokio::sync::oneshot::error::RecvError> for Shutdown {
-    fn from(_: crate::tokio::sync::oneshot::error::RecvError) -> Self {
+impl From<tokio::sync::oneshot::error::RecvError> for Shutdown {
+    fn from(_: tokio::sync::oneshot::error::RecvError) -> Self {
         Shutdown
     }
 }

--- a/dnp3/src/util/phys.rs
+++ b/dnp3/src/util/phys.rs
@@ -1,15 +1,16 @@
 use crate::decode::PhysDecodeLevel;
-use crate::tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 // encapsulates all possible physical layers as an enum
 pub(crate) enum PhysLayer {
-    Tcp(crate::tokio::net::TcpStream),
+    Tcp(tokio::net::TcpStream),
     // TLS type is boxed because its size is huge
     #[cfg(feature = "tls")]
-    Tls(Box<tokio_rustls::TlsStream<crate::tokio::net::TcpStream>>),
+    Tls(Box<tokio_rustls::TlsStream<tokio::net::TcpStream>>),
     Serial(tokio_serial::SerialStream),
     #[cfg(test)]
-    Mock(tokio_mock::mock::test::io::MockIo),
+    Mock(tokio_mock_io::Mock),
 }
 
 impl std::fmt::Debug for PhysLayer {

--- a/ffi/dnp3-ffi-java/src/lib.rs
+++ b/ffi/dnp3-ffi-java/src/lib.rs
@@ -5,6 +5,7 @@
     clippy::needless_borrow,
     clippy::needless_return,
     clippy::not_unsafe_ptr_arg_deref,
+    clippy::let_unit_value,
     unused_variables,
     dead_code
 )]

--- a/ffi/dnp3-schema/src/constants.rs
+++ b/ffi/dnp3-schema/src/constants.rs
@@ -13,7 +13,7 @@ mod bits {
 pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
     use bits::*;
 
-    let flag = lib.define_constants("flag")?
+    lib.define_constants("flag")?
         .add("online", ConstantValue::U8(BIT_0,Representation::Hex), "Object value is 'good' / 'valid' / 'nominal'")?
         .add("restart", ConstantValue::U8(BIT_1,Representation::Hex), "Object value has not been updated since device restart")?
         .add("comm_lost", ConstantValue::U8(BIT_2,Representation::Hex), "Object value represents the last value available before a communication failure occurred. Should never be set by originating devices")?
@@ -26,5 +26,5 @@ pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
         .doc("Individual flag constants that may be combined using bitwise-OR operator")?
         .build()?;
 
-    Ok(flag)
+    Ok(())
 }


### PR DESCRIPTION
Removes tokio-mock crate, and replaces tests with proper async `tokio::test`. Use custom I/O mocking instead.