### PR TITLE
fix #202

### DIFF
--- a/dnp3/src/master/session.rs
+++ b/dnp3/src/master/session.rs
@@ -465,7 +465,7 @@ impl MasterSession {
         &mut self,
         destination: EndpointAddress,
         seq: Sequence,
-        io: &mut PhysLayer,
+        io: &'a mut PhysLayer,
         writer: &mut TransportWriter,
         source: EndpointAddress,
         response: Response<'a>,

--- a/dnp3/src/serial/outstation.rs
+++ b/dnp3/src/serial/outstation.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-
 use tracing::Instrument;
 
 use crate::link::LinkErrorMode;
@@ -15,7 +13,8 @@ use crate::util::phys::PhysLayer;
 /// a serial port error occurs, e.g. a serial port is removed from the OS.
 ///
 /// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
-/// It is preferable to use this method instead of `create_outstation_serial(..)` when using `[tokio::main]`.
+///
+/// Use `Runtime::enter` to create a runtime context if needed before calling.
 pub fn spawn_outstation_serial(
     path: &str,
     settings: SerialSettings,
@@ -24,34 +23,6 @@ pub fn spawn_outstation_serial(
     information: Box<dyn OutstationInformation>,
     control_handler: Box<dyn ControlHandler>,
 ) -> std::io::Result<OutstationHandle> {
-    let (future, handle) = create_outstation_serial(
-        path,
-        settings,
-        config,
-        application,
-        information,
-        control_handler,
-    )?;
-    tokio::spawn(future);
-    Ok(handle)
-}
-
-/// Create an outstation future, which can be spawned onto a runtime, along with a controlling handle.
-///
-/// Once spawned or otherwise executed using the `run` method, the task runs until the handle
-/// is dropped or the serial port is removed from the OS.
-///
-/// **Note**: This function is required instead of `spawn` when using a runtime to directly spawn
-/// tasks instead of within the context of a runtime, e.g. in applications that cannot use
-/// `[tokio::main]` such as C language bindings.
-pub fn create_outstation_serial(
-    path: &str,
-    settings: SerialSettings,
-    config: OutstationConfig,
-    application: Box<dyn OutstationApplication>,
-    information: Box<dyn OutstationInformation>,
-    control_handler: Box<dyn ControlHandler>,
-) -> std::io::Result<(impl Future<Output = ()> + 'static, OutstationHandle)> {
     let serial = crate::serial::open(path, settings)?;
     let (mut task, handle) = OutstationTask::create(
         LinkErrorMode::Discard,
@@ -69,5 +40,6 @@ pub fn create_outstation_serial(
             .instrument(tracing::info_span!("dnp3-master-serial", "port" = ?log_path))
             .await;
     };
-    Ok((future, handle))
+    tokio::spawn(future);
+    Ok(handle)
 }

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -169,9 +169,7 @@ pub unsafe fn outstation_create_serial_session(
     information: ffi::OutstationInformation,
     control_handler: ffi::ControlHandler,
 ) -> Result<*mut crate::Outstation, ffi::ParamError> {
-    let runtime = runtime
-        .as_ref()
-        .ok_or(ffi::ParamError::NullParameter)?;
+    let runtime = runtime.as_ref().ok_or(ffi::ParamError::NullParameter)?;
 
     let _enter = runtime.inner.enter();
     let serial_path = serial_path.to_string_lossy();
@@ -187,7 +185,10 @@ pub unsafe fn outstation_create_serial_session(
         Box::new(control_handler),
     )?;
 
-    let handle = Box::new(crate::Outstation { handle, runtime: runtime.handle() });
+    let handle = Box::new(crate::Outstation {
+        handle,
+        runtime: runtime.handle(),
+    });
 
     Ok(Box::into_raw(handle))
 }


### PR DESCRIPTION
Resolves https://github.com/stepfunc/dnp3/issues/202 by removing `create_outstation_serial` and instead using `spawn_outstation_serial` in the FFI using `Runtime::enter()`.