### PR TITLE
serial feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,6 @@ dependencies = [
 name = "dnp3-schema"
 version = "1.1.0-alpha1"
 dependencies = [
- "dnp3",
  "oo-bindgen",
 ]
 

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 tracing = "0.1"
 chrono = "0.4"
 tokio = { version = "1", features = ["net", "sync", "io-util", "io-std", "time", "rt", "rt-multi-thread", "macros"] }
-tokio-serial = "5.4"
 xxhash-rust = { version = "0.8.2", features = ["xxh64"] }
 
 # TLS dependencies
@@ -16,6 +15,9 @@ pem = { version = "1.0", optional = true }
 pkcs8 = { version = "0.7", features = ["encryption", "pem", "std"], optional = true }
 rasn = { git = "https://github.com/stepfunc/rasn", tag = "0.1.2", optional = true }
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration", "tls12"], default-features = false, optional = true }
+
+# serial dependencies
+tokio-serial = { version = "5.4", optional = true }
 
 [dev-dependencies]
 tokio-mock-io = { git = "https://github.com/stepfunc/tokio-mock-io.git", tag = "0.2.0" }
@@ -28,9 +30,10 @@ rand = "0.8"
 tokio = { version = "1", features = ["test-util"] }
 
 [features]
-default = ["tls"]
+default = ["tls", "serial"]
 ffi = [] # this feature flag is only used when building the FFI
 tls = ["pem", "pkcs8", "rasn", "tokio-rustls"]
+serial = ["tokio-serial"]
 
 [[bench]]
 name = "benchmark"

--- a/dnp3/examples/master.rs
+++ b/dnp3/examples/master.rs
@@ -9,13 +9,13 @@ use dnp3::app::*;
 use dnp3::decode::*;
 use dnp3::link::*;
 use dnp3::master::*;
-use dnp3::serial::*;
 use dnp3::tcp::*;
 
+#[cfg(feature = "serial")]
+use dnp3::serial::*;
 #[cfg(feature = "tls")]
 use dnp3::tcp::tls::*;
 
-use std::path::Path;
 use std::process::exit;
 
 /// read handler that does nothing
@@ -343,6 +343,7 @@ fn create_channel() -> Result<MasterChannel, Box<dyn std::error::Error>> {
     };
     match transport {
         "tcp" => create_tcp_channel(),
+        #[cfg(feature = "serial")]
         "serial" => create_serial_channel(),
         #[cfg(feature = "tls")]
         "tls-ca" => create_tls_channel(get_tls_authority_config()?),
@@ -386,6 +387,7 @@ fn get_association_config() -> AssociationConfig {
 
 #[cfg(feature = "tls")]
 fn get_tls_self_signed_config() -> Result<TlsClientConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_self_signed_config
     let config = TlsClientConfig::new(
         "test.com",
@@ -402,6 +404,7 @@ fn get_tls_self_signed_config() -> Result<TlsClientConfig, Box<dyn std::error::E
 
 #[cfg(feature = "tls")]
 fn get_tls_authority_config() -> Result<TlsClientConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_ca_chain_config
     let config = TlsClientConfig::new(
         "test.com",
@@ -429,6 +432,7 @@ fn create_tcp_channel() -> Result<MasterChannel, Box<dyn std::error::Error>> {
     Ok(channel)
 }
 
+#[cfg(feature = "serial")]
 fn create_serial_channel() -> Result<MasterChannel, Box<dyn std::error::Error>> {
     // ANCHOR: create_master_serial_channel
     let channel = spawn_master_serial(

--- a/dnp3/examples/outstation.rs
+++ b/dnp3/examples/outstation.rs
@@ -5,14 +5,15 @@ use dnp3::decode::*;
 use dnp3::link::*;
 use dnp3::outstation::database::*;
 use dnp3::outstation::*;
-use dnp3::serial::*;
+
 use dnp3::tcp::*;
-use std::path::Path;
 use std::process::exit;
 use tokio_stream::StreamExt;
 use tokio_util::codec::FramedRead;
 use tokio_util::codec::LinesCodec;
 
+#[cfg(feature = "serial")]
+use dnp3::serial::*;
 #[cfg(feature = "tls")]
 use dnp3::tcp::tls::*;
 
@@ -37,6 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     match transport {
         "tcp" => run_tcp().await,
+        #[cfg(feature = "serial")]
         "serial" => run_serial().await,
         #[cfg(feature = "tls")]
         "tls-ca" => run_tls(get_ca_chain_config()?).await,
@@ -226,6 +228,7 @@ async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     run_tcp_server(server).await
 }
 
+#[cfg(feature = "serial")]
 async fn run_serial() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: create_serial_server
     let outstation = spawn_outstation_serial(
@@ -429,6 +432,7 @@ fn get_current_time() -> Time {
 
 #[cfg(feature = "tls")]
 fn get_ca_chain_config() -> Result<TlsServerConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_ca_chain_config
     let config = TlsServerConfig::new(
         "test.com",
@@ -446,6 +450,7 @@ fn get_ca_chain_config() -> Result<TlsServerConfig, Box<dyn std::error::Error>> 
 
 #[cfg(feature = "tls")]
 fn get_self_signed_config() -> Result<TlsServerConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_self_signed_config
     let config = TlsServerConfig::new(
         "test.com",

--- a/dnp3/src/lib.rs
+++ b/dnp3/src/lib.rs
@@ -65,6 +65,7 @@ pub mod master;
 /// Types and traits specific to outstations
 pub mod outstation;
 /// Entry points and types for serial
+#[cfg(feature = "serial")]
 pub mod serial;
 /// Entry points and types for TCP
 pub mod tcp;

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -56,12 +56,12 @@ impl MasterTaskConnectionHandler {
     async fn handle(
         &mut self,
         socket: TcpStream,
-        endpoint: &SocketAddr,
+        _endpoint: &SocketAddr,
     ) -> Result<PhysLayer, String> {
         match self {
             Self::Tcp => Ok(PhysLayer::Tcp(socket)),
             #[cfg(feature = "tls")]
-            Self::Tls(config) => config.handle_connection(socket, endpoint).await,
+            Self::Tls(config) => config.handle_connection(socket, _endpoint).await,
         }
     }
 }

--- a/dnp3/src/util/phys.rs
+++ b/dnp3/src/util/phys.rs
@@ -8,6 +8,7 @@ pub(crate) enum PhysLayer {
     // TLS type is boxed because its size is huge
     #[cfg(feature = "tls")]
     Tls(Box<tokio_rustls::TlsStream<tokio::net::TcpStream>>),
+    #[cfg(feature = "serial")]
     Serial(tokio_serial::SerialStream),
     #[cfg(test)]
     Mock(tokio_mock_io::Mock),
@@ -19,6 +20,7 @@ impl std::fmt::Debug for PhysLayer {
             PhysLayer::Tcp(_) => f.write_str("Tcp"),
             #[cfg(feature = "tls")]
             PhysLayer::Tls(_) => f.write_str("Tls"),
+            #[cfg(feature = "serial")]
             PhysLayer::Serial(_) => f.write_str("Serial"),
             #[cfg(test)]
             PhysLayer::Mock(_) => f.write_str("Mock"),
@@ -36,6 +38,7 @@ impl PhysLayer {
             Self::Tcp(x) => x.read(buffer).await?,
             #[cfg(feature = "tls")]
             Self::Tls(x) => x.read(buffer).await?,
+            #[cfg(feature = "serial")]
             Self::Serial(x) => x.read(buffer).await?,
             #[cfg(test)]
             Self::Mock(x) => x.read(buffer).await?,
@@ -63,6 +66,7 @@ impl PhysLayer {
             Self::Tcp(x) => x.write_all(data).await,
             #[cfg(feature = "tls")]
             Self::Tls(x) => x.write_all(data).await,
+            #[cfg(feature = "serial")]
             Self::Serial(x) => x.write_all(data).await,
             #[cfg(test)]
             Self::Mock(x) => x.write_all(data).await,

--- a/ffi/dnp3-ffi-java/Cargo.toml
+++ b/ffi/dnp3-ffi-java/Cargo.toml
@@ -10,7 +10,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 jni = "0.19"
-dnp3-ffi = { path = "../dnp3-ffi" }
+dnp3-ffi = { path = "../dnp3-ffi", default-features = false }
+
+[features]
+default = ["tls", "serial"]
+tls = ["dnp3-ffi/tls"]
+serial = ["dnp3-ffi/serial"]
 
 [build-dependencies]
 dnp3-schema = { path = "../dnp3-schema" }

--- a/ffi/dnp3-ffi/Cargo.toml
+++ b/ffi/dnp3-ffi/Cargo.toml
@@ -12,9 +12,14 @@ lazy_static = "1.0"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"
-dnp3 = { path = "../../dnp3", features = ["ffi", "tls"] }
+dnp3 = { path = "../../dnp3", default-features = false, features = ["ffi"] }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 num_cpus = "1"
+
+[features]
+default = ["tls", "serial"]
+tls = ["dnp3/tls"]
+serial = ["dnp3/serial"]
 
 [build-dependencies]
 dnp3-schema = { path = "../dnp3-schema" }

--- a/ffi/dnp3-ffi/src/lib.rs
+++ b/ffi/dnp3-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc, clippy::useless_conversion)]
+#![allow(dead_code)]
 
 /// these use statements allow the code in the FFI to not have to known the real locations
 /// but instead just use crate::<name> when invoking an implementation

--- a/ffi/dnp3-schema/Cargo.toml
+++ b/ffi/dnp3-schema/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "dnp3-schema"
+# this version is what gets applied to the FFI libraries
 version = "1.1.0-alpha1"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 
 [dependencies]
-dnp3 = { path = "../../dnp3" }
 oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.2.1" }

--- a/ffi/dnp3-schema/src/lib.rs
+++ b/ffi/dnp3-schema/src/lib.rs
@@ -65,7 +65,11 @@ pub fn build_lib() -> BackTraced<Library> {
         InterfaceSettings::default(),
     )?;
 
-    let mut builder = LibraryBuilder::new(Version::parse(dnp3::VERSION).unwrap(), info, settings);
+    let mut builder = LibraryBuilder::new(
+        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        info,
+        settings,
+    );
 
     // Shared stuff
     let shared_def = shared::define(&mut builder)?;

--- a/ffi/dnp3-schema/src/shared.rs
+++ b/ffi/dnp3-schema/src/shared.rs
@@ -47,6 +47,10 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<SharedDefinitions> {
         )?
         .add_error("null_parameter", "Null parameter")?
         .add_error(
+            "no_support",
+            "Native library was compiled without support for this feature",
+        )?
+        .add_error(
             "association_does_not_exist",
             "The specified association does not exist",
         )?


### PR DESCRIPTION
Adds a serial feature flag.

Makes it possible to build the FFI and JNI libraries without serial or TLS support.