### PR TITLE
Enable TCP_NODELAY by default

### DIFF
--- a/dnp3/src/tcp/mod.rs
+++ b/dnp3/src/tcp/mod.rs
@@ -1,6 +1,7 @@
 pub use address_filter::*;
 pub use endpoint_list::*;
 pub use master::*;
+pub use no_delay::*;
 pub use outstation::*;
 
 /// Entry points and types for TLS
@@ -10,6 +11,7 @@ pub mod tls;
 mod address_filter;
 mod endpoint_list;
 mod master;
+mod no_delay;
 mod outstation;
 
 /// state of TCP client connection

--- a/dnp3/src/tcp/no_delay.rs
+++ b/dnp3/src/tcp/no_delay.rs
@@ -1,0 +1,50 @@
+use std::sync::atomic::Ordering;
+
+static CLIENT_TCP_NO_DELAY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+static SERVER_TCP_NO_DELAY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+pub(crate) fn configure_client(stream: &tokio::net::TcpStream) {
+    configure_no_delay(CLIENT_TCP_NO_DELAY.load(Ordering::Relaxed), stream)
+}
+
+pub(crate) fn configure_server(stream: &tokio::net::TcpStream) {
+    configure_no_delay(SERVER_TCP_NO_DELAY.load(Ordering::Relaxed), stream)
+}
+
+fn configure_no_delay(value: bool, stream: &tokio::net::TcpStream) {
+    if let Err(err) = stream.set_nodelay(value) {
+        tracing::info!("Unable to set TCP_NODELAY to {}: {}", value, err);
+    }
+}
+
+/// By default, TCP_NODELAY is set to true for all client TCP/TLS connections. This disables Nagle's
+/// algorithm causing the OS to send data written to socket ASAP without waiting. This reduces
+/// latency and is usually the appropriate setting for DNP3. This library always writes data
+/// in units of link-layer frames so the default setting might cause more TCP fragmentation
+/// if clients send requests that exceed a single link-layer frame.
+///
+/// Calling this function will enable Nagle's algorithm for all future outbound TCP connections.
+/// This would typically be called prior to creating any TCP/TLS clients.
+///
+/// In a future 2.0 release, this flag will likely be settable on a per-session basis but is done
+/// globally to preserve API compatibility
+pub fn disable_client_tcp_no_delay() {
+    CLIENT_TCP_NO_DELAY.store(false, Ordering::Relaxed)
+}
+
+/// By default, TCP_NODELAY is set to true for all server TCP/TLS connections. This disables Nagle's
+/// algorithm causing the OS to send data written to socket ASAP without waiting. This reduces
+/// latency and is usually the appropriate setting for DNP3. This library always writes data
+/// in units of link-layer frames so the default setting might cause more TCP fragmentation
+/// if clients send requests that exceed a single link-layer frame.
+///
+/// Calling this function will enable Nagle's algorithm for all future TCP connections accepted by servers.
+/// This would typically be called prior to creating any TCP/TLS servers.
+///
+/// In a future 2.0 release, this flag will likely be settable on a per-session basis but is done
+/// globally to preserve API compatibility
+pub fn disable_server_tcp_no_delay() {
+    SERVER_TCP_NO_DELAY.store(false, Ordering::Relaxed)
+}

