### PR TITLE
Enable full LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "ffi/dnp3-bindings",
     "ffi/dnp3-ffi-java",
 ]
+
+[profile.release]
+lto=true


### PR DESCRIPTION
Faster and smaller code in exchange for longer link-time in release mode.