### PR TITLE
Connect options

### DIFF
--- a/dnp3/src/tcp/connect.rs
+++ b/dnp3/src/tcp/connect.rs
@@ -34,7 +34,7 @@ pub struct ConnectOptions {
 
 impl ConnectOptions {
     /// Set the local address to which the socket is bound. If not specified, then any available
-    /// ethernet adapter may be used with an OS assigned port.
+    /// adapter may be used with an OS assigned port.
     pub fn set_local_endpoint(&mut self, address: SocketAddr) {
         self.local_endpoint = Some(address);
     }

--- a/dnp3/src/tcp/connect.rs
+++ b/dnp3/src/tcp/connect.rs
@@ -1,0 +1,114 @@
+use crate::app::ExponentialBackOff;
+use crate::tcp::EndpointList;
+use crate::util::phys::PhysLayer;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::net::{TcpSocket, TcpStream};
+
+pub(crate) enum PostConnectionHandler {
+    Tcp,
+    #[cfg(feature = "tls")]
+    Tls(crate::tcp::tls::TlsClientConfig),
+}
+
+impl PostConnectionHandler {
+    async fn post_connect(
+        &mut self,
+        socket: TcpStream,
+        _endpoint: &SocketAddr,
+    ) -> Option<PhysLayer> {
+        match self {
+            Self::Tcp => Some(PhysLayer::Tcp(socket)),
+            #[cfg(feature = "tls")]
+            Self::Tls(config) => config.handle_connection(socket, _endpoint).await,
+        }
+    }
+}
+
+/// Options that control how TCP connections are established
+#[allow(clippy::missing_copy_implementations)]
+#[derive(Clone, Debug, Default)]
+pub struct ConnectOptions {
+    pub(crate) local_endpoint: Option<SocketAddr>,
+    pub(crate) timeout: Option<SocketAddr>,
+}
+
+impl ConnectOptions {
+    /// Set the local address to which the socket is bound. If not specified, then any available
+    /// ethernet adapter may be used with an OS assigned port.
+    pub fn set_local_endpoint(&mut self, address: SocketAddr) {
+        self.local_endpoint = Some(address);
+    }
+}
+
+/// All of the state required to establish a TCP or TLS connection including the retry logic
+pub(crate) struct Connector {
+    endpoints: EndpointList,
+    options: ConnectOptions,
+    back_off: ExponentialBackOff,
+    post_connect: PostConnectionHandler,
+}
+
+impl Connector {
+    /// Attempt a single connection to the next address in the list
+    pub(crate) async fn connect(&mut self) -> Result<PhysLayer, Duration> {
+        match self.endpoints.next_address().await {
+            None => {
+                let delay = self.back_off.on_failure();
+                tracing::warn!("name resolution failure");
+                Err(delay)
+            }
+            Some(addr) => self.connect_to(addr).await,
+        }
+    }
+
+    async fn connect_to(&mut self, addr: SocketAddr) -> Result<PhysLayer, Duration> {
+        let result = if addr.is_ipv4() {
+            TcpSocket::new_v4()
+        } else {
+            TcpSocket::new_v6()
+        };
+
+        let socket = match result {
+            Ok(x) => x,
+            Err(err) => {
+                let delay = self.back_off.on_failure();
+                tracing::warn!("unable to create socket: {}", err);
+                return Err(delay);
+            }
+        };
+
+        if let Some(local) = self.options.local_endpoint {
+            if let Err(err) = socket.bind(local) {
+                let delay = self.back_off.on_failure();
+                tracing::warn!("unable to bind socket to {}: {}", local, err);
+                return Err(delay);
+            }
+        }
+
+        let stream = match socket.connect(addr).await {
+            Ok(x) => x,
+            Err(err) => {
+                let delay = self.back_off.on_failure();
+                tracing::warn!("failed to connect to {}: {}", addr, err);
+                return Err(delay);
+            }
+        };
+
+        crate::tcp::configure_client(&stream);
+
+        let phys = match self.post_connect.post_connect(stream, &addr).await {
+            Some(x) => x,
+            None => {
+                let delay = self.back_off.on_failure();
+                return Err(delay);
+            }
+        };
+
+        tracing::info!("connected to {}", addr);
+        self.endpoints.reset();
+        self.back_off.on_success();
+
+        Ok(phys)
+    }
+}

--- a/dnp3/src/tcp/connect.rs
+++ b/dnp3/src/tcp/connect.rs
@@ -65,17 +65,15 @@ impl Connector {
 
     /// Attempt a single connection to the next address in the list
     pub(crate) async fn connect(&mut self) -> Result<PhysLayer, Duration> {
-        match self.endpoints.next_address().await {
+        let addr = match self.endpoints.next_address().await {
+            Some(x) => x,
             None => {
                 let delay = self.back_off.on_failure();
                 tracing::warn!("name resolution failure");
-                Err(delay)
+                return Err(delay);
             }
-            Some(addr) => self.connect_to(addr).await,
-        }
-    }
+        };
 
-    async fn connect_to(&mut self, addr: SocketAddr) -> Result<PhysLayer, Duration> {
         let result = if addr.is_ipv4() {
             TcpSocket::new_v4()
         } else {

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -112,6 +112,7 @@ impl MasterTask {
     }
 
     async fn run_one_connection(&mut self) -> Result<(), StateChange> {
+        self.listener.update(ClientState::Connecting).get().await;
         match self.connector.connect().await {
             Ok(phys) => {
                 self.listener.update(ClientState::Connected).get().await;

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -30,6 +30,7 @@ pub fn spawn_master_tcp_client(
         endpoints,
         config,
         connect_strategy,
+        ConnectOptions::default(),
         PostConnectionHandler::Tcp,
         listener,
     );
@@ -57,6 +58,7 @@ impl MasterTask {
         endpoints: EndpointList,
         config: MasterChannelConfig,
         connect_strategy: ConnectStrategy,
+        connect_options: ConnectOptions,
         connection_handler: PostConnectionHandler,
         listener: Box<dyn Listener<ClientState>>,
     ) -> (Self, MasterChannel) {
@@ -76,7 +78,7 @@ impl MasterTask {
         let task = Self {
             connector: Connector::new(
                 endpoints,
-                ConnectOptions::default(),
+                connect_options,
                 retry_strategy,
                 connection_handler,
             ),

--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -24,13 +24,33 @@ pub fn spawn_master_tcp_client(
     connect_strategy: ConnectStrategy,
     listener: Box<dyn Listener<ClientState>>,
 ) -> MasterChannel {
+    spawn_master_tcp_client_2(
+        link_error_mode,
+        config,
+        endpoints,
+        connect_strategy,
+        ConnectOptions::default(),
+        listener,
+    )
+}
+
+/// Just like [spawn_master_tcp_client], but this variant was added later to also accept and
+/// apply [ConnectOptions].
+pub fn spawn_master_tcp_client_2(
+    link_error_mode: LinkErrorMode,
+    config: MasterChannelConfig,
+    endpoints: EndpointList,
+    connect_strategy: ConnectStrategy,
+    connect_options: ConnectOptions,
+    listener: Box<dyn Listener<ClientState>>,
+) -> MasterChannel {
     let main_addr = endpoints.main_addr().to_string();
     let (mut task, handle) = MasterTask::new(
         link_error_mode,
         endpoints,
         config,
         connect_strategy,
-        ConnectOptions::default(),
+        connect_options,
         PostConnectionHandler::Tcp,
         listener,
     );

--- a/dnp3/src/tcp/mod.rs
+++ b/dnp3/src/tcp/mod.rs
@@ -1,4 +1,5 @@
 pub use address_filter::*;
+pub use connect::*;
 pub use endpoint_list::*;
 pub use master::*;
 pub use no_delay::*;
@@ -9,6 +10,7 @@ pub use outstation::*;
 pub mod tls;
 
 mod address_filter;
+mod connect;
 mod endpoint_list;
 mod master;
 mod no_delay;

--- a/dnp3/src/tcp/tls/master.rs
+++ b/dnp3/src/tcp/tls/master.rs
@@ -8,8 +8,8 @@ use crate::app::{ConnectStrategy, Listener};
 use crate::link::LinkErrorMode;
 use crate::master::{MasterChannel, MasterChannelConfig};
 use crate::tcp::tls::{load_certs, load_private_key, CertificateMode, MinTlsVersion, TlsError};
-use crate::tcp::EndpointList;
-use crate::tcp::{ClientState, MasterTask, MasterTaskConnectionHandler};
+use crate::tcp::{ClientState, MasterTask};
+use crate::tcp::{EndpointList, PostConnectionHandler};
 use crate::util::phys::PhysLayer;
 
 use rx509;
@@ -42,7 +42,7 @@ pub fn spawn_master_tls_client(
         endpoints,
         config,
         connect_strategy,
-        MasterTaskConnectionHandler::Tls(tls_config),
+        PostConnectionHandler::Tls(tls_config),
         listener,
     );
     let future = async move {

--- a/dnp3/src/tcp/tls/master.rs
+++ b/dnp3/src/tcp/tls/master.rs
@@ -36,13 +36,35 @@ pub fn spawn_master_tls_client(
     listener: Box<dyn Listener<ClientState>>,
     tls_config: TlsClientConfig,
 ) -> MasterChannel {
+    spawn_master_tls_client_2(
+        link_error_mode,
+        config,
+        endpoints,
+        connect_strategy,
+        ConnectOptions::default(),
+        listener,
+        tls_config,
+    )
+}
+
+/// Just like [spawn_master_tls_client], but this variant was added later to also accept and
+/// apply [ConnectOptions]
+pub fn spawn_master_tls_client_2(
+    link_error_mode: LinkErrorMode,
+    config: MasterChannelConfig,
+    endpoints: EndpointList,
+    connect_strategy: ConnectStrategy,
+    connect_options: ConnectOptions,
+    listener: Box<dyn Listener<ClientState>>,
+    tls_config: TlsClientConfig,
+) -> MasterChannel {
     let main_addr = endpoints.main_addr().to_string();
     let (mut task, handle) = MasterTask::new(
         link_error_mode,
         endpoints,
         config,
         connect_strategy,
-        ConnectOptions::default(),
+        connect_options,
         PostConnectionHandler::Tls(tls_config),
         listener,
     );

--- a/dnp3/src/tcp/tls/master.rs
+++ b/dnp3/src/tcp/tls/master.rs
@@ -8,7 +8,7 @@ use crate::app::{ConnectStrategy, Listener};
 use crate::link::LinkErrorMode;
 use crate::master::{MasterChannel, MasterChannelConfig};
 use crate::tcp::tls::{load_certs, load_private_key, CertificateMode, MinTlsVersion, TlsError};
-use crate::tcp::{ClientState, MasterTask};
+use crate::tcp::{ClientState, ConnectOptions, MasterTask};
 use crate::tcp::{EndpointList, PostConnectionHandler};
 use crate::util::phys::PhysLayer;
 
@@ -42,6 +42,7 @@ pub fn spawn_master_tls_client(
         endpoints,
         config,
         connect_strategy,
+        ConnectOptions::default(),
         PostConnectionHandler::Tls(tls_config),
         listener,
     );

--- a/dnp3/src/tcp/tls/master.rs
+++ b/dnp3/src/tcp/tls/master.rs
@@ -140,14 +140,14 @@ impl TlsClientConfig {
         &mut self,
         socket: TcpStream,
         endpoint: &SocketAddr,
-    ) -> Result<PhysLayer, String> {
+    ) -> Option<PhysLayer> {
         let connector = tokio_rustls::TlsConnector::from(self.config.clone());
         match connector.connect(self.dns_name.clone(), socket).await {
-            Err(err) => Err(format!(
-                "failed to establish TLS session with {}: {}",
-                endpoint, err
-            )),
-            Ok(stream) => Ok(PhysLayer::Tls(Box::new(tokio_rustls::TlsStream::from(
+            Err(err) => {
+                tracing::warn!("failed to establish TLS session with {}: {}", endpoint, err);
+                None
+            }
+            Ok(stream) => Some(PhysLayer::Tls(Box::new(tokio_rustls::TlsStream::from(
                 stream,
             )))),
         }

--- a/ffi/dnp3-ffi/src/connect.rs
+++ b/ffi/dnp3-ffi/src/connect.rs
@@ -8,7 +8,7 @@ pub struct ConnectOptions {
 }
 
 pub(crate) fn connect_options_create() -> *mut ConnectOptions {
-    Box::into_raw(Box::new(ConnectOptions::default()))
+    Box::into_raw(Box::default())
 }
 
 pub(crate) unsafe fn connect_options_destroy(instance: *mut ConnectOptions) {

--- a/ffi/dnp3-ffi/src/connect.rs
+++ b/ffi/dnp3-ffi/src/connect.rs
@@ -1,0 +1,47 @@
+use crate::ffi::ParamError;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+#[derive(Default)]
+pub struct ConnectOptions {
+    pub(crate) inner: dnp3::tcp::ConnectOptions,
+}
+
+pub(crate) fn connect_options_create() -> *mut ConnectOptions {
+    Box::into_raw(Box::new(ConnectOptions::default()))
+}
+
+pub(crate) unsafe fn connect_options_destroy(instance: *mut ConnectOptions) {
+    if !instance.is_null() {
+        drop(Box::from_raw(instance));
+    }
+}
+
+pub(crate) unsafe fn connect_options_set_timeout(
+    instance: *mut ConnectOptions,
+    timeout: std::time::Duration,
+) {
+    let options = match instance.as_mut() {
+        Some(x) => x,
+        None => return,
+    };
+
+    options.inner.set_connect_timeout(timeout);
+}
+
+pub(crate) unsafe fn connect_options_set_local_endpoint(
+    instance: *mut crate::ConnectOptions,
+    endpoint: &std::ffi::CStr,
+) -> Result<(), ParamError> {
+    let options = match instance.as_mut() {
+        Some(x) => x,
+        None => return Err(ParamError::NullParameter),
+    };
+
+    let addr: SocketAddr = SocketAddr::from_str(&endpoint.to_string_lossy())
+        .map_err(|_| ParamError::InvalidSocketAddress)?;
+
+    options.inner.set_local_endpoint(addr);
+
+    Ok(())
+}

--- a/ffi/dnp3-ffi/src/lib.rs
+++ b/ffi/dnp3-ffi/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) use crate::tracing::*;
 /// these use statements allow the code in the FFI to not have to known the real locations
 /// but instead just use crate::<name> when invoking an implementation
 pub use command::*;
+pub use connect::*;
 pub use decoding::*;
 use dnp3::app::Shutdown;
 pub use handler::*;
@@ -16,6 +17,7 @@ pub use runtime::*;
 pub(crate) use tcp::*;
 
 mod command;
+mod connect;
 mod decoding;
 mod handler;
 mod master;

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -1,5 +1,5 @@
 use std::ffi::CStr;
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 use std::time::Duration;
 
 use dnp3::app::{
@@ -84,20 +84,6 @@ pub(crate) unsafe fn master_channel_create_tcp_2(
     Ok(Box::into_raw(Box::new(channel)))
 }
 
-#[cfg(not(feature = "tls"))]
-pub(crate) unsafe fn master_channel_create_tls(
-    _runtime: *mut crate::runtime::Runtime,
-    _link_error_mode: ffi::LinkErrorMode,
-    _config: ffi::MasterChannelConfig,
-    _endpoints: *const crate::EndpointList,
-    _connect_strategy: ffi::ConnectStrategy,
-    _listener: ffi::ClientStateListener,
-    _tls_config: ffi::TlsClientConfig,
-) -> Result<*mut MasterChannel, ffi::ParamError> {
-    Err(ffi::ParamError::NoSupport)
-}
-
-#[cfg(feature = "tls")]
 pub(crate) unsafe fn master_channel_create_tls(
     runtime: *mut crate::runtime::Runtime,
     link_error_mode: ffi::LinkErrorMode,
@@ -107,11 +93,54 @@ pub(crate) unsafe fn master_channel_create_tls(
     listener: ffi::ClientStateListener,
     tls_config: ffi::TlsClientConfig,
 ) -> Result<*mut MasterChannel, ffi::ParamError> {
+    master_channel_create_tls_2(
+        runtime,
+        link_error_mode,
+        config,
+        endpoints,
+        connect_strategy,
+        null(),
+        listener,
+        tls_config,
+    )
+}
+
+#[cfg(not(feature = "tls"))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) unsafe fn master_channel_create_tls_2(
+    _runtime: *mut crate::runtime::Runtime,
+    _link_error_mode: ffi::LinkErrorMode,
+    _config: ffi::MasterChannelConfig,
+    _endpoints: *const crate::EndpointList,
+    _connect_strategy: ffi::ConnectStrategy,
+    _connect_options: *const crate::ConnectOptions,
+    _listener: ffi::ClientStateListener,
+    _tls_config: ffi::TlsClientConfig,
+) -> Result<*mut MasterChannel, ffi::ParamError> {
+    Err(ffi::ParamError::NoSupport)
+}
+
+#[cfg(feature = "tls")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) unsafe fn master_channel_create_tls_2(
+    runtime: *mut crate::runtime::Runtime,
+    link_error_mode: ffi::LinkErrorMode,
+    config: ffi::MasterChannelConfig,
+    endpoints: *const crate::EndpointList,
+    connect_strategy: ffi::ConnectStrategy,
+    connect_options: *const crate::ConnectOptions,
+    listener: ffi::ClientStateListener,
+    tls_config: ffi::TlsClientConfig,
+) -> Result<*mut MasterChannel, ffi::ParamError> {
     use std::path::Path;
 
     let runtime = runtime.as_ref().ok_or(ffi::ParamError::NullParameter)?;
     let config = convert_config(config)?;
     let endpoints = endpoints.as_ref().ok_or(ffi::ParamError::NullParameter)?;
+    let connect_options = connect_options
+        .as_ref()
+        .map(|x| x.inner)
+        .unwrap_or_else(Default::default);
 
     let password = tls_config.password().to_string_lossy();
     let optional_password = match password.as_ref() {
@@ -142,11 +171,12 @@ pub(crate) unsafe fn master_channel_create_tls(
     // enter the runtime context so that we can spawn
     let _enter = runtime.inner.enter();
 
-    let channel = dnp3::tcp::tls::spawn_master_tls_client(
+    let channel = dnp3::tcp::tls::spawn_master_tls_client_2(
         link_error_mode.into(),
         config,
         endpoints.clone(),
         connect_strategy,
+        connect_options,
         Box::new(listener),
         tls_config,
     );

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -106,7 +106,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         )?
         .fails_with(shared.error_type.clone())?
         .doc("Create a master channel that connects to the specified TCP endpoint(s)")?
-        .build_static("create_tcp_channel")?;
+        .build_static("create_tcp_channel_2")?;
 
     let master_channel_create_serial_fn = lib
         .define_function("master_channel_create_serial")?

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -17,7 +17,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
 
     let connect_strategy = define_connect_strategy(lib)?;
 
-    let _connect_options = define_connect_options(lib, shared)?;
+    let connect_options = define_connect_options(lib, shared)?;
 
     let nothing = lib
         .define_enum("nothing")?
@@ -51,6 +51,51 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
             "connect_strategy",
             connect_strategy.clone(),
             "Controls the timing of (re)connection attempts",
+        )?
+        .param(
+            "listener",
+            tcp_client_state_listener.clone(),
+            "TCP connection listener used to receive updates on the status of the connection",
+        )?
+        .returns(
+            master_channel_class.clone(),
+            "Handle to the master created, {null} if an error occurred",
+        )?
+        .fails_with(shared.error_type.clone())?
+        .doc("Create a master channel that connects to the specified TCP endpoint(s)")?
+        .build_static("create_tcp_channel")?;
+
+    let master_channel_create_tcp_2_fn = lib
+        .define_function("master_channel_create_tcp_2")?
+        .param(
+            "runtime",
+            shared.runtime_class.clone(),
+            "Runtime to use to drive asynchronous operations of the master",
+        )?
+        .param(
+            "link_error_mode",
+            shared.link_error_mode.clone(),
+            "Controls how link errors are handled with respect to the TCP session",
+        )?
+        .param(
+            "config",
+            master_channel_config.clone(),
+            "Generic configuration for the channel",
+        )?
+        .param(
+            "endpoints",
+            endpoint_list.declaration(),
+            "List of IP endpoints.",
+        )?
+        .param(
+            "connect_strategy",
+            connect_strategy.clone(),
+            "Controls the timing of (re)connection attempts",
+        )?
+        .param(
+            "connect_options",
+            connect_options.declaration(),
+            "Options that control the TCP connection process",
         )?
         .param(
             "listener",
@@ -346,6 +391,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
     lib.define_class(&master_channel_class)?
         .destructor(channel_destructor)?
         .static_method(master_channel_create_tcp_fn)?
+        .static_method(master_channel_create_tcp_2_fn)?
         .static_method(master_channel_create_tls_fn)?
         .static_method(master_channel_create_serial_fn)?
         .method(enable_method)?

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -17,8 +17,6 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
 
     let connect_strategy = define_connect_strategy(lib)?;
 
-    let connect_options = define_connect_options(lib, shared)?;
-
     let nothing = lib
         .define_enum("nothing")?
         .push("nothing", "the only value this enum has")?
@@ -94,7 +92,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         )?
         .param(
             "connect_options",
-            connect_options.declaration(),
+            shared.connect_options.declaration(),
             "Options that control the TCP connection process",
         )?
         .param(
@@ -419,47 +417,6 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         .build()?;
 
     Ok(())
-}
-
-fn define_connect_options(
-    lib: &mut LibraryBuilder,
-    shared: &SharedDefinitions,
-) -> BackTraced<ClassHandle> {
-    let options = lib.declare_class("connect_options")?;
-
-    let constructor = lib
-        .define_constructor(options.clone())?
-        .doc("Initialize to the defaults")?
-        .build()?;
-
-    let destructor = lib.define_destructor(options.clone(), "Destroy an instance")?;
-
-    let set_timeout = lib
-        .define_method("set_timeout", options.clone())?
-        .doc("Set a timeout for the TCP connection that might be less than the default for the OS")?
-        .param("timeout", DurationType::Seconds, "Timeout value")?
-        .build()?;
-
-    let set_local_endpoint = lib
-        .define_method("set_local_endpoint", options.clone())?
-        .doc(
-            doc("Set the local address to which the socket is bound")
-                .details("If not specified, then any available adapter may be used with an OS assigned port.")
-        )?
-        .param("endpoint", StringType, "String in <address:port> format, where address can be IPv4 or IPv6. Using 0 for the port results in an OS assigned port")?
-        .fails_with(shared.error_type.clone())?
-        .build()?;
-
-    let options = lib
-        .define_class(&options)?
-        .doc("Options that control how TCP connections are established")?
-        .constructor(constructor)?
-        .destructor(destructor)?
-        .method(set_timeout)?
-        .method(set_local_endpoint)?
-        .build()?;
-
-    Ok(options)
 }
 
 fn define_connect_strategy(lib: &mut LibraryBuilder) -> BackTraced<FunctionArgStructHandle> {

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -105,7 +105,10 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
             "Handle to the master created, {null} if an error occurred",
         )?
         .fails_with(shared.error_type.clone())?
-        .doc("Create a master channel that connects to the specified TCP endpoint(s)")?
+        .doc(
+            doc("Create a master channel that connects to the specified TCP endpoint(s)")
+                .details("This is just like {class:master_channel.create_tcp_channel()} but adds the {class:connect_options} parameter")
+        )?
         .build_static("create_tcp_channel_2")?;
 
     let master_channel_create_serial_fn = lib
@@ -143,6 +146,51 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         )?
         .param(
             "config",
+            master_channel_config.clone(),
+            "Generic configuration for the channel",
+        )?
+        .param(
+            "endpoints",
+            endpoint_list.declaration(),
+            "List of IP endpoints.",
+        )?
+        .param(
+            "connect_strategy",
+            connect_strategy.clone(),
+            "Controls the timing of (re)connection attempts",
+        )?
+        .param(
+            "listener",
+            tcp_client_state_listener.clone(),
+            "TCP connection listener used to receive updates on the status of the connection",
+        )?
+        .param(
+            "tls_config",
+            tls_client_config.clone(),
+            "TLS client configuration",
+        )?
+        .returns(
+            master_channel_class.clone(),
+            "Handle to the master created, {null} if an error occurred",
+        )?
+        .fails_with(shared.error_type.clone())?
+        .doc("Create a master channel that connects to the specified TCP endpoint(s) and establish a TLS session with the remote.")?
+        .build_static("create_tls_channel")?;
+
+    let master_channel_create_tls_2_fn = lib
+        .define_function("master_channel_create_tls_2")?
+        .param(
+            "runtime",
+            shared.runtime_class.clone(),
+            "Runtime to use to drive asynchronous operations of the master",
+        )?
+        .param(
+            "link_error_mode",
+            shared.link_error_mode.clone(),
+            "Controls how link errors are handled with respect to the TCP session",
+        )?
+        .param(
+            "config",
             master_channel_config,
             "Generic configuration for the channel",
         )?
@@ -155,6 +203,11 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
             "connect_strategy",
             connect_strategy,
             "Controls the timing of (re)connection attempts",
+        )?
+        .param(
+            "connect_options",
+            shared.connect_options.declaration(),
+            "Options that control the TCP connection process",
         )?
         .param(
             "listener",
@@ -171,8 +224,11 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
             "Handle to the master created, {null} if an error occurred",
         )?
         .fails_with(shared.error_type.clone())?
-        .doc("Create a master channel that connects to the specified TCP endpoint(s) and establish a TLS session with the remote.")?
-        .build_static("create_tls_channel")?;
+        .doc(
+            doc("Create a master channel that connects to the specified TCP endpoint(s) and establish a TLS session with the remote.")
+                .details("This is just like {class:master_channel.create_tls_channel()} but adds the {class:connect_options} parameter")
+        )?
+        .build_static("create_tls_channel_2")?;
 
     let enable_method = lib
         .define_method("enable", master_channel_class.clone())?
@@ -391,6 +447,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         .static_method(master_channel_create_tcp_fn)?
         .static_method(master_channel_create_tcp_2_fn)?
         .static_method(master_channel_create_tls_fn)?
+        .static_method(master_channel_create_tls_2_fn)?
         .static_method(master_channel_create_serial_fn)?
         .method(enable_method)?
         .method(disable_method)?

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -17,6 +17,8 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
 
     let connect_strategy = define_connect_strategy(lib)?;
 
+    let _connect_options = define_connect_options(lib, shared)?;
+
     let nothing = lib
         .define_enum("nothing")?
         .push("nothing", "the only value this enum has")?
@@ -371,6 +373,47 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         .build()?;
 
     Ok(())
+}
+
+fn define_connect_options(
+    lib: &mut LibraryBuilder,
+    shared: &SharedDefinitions,
+) -> BackTraced<ClassHandle> {
+    let options = lib.declare_class("connect_options")?;
+
+    let constructor = lib
+        .define_constructor(options.clone())?
+        .doc("Initialize to the defaults")?
+        .build()?;
+
+    let destructor = lib.define_destructor(options.clone(), "Destroy an instance")?;
+
+    let set_timeout = lib
+        .define_method("set_timeout", options.clone())?
+        .doc("Set a timeout for the TCP connection that might be less than the default for the OS")?
+        .param("timeout", DurationType::Seconds, "Timeout value")?
+        .build()?;
+
+    let set_local_endpoint = lib
+        .define_method("set_local_endpoint", options.clone())?
+        .doc(
+            doc("Set the local address to which the socket is bound")
+                .details("If not specified, then any available adapter may be used with an OS assigned port.")
+        )?
+        .param("endpoint", StringType, "String in <address:port> format, where address can be IPv4 or IPv6. Using 0 for the port results in an OS assigned port")?
+        .fails_with(shared.error_type.clone())?
+        .build()?;
+
+    let options = lib
+        .define_class(&options)?
+        .doc("Options that control how TCP connections are established")?
+        .constructor(constructor)?
+        .destructor(destructor)?
+        .method(set_timeout)?
+        .method(set_local_endpoint)?
+        .build()?;
+
+    Ok(options)
 }
 
 fn define_connect_strategy(lib: &mut LibraryBuilder) -> BackTraced<FunctionArgStructHandle> {


### PR DESCRIPTION
Adds overloaded constructors for creating a TCP/TLS  master channel that takes an opaque `ConnectOptions`. The new parameter provides a way to set:

* An optional timeout that may be less than the OS default connect timeout. If not set, the behavior just reverts to the OS default timeout.
* An optional local endpoint to bind the socket prior to connecting. This is useful in dual-homed systems with multiple NICs. If not provided, then the behavior reverts to all adapters and an OS specified port (`0.0.0.0:0`).  Most users wishing to specify the IP of the adapter will chose to use `0` for a random available port from the OS, but manual port selection is possible as well.

This is a proposed way of addressing https://github.com/stepfunc/dnp3/issues/245 and https://github.com/stepfunc/dnp3/issues/244 without breaking backward compatibility. Some of the various options, like the retry paramters, could be merged in a future 2.0.