--- a/dnp3/src/tcp/outstation.rs
+++ b/dnp3/src/tcp/outstation.rs
@@ -218,6 +218,7 @@ impl Server {
     async fn accept_one(&mut self, listener: &mut tokio::net::TcpListener) -> Result<(), Shutdown> {
         match listener.accept().await {
             Ok((stream, addr)) => {
+                crate::tcp::configure_server(&stream);
                 self.process_connection(stream, addr).await;
                 Ok(())
             }

--- a/ffi/dnp3-ffi/src/lib.rs
+++ b/ffi/dnp3-ffi/src/lib.rs
@@ -11,6 +11,7 @@ pub use master::*;
 pub use outstation::*;
 pub use request::*;
 pub use runtime::*;
+pub(crate) use tcp::*;
 
 mod command;
 mod handler;
@@ -19,6 +20,7 @@ mod master;
 mod outstation;
 mod request;
 mod runtime;
+mod tcp;
 
 pub mod ffi;
 

--- a/ffi/dnp3-ffi/src/tcp.rs
+++ b/ffi/dnp3-ffi/src/tcp.rs
@@ -1,0 +1,7 @@
+pub(crate) fn disable_client_tcp_no_delay() {
+    dnp3::tcp::disable_client_tcp_no_delay();
+}
+
+pub(crate) fn disable_server_tcp_no_delay() {
+    dnp3::tcp::disable_server_tcp_no_delay();
+}

--- a/ffi/dnp3-schema/src/lib.rs
+++ b/ffi/dnp3-schema/src/lib.rs
@@ -11,6 +11,7 @@ mod outstation;
 mod request;
 mod runtime;
 mod shared;
+mod tcp;
 mod variation;
 
 pub(crate) fn gv(g: u8, v: u8) -> String {
@@ -70,6 +71,9 @@ pub fn build_lib() -> BackTraced<Library> {
         info,
         settings,
     );
+
+    // global settings
+    crate::tcp::define(&mut builder)?;
 
     // Shared stuff
     let shared_def = shared::define(&mut builder)?;

--- a/ffi/dnp3-schema/src/tcp.rs
+++ b/ffi/dnp3-schema/src/tcp.rs
@@ -1,0 +1,29 @@
+use oo_bindgen::model::{doc, BackTraced, LibraryBuilder};
+
+pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
+    let disable_client_tcp_no_delay = lib
+        .define_function("disable_client_tcp_no_delay")?
+        .doc(
+            doc("By default, TCP_NODELAY is set to true for all client TCP/TLS connections. This disables Nagle's algorithm causing the OS to send data written to socket ASAP without waiting. This reduces latency and is usually the appropriate setting for DNP3. This library always writes data in units of link-layer frames so the default setting might cause more TCP fragmentation if clients send requests that exceed a single link-layer frame")
+                .details("Calling this function will enable Nagle's algorithm for all future outbound TCP connections.")
+                .details("This would typically be called prior to creating any TCP/TLS clients. In a future 2.0 release, this flag will likely be settable on a per-session basis but is done globally to preserve API compatibility")
+        )?
+        .build_static("disable_client_tcp_no_delay")?;
+
+    let disable_server_tcp_no_delay = lib
+        .define_function("disable_server_tcp_no_delay")?
+        .doc(
+            doc("By default, TCP_NODELAY is set to true for all server TCP/TLS connections. This disables Nagle's algorithm causing the OS to send data written to socket ASAP without waiting. This reduces latency and is usually the appropriate setting for DNP3. This library always writes data in units of link-layer frames so the default setting might cause more TCP fragmentation if clients send requests that exceed a single link-layer frame")
+                .details("Calling this function will enable Nagle's algorithm for all future TCP/TLS connections accepted by servers")
+                .details("This would typically be called prior to creating any TCP/TLS clients. In a future 2.0 release, this flag will likely be settable on a per-session basis but is done globally to preserve API compatibility")
+        )?
+        .build_static("disable_server_tcp_no_delay")?;
+
+    lib.define_static_class("tcp_settings")?
+        .static_method(disable_client_tcp_no_delay)?
+        .static_method(disable_server_tcp_no_delay)?
+        .doc("Global TCP/TLS configuration settings")?
+        .build()?;
+
+    Ok(())
+}


### PR DESCRIPTION
Doing performance testing under Linux revealed that Nagle's algorithm was degrading performance, particularly in the case of the master confirming data from the outstation.  This PR does the following:

* Disables Nagle's algorithm by setting TCP_NODELAY to true by default.
* Provide global functions for changing this default on client/server basis if desired.