### PR TITLE
remove non-spawning methods from master API

### DIFF
--- a/dnp3/src/master/session.rs
+++ b/dnp3/src/master/session.rs
@@ -460,12 +460,11 @@ impl MasterSession {
         }
     }
 
-    #[allow(clippy::needless_lifetimes)]
     async fn validate_non_read_response<'a>(
         &mut self,
         destination: EndpointAddress,
         seq: Sequence,
-        io: &'a mut PhysLayer,
+        io: &mut PhysLayer,
         writer: &mut TransportWriter,
         source: EndpointAddress,
         response: Response<'a>,

--- a/dnp3/src/serial/outstation.rs
+++ b/dnp3/src/serial/outstation.rs
@@ -13,8 +13,7 @@ use crate::util::phys::PhysLayer;
 /// a serial port error occurs, e.g. a serial port is removed from the OS.
 ///
 /// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
-///
-/// Use `Runtime::enter` to create a runtime context if needed before calling.
+/// Use Runtime::enter() if required.
 pub fn spawn_outstation_serial(
     path: &str,
     settings: SerialSettings,


### PR DESCRIPTION
Removes the remaining non-spawning Rust API methods that should not have been part of public API.