### PR TITLE
Fault-tolerant outstation serial task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -702,13 +702,14 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1281,7 +1282,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.10.1",
  "salsa20",
- "sha2 0.10.2",
+ "sha2 0.10.3",
 ]
 
 [[package]]
@@ -1381,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1416,9 +1417,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -1473,18 +1474,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dnp3/src/serial/outstation.rs
+++ b/dnp3/src/serial/outstation.rs
@@ -1,6 +1,8 @@
+use crate::app::{ExponentialBackOff, RetryStrategy, Shutdown};
 use tracing::Instrument;
 
 use crate::link::LinkErrorMode;
+use crate::outstation::session::RunError;
 use crate::outstation::task::OutstationTask;
 use crate::outstation::{
     ControlHandler, OutstationApplication, OutstationConfig, OutstationHandle,
@@ -10,7 +12,11 @@ use crate::serial::SerialSettings;
 use crate::util::phys::PhysLayer;
 
 /// Spawn an outstation task onto the `Tokio` runtime. The task runs until the returned handle is dropped or
-/// a serial port error occurs, e.g. a serial port is removed from the OS.
+/// a serial port error occurs, e.g. a serial port is removed from the OS. It attempts to open
+/// the serial port immediately, and fails if it cannot.
+///
+/// Most users should prefer `spawn_outstation_serial_fault_tolerant`. This function remains for API
+/// compatibility reasons, but will likely be removed in future MAJOR release of the library.
 ///
 /// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
 /// Use Runtime::enter() if required.
@@ -36,9 +42,103 @@ pub fn spawn_outstation_serial(
         let mut io = PhysLayer::Serial(serial);
         let _ = task
             .run(&mut io)
-            .instrument(tracing::info_span!("dnp3-master-serial", "port" = ?log_path))
+            .instrument(tracing::info_span!("dnp3-outstation-serial", "port" = ?log_path))
             .await;
     };
     tokio::spawn(future);
     Ok(handle)
+}
+
+/// Spawns an outstation task onto the `Tokio` runtime. The task runs until the returned handle is dropped.
+/// It is tolerant to the serial port being unavailable at startup or being removed from the OS. It
+/// uses the provided `RetryStrategy` to determine when to retry the port if the port cannot be
+/// opened or fails.
+///
+/// This function should be preferred over `spawn_outstation_serial`.
+///
+/// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
+/// Use Runtime::enter() if required.
+pub fn spawn_outstation_serial_fault_tolerant(
+    path: &str,
+    settings: SerialSettings,
+    config: OutstationConfig,
+    retry: RetryStrategy,
+    application: Box<dyn OutstationApplication>,
+    information: Box<dyn OutstationInformation>,
+    control_handler: Box<dyn ControlHandler>,
+) -> OutstationHandle {
+    let (task, handle) = OutstationTask::create(
+        LinkErrorMode::Discard,
+        config,
+        application,
+        information,
+        control_handler,
+    );
+
+    let mut serial_task = SerialOutstation {
+        port: path.to_string(),
+        backoff: ExponentialBackOff::new(retry),
+        settings,
+        outstation: task,
+    };
+
+    let log_path = path.to_owned();
+    let future = async move {
+        let _ = serial_task
+            .run()
+            .instrument(tracing::info_span!("dnp3-outstation-serial", "port" = ?log_path))
+            .await;
+    };
+    tokio::spawn(future);
+    handle
+}
+
+struct SerialOutstation {
+    port: String,
+    backoff: ExponentialBackOff,
+    settings: SerialSettings,
+    outstation: OutstationTask,
+}
+
+impl SerialOutstation {
+    async fn sleep_for(&mut self, delay: std::time::Duration) -> Result<(), Shutdown> {
+        match tokio::time::timeout(delay, self.outstation.process_messages()).await {
+            Ok(x) => x,
+            // timeout
+            Err(_) => Ok(()),
+        }
+    }
+
+    async fn run(&mut self) -> Shutdown {
+        loop {
+            match crate::serial::open(&self.port, self.settings) {
+                Ok(serial) => {
+                    self.backoff.on_success();
+                    tracing::info!("opened port");
+                    // run an open port until shutdown or failure
+                    let mut phys = PhysLayer::Serial(serial);
+                    if let RunError::Shutdown = self.outstation.run(&mut phys).await {
+                        return Shutdown;
+                    }
+                    let delay = self.backoff.on_failure();
+                    // we wait here to prevent any kind of rapid retry scenario if the port opens and immediately fails
+                    tracing::warn!("waiting {:?} to reopen port", delay);
+                    if let Err(Shutdown) = self.sleep_for(delay).await {
+                        return Shutdown;
+                    }
+                }
+                Err(err) => {
+                    let delay = self.backoff.on_failure();
+                    tracing::warn!(
+                        "unable to open serial port, retrying in {:?} - error: {}",
+                        delay,
+                        err
+                    );
+                    if let Err(Shutdown) = self.sleep_for(delay).await {
+                        return Shutdown;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/ffi/bindings/c/outstation_example.c
+++ b/ffi/bindings/c/outstation_example.c
@@ -598,10 +598,11 @@ int run_serial(dnp3_runtime_t* runtime)
 {
     // ANCHOR: create_serial_server
     dnp3_outstation_t* outstation = NULL;
-    dnp3_param_error_t err = dnp3_outstation_create_serial_session(
+    dnp3_param_error_t err = dnp3_outstation_create_serial_session_fault_tolerant(
         runtime,
         "/dev/pts/4",                // change to a real port
         dnp3_serial_settings_init(), // default settings
+        5000,                        // retry the port every 5 seconds
         get_outstation_config(),
         get_outstation_application(),
         get_outstation_information(),

--- a/ffi/bindings/c/outstation_example.cpp
+++ b/ffi/bindings/c/outstation_example.cpp
@@ -319,10 +319,11 @@ void run_tcp_server(dnp3::Runtime &runtime)
 void run_serial(dnp3::Runtime &runtime)
 {
     // ANCHOR: create_serial_server
-    auto outstation = dnp3::Outstation::create_serial_session(
+    auto outstation = dnp3::Outstation::create_serial_session_fault_tolerant(
         runtime,
         "/dev/pts/4",  // change this to a real port
         dnp3::SerialSettings(), // default settings
+        std::chrono::seconds(5), // retry the port every 5 seconds
         get_outstation_config(),
         std::make_unique<MyOutstationApplication>(),
         std::make_unique<MyOutstationInformation>(),

--- a/ffi/bindings/dotnet/examples/outstation/Program.cs
+++ b/ffi/bindings/dotnet/examples/outstation/Program.cs
@@ -216,10 +216,11 @@ class ExampleOutstation
     private static void RunSerial(Runtime runtime)
     {
         // ANCHOR: create_serial_server
-        var outstation = Outstation.CreateSerialSession(
+        var outstation = Outstation.CreateSerialSessionFaultTolerant(
             runtime,
             "COM1",
             new SerialSettings(),
+            TimeSpan.FromSeconds(5), // try to open the port every 5 seconds
             GetOutstationConfig(),
             new TestOutstationApplication(),
             new TestOutstationInformation(),

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/OutstationExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/OutstationExample.java
@@ -7,6 +7,7 @@ import io.stepfunc.dnp3.Runtime;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.joou.UByte;
@@ -287,10 +288,11 @@ public class OutstationExample {
 
   private static void runSerial(Runtime runtime) {
     // ANCHOR: create_serial_server
-    Outstation outstation = Outstation.createSerialSession(
+    Outstation outstation = Outstation.createSerialSessionFaultTolerant(
             runtime,
             "/dev/pts/4",
             new SerialSettings(),
+            Duration.ofSeconds(5), // try to open the port every 5 seconds
             getOutstationConfig(),
             new TestOutstationApplication(),
             new TestOutstationInformation(),

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -3,7 +3,7 @@ use std::net::AddrParseError;
 use std::time::Duration;
 
 pub use database::*;
-use dnp3::app::{BufferSize, BufferSizeError, Listener, MaybeAsync, Timeout};
+use dnp3::app::{BufferSize, BufferSizeError, Listener, MaybeAsync, RetryStrategy, Timeout};
 use dnp3::link::{EndpointAddress, LinkErrorMode};
 use dnp3::outstation::database::{ClassZeroConfig, EventBufferConfig};
 use dnp3::outstation::{ConnectionState, Feature, Features, OutstationConfig, OutstationHandle};
@@ -14,6 +14,7 @@ use crate::{ffi, Runtime, RuntimeHandle};
 
 #[cfg(feature = "serial")]
 use dnp3::serial::spawn_outstation_serial;
+use dnp3::serial::spawn_outstation_serial_fault_tolerant;
 #[cfg(feature = "tls")]
 use dnp3::tcp::tls::TlsServerConfig;
 
@@ -188,7 +189,6 @@ pub unsafe fn outstation_create_serial_session(
 }
 
 #[cfg(feature = "serial")]
-#[allow(clippy::too_many_arguments)] // TODO
 pub unsafe fn outstation_create_serial_session(
     runtime: *mut crate::Runtime,
     serial_path: &CStr,
@@ -213,6 +213,58 @@ pub unsafe fn outstation_create_serial_session(
         Box::new(information),
         Box::new(control_handler),
     )?;
+
+    let handle = Box::new(crate::Outstation {
+        handle,
+        runtime: runtime.handle(),
+    });
+
+    Ok(Box::into_raw(handle))
+}
+
+#[cfg(not(feature = "serial"))]
+#[allow(clippy::too_many_arguments)] // TODO
+pub unsafe fn outstation_create_serial_session_fault_tolerant(
+    _runtime: *mut crate::Runtime,
+    _serial_path: &CStr,
+    _settings: ffi::SerialSettings,
+    _open_retry_delay: std::time::Duration,
+    _config: ffi::OutstationConfig,
+    _application: ffi::OutstationApplication,
+    _information: ffi::OutstationInformation,
+    _control_handler: ffi::ControlHandler,
+) -> Result<*mut crate::Outstation, ffi::ParamError> {
+    Err(ffi::ParamError::NoSupport)
+}
+
+#[cfg(feature = "serial")]
+#[allow(clippy::too_many_arguments)] // TODO
+pub unsafe fn outstation_create_serial_session_fault_tolerant(
+    runtime: *mut crate::Runtime,
+    serial_path: &CStr,
+    settings: ffi::SerialSettings,
+    open_retry_delay: std::time::Duration,
+    config: ffi::OutstationConfig,
+    application: ffi::OutstationApplication,
+    information: ffi::OutstationInformation,
+    control_handler: ffi::ControlHandler,
+) -> Result<*mut crate::Outstation, ffi::ParamError> {
+    let runtime = runtime.as_ref().ok_or(ffi::ParamError::NullParameter)?;
+
+    let _enter = runtime.inner.enter();
+    let serial_path = serial_path.to_string_lossy();
+
+    let config = convert_outstation_config(config)?;
+
+    let handle = spawn_outstation_serial_fault_tolerant(
+        &serial_path,
+        settings.into(),
+        config,
+        RetryStrategy::new(open_retry_delay, open_retry_delay),
+        Box::new(application),
+        Box::new(information),
+        Box::new(control_handler),
+    );
 
     let handle = Box::new(crate::Outstation {
         handle,

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -3,7 +3,7 @@ use std::net::AddrParseError;
 use std::time::Duration;
 
 pub use database::*;
-use dnp3::app::{BufferSize, BufferSizeError, Listener, MaybeAsync, RetryStrategy, Timeout};
+use dnp3::app::{BufferSize, BufferSizeError, Listener, MaybeAsync, Timeout};
 use dnp3::link::{EndpointAddress, LinkErrorMode};
 use dnp3::outstation::database::{ClassZeroConfig, EventBufferConfig};
 use dnp3::outstation::{ConnectionState, Feature, Features, OutstationConfig, OutstationHandle};
@@ -12,9 +12,6 @@ pub use struct_constructors::*;
 
 use crate::{ffi, Runtime, RuntimeHandle};
 
-#[cfg(feature = "serial")]
-use dnp3::serial::spawn_outstation_serial;
-use dnp3::serial::spawn_outstation_serial_fault_tolerant;
 #[cfg(feature = "tls")]
 use dnp3::tcp::tls::TlsServerConfig;
 
@@ -205,7 +202,7 @@ pub unsafe fn outstation_create_serial_session(
 
     let config = convert_outstation_config(config)?;
 
-    let handle = spawn_outstation_serial(
+    let handle = dnp3::serial::spawn_outstation_serial(
         &serial_path,
         settings.into(),
         config,
@@ -256,11 +253,11 @@ pub unsafe fn outstation_create_serial_session_fault_tolerant(
 
     let config = convert_outstation_config(config)?;
 
-    let handle = spawn_outstation_serial_fault_tolerant(
+    let handle = dnp3::serial::spawn_outstation_serial_fault_tolerant(
         &serial_path,
         settings.into(),
         config,
-        RetryStrategy::new(open_retry_delay, open_retry_delay),
+        dnp3::app::RetryStrategy::new(open_retry_delay, open_retry_delay),
         Box::new(application),
         Box::new(information),
         Box::new(control_handler),

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -174,8 +174,56 @@ fn define_outstation(
             "Outstation instance or {null} if the port cannot be opened",
         )?
         .fails_with(shared_def.error_type.clone())?
-        .doc("Create an outstation instance running on a serial port")?
+        .doc(
+            doc("Create an outstation instance running on a serial port")
+                .details("The port is opened immediately on the calling thread and fails if not successful")
+                .warning("Most users should prefer the fault tolerant version of the this method {class:outstation.create_serial_session_fault_tolerant()}")
+        )?
         .build_static("create_serial_session")?;
+
+    let outstation_create_serial_session_fault_tolerant_fn = lib
+        .define_function("outstation_create_serial_session_fault_tolerant")?
+        .param(
+            "runtime",
+            shared_def.runtime_class.clone(),
+            "runtime on which to spawn the outstation",
+        )?
+        .param("serial_path", StringType, "Path of the serial device")?
+        .param(
+            "settings",
+            shared_def.serial_port_settings.clone(),
+            "settings for the serial port",
+        )?
+        .param("open_retry_delay", DurationType::Milliseconds, "delay between attempts to open the serial port")?
+        .param(
+            "config",
+            types.outstation_config.clone(),
+            "outstation configuration",
+        )?
+        .param(
+            "application",
+            types.outstation_application.clone(),
+            "application interface",
+        )?
+        .param(
+            "information",
+            types.outstation_information.clone(),
+            "informational events interface",
+        )?
+        .param(
+            "control_handler",
+            types.control_handler.clone(),
+            "control handler interface",
+        )?
+        .returns(
+            outstation.clone(),
+            "Outstation instance or {null} if the port cannot be opened",
+        )?
+        .fails_with(shared_def.error_type.clone())?
+        .doc(
+            doc("Create an outstation instance running on a serial port which is tolerant to the serial port being added and removed")
+        )?
+        .build_static("create_serial_session_fault_tolerant")?;
 
     let destructor = lib.define_destructor(
         outstation.clone(),
@@ -203,6 +251,7 @@ fn define_outstation(
         .define_class(&outstation)?
         .destructor(destructor)?
         .static_method(outstation_create_serial_session_fn)?
+        .static_method(outstation_create_serial_session_fault_tolerant_fn)?
         .method(execute_transaction)?
         .method(set_decode_level)?
         .doc(doc("Outstation handle").details("Use this handle to modify the internal database."))?


### PR DESCRIPTION
The existing outstation serial task tries to open the serial port during creation, and fails if the port isn't available. The task will also exit if the serial port disappears during execution.  It is possible for serial ports to come and go for example with USB to serial converters... I'm sure there are other cases too.

This PR adds additional methods for spawning serial outstations that control the port on the background task. They are "self-healing" and retry opening the port at a configurable rate.

The old methods still exist for API backwards compatibility in the 1.x release series, but will probably be removed once we eventually do a 2.0 release.