### PR TITLE
Freeze operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ ffi/bindings/java/dnp3
 ffi/bindings/java/dnp3-jni
 ffi/bindings/java/*/target
 ffi/bindings/java/**/*.iml
+
+# .NET examples properties
+ffi/bindings/dotnet/examples/master/Properties/
+ffi/bindings/dotnet/examples/outstation/Properties/

--- a/dnp3/codegen/src/main/scala/dev/gridio/dnp3/codegen/model/groups/Group50.scala
+++ b/dnp3/codegen/src/main/scala/dev/gridio/dnp3/codegen/model/groups/Group50.scala
@@ -5,7 +5,7 @@ import dev.gridio.dnp3.codegen.model.FixedSizeField._
 
 // absolute time
 object Group50 extends ObjectGroup {
-  def variations: List[Variation] = List(Group50Var1, Group50Var3, Group50Var4)
+  def variations: List[Variation] = List(Group50Var1, Group50Var2, Group50Var3, Group50Var4)
 
   def group: Byte = 50
 
@@ -15,6 +15,11 @@ object Group50 extends ObjectGroup {
 }
 
 object Group50Var1 extends FixedSize(Group50, 1, "Absolute Time")(time48)
+
+object Group50Var2 extends FixedSize(Group50, 2, "Absolute time and interval")(
+  time48,
+  FixedSizeField("interval", UInt32Field)
+)
 
 object Group50Var3 extends FixedSize(Group50, 3, "Absolute Time at last recorded time")(time48)
 

--- a/dnp3/examples/master.rs
+++ b/dnp3/examples/master.rs
@@ -321,11 +321,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // ANCHOR_END: write_dead_bands
             }
             "fat" => {
+                // ANCHOR: freeze_at_time
                 let headers = Headers::new()
                     // freeze all the counters once per day relative to the beginning of the current hour
                     .add_freeze_interval(FreezeInterval::PeriodicallyFreezeRelative(86_400_000))
                     // apply this schedule to all counters
-                    .all_objects(Variation::Group20Var0);
+                    .add_all_objects(Variation::Group20Var0);
 
                 if let Err(err) = association
                     .request_expecting_empty_response(FunctionCode::FreezeAtTime, headers)
@@ -333,6 +334,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 {
                     tracing::warn!("error: {}", err);
                 }
+                // ANCHOR_END: freeze_at_time
             }
             "crt" => {
                 let result = association.cold_restart().await;

--- a/dnp3/examples/master.rs
+++ b/dnp3/examples/master.rs
@@ -16,6 +16,7 @@ use dnp3::serial::*;
 #[cfg(feature = "tls")]
 use dnp3::tcp::tls::*;
 
+use dnp3::outstation::FreezeInterval;
 use std::process::exit;
 
 /// read handler that does nothing
@@ -320,9 +321,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // ANCHOR_END: write_dead_bands
             }
             "fat" => {
-                // freeze all the counters once per day relative to the beginning of the current hour
                 let headers = Headers::new()
-                    .add_time_and_interval(Timestamp::zero(), 86_400_000)
+                    // freeze all the counters once per day relative to the beginning of the current hour
+                    .add_freeze_interval(FreezeInterval::PeriodicallyFreezeRelative(86_400_000))
+                    // apply this schedule to all counters
                     .all_objects(Variation::Group20Var0);
 
                 if let Err(err) = association

--- a/dnp3/examples/master.rs
+++ b/dnp3/examples/master.rs
@@ -319,6 +319,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 // ANCHOR_END: write_dead_bands
             }
+            "fat" => {
+                // freeze all the counters once per day relative to the beginning of the current hour
+                let headers = Headers::new()
+                    .add_time_and_interval(Timestamp::zero(), 86_400_000)
+                    .all_objects(Variation::Group20Var0);
+
+                if let Err(err) = association
+                    .request_expecting_empty_response(FunctionCode::FreezeAtTime, headers)
+                    .await
+                {
+                    tracing::warn!("error: {}", err);
+                }
+            }
             "crt" => {
                 let result = association.cold_restart().await;
 

--- a/dnp3/src/app/app_enums.rs
+++ b/dnp3/src/app/app_enums.rs
@@ -70,7 +70,7 @@ impl QualifierCode {
 }
 
 /// Application layer function code enumeration
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FunctionCode {
     ///  Master sends this to an outstation to confirm the receipt of an Application Layer fragment (value == 0)
     Confirm,

--- a/dnp3/src/app/gen/count.rs
+++ b/dnp3/src/app/gen/count.rs
@@ -118,6 +118,8 @@ pub(crate) enum CountVariation<'a> {
     Group42Var8,
     /// Time and Date - Absolute Time
     Group50Var1(CountSequence<'a, Group50Var1>),
+    /// Time and Date - Absolute time and interval
+    Group50Var2(CountSequence<'a, Group50Var2>),
     /// Time and Date - Absolute Time at last recorded time
     Group50Var3(CountSequence<'a, Group50Var3>),
     /// Time and Date - Indexed absolute time and long interval
@@ -193,6 +195,7 @@ impl<'a> CountVariation<'a> {
             Variation::Group42Var7 => Ok(CountVariation::Group42Var7),
             Variation::Group42Var8 => Ok(CountVariation::Group42Var8),
             Variation::Group50Var1 => Ok(CountVariation::Group50Var1(CountSequence::parse(count, cursor)?)),
+            Variation::Group50Var2 => Ok(CountVariation::Group50Var2(CountSequence::parse(count, cursor)?)),
             Variation::Group50Var3 => Ok(CountVariation::Group50Var3(CountSequence::parse(count, cursor)?)),
             Variation::Group50Var4 => Ok(CountVariation::Group50Var4(CountSequence::parse(count, cursor)?)),
             Variation::Group51Var1 => Ok(CountVariation::Group51Var1(CountSequence::parse(count, cursor)?)),
@@ -259,6 +262,7 @@ impl<'a> CountVariation<'a> {
             CountVariation::Group42Var7 => Ok(()),
             CountVariation::Group42Var8 => Ok(()),
             CountVariation::Group50Var1(seq) => format_count_of_items(f, seq.iter()),
+            CountVariation::Group50Var2(seq) => format_count_of_items(f, seq.iter()),
             CountVariation::Group50Var3(seq) => format_count_of_items(f, seq.iter()),
             CountVariation::Group50Var4(seq) => format_count_of_items(f, seq.iter()),
             CountVariation::Group51Var1(seq) => format_count_of_items(f, seq.iter()),

--- a/dnp3/src/app/header.rs
+++ b/dnp3/src/app/header.rs
@@ -261,6 +261,10 @@ impl Iin2 {
         Self { value }
     }
 
+    pub(crate) fn set(&mut self, iin2: Self) {
+        self.value |= iin2.value;
+    }
+
     /// test IIN.2 to see if the NO_FUNC_CODE_SUPPORT bit is set
     pub fn get_no_func_code_support(self) -> bool {
         self.value.bit_0()

--- a/dnp3/src/app/listener.rs
+++ b/dnp3/src/app/listener.rs
@@ -11,7 +11,7 @@ pub trait Listener<T>: Send + Sync {
 pub struct NullListener;
 
 impl NullListener {
-    /// create a Box<dyn Listener<T>> that does nothing
+    /// create a `Box<dyn Listener<T>>` that does nothing
     pub fn create<T>() -> Box<dyn Listener<T>> {
         Box::new(NullListener)
     }

--- a/dnp3/src/app/parse/parser.rs
+++ b/dnp3/src/app/parse/parser.rs
@@ -967,6 +967,32 @@ mod test {
     }
 
     #[test]
+    fn parses_count_of_g50v2() {
+        let input = [
+            0x32, 0x02, 0x07, 0x01, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC, 0xDD,
+        ];
+        let mut headers = HeaderCollection::parse(FunctionCode::Write, &input)
+            .unwrap()
+            .iter();
+
+        let received = match headers.next().unwrap().details {
+            HeaderDetails::OneByteCount(01, CountVariation::Group50Var2(seq)) => {
+                seq.single().unwrap()
+            }
+            _ => unreachable!(),
+        };
+
+        assert!(headers.next().is_none());
+
+        let expected = Group50Var2 {
+            time: Timestamp::new(0xFF),
+            interval: 0xDDCCBBAA,
+        };
+
+        assert_eq!(received, expected);
+    }
+
+    #[test]
     fn parses_group110var0_as_read() {
         let input = [0x6E, 0x00, 0x00, 0x02, 0x03];
         let mut headers = HeaderCollection::parse(FunctionCode::Read, &input)

--- a/dnp3/src/app/types.rs
+++ b/dnp3/src/app/types.rs
@@ -31,7 +31,8 @@ impl Timestamp {
         Self::zero()
     }
 
-    pub(crate) const fn zero() -> Self {
+    /// Timestamp value of zero corresponding to the epoch
+    pub const fn zero() -> Self {
         Self::new(0)
     }
 

--- a/dnp3/src/app/types.rs
+++ b/dnp3/src/app/types.rs
@@ -20,14 +20,18 @@ impl Timestamp {
     pub(crate) const OUT_OF_RANGE: &'static str = "<out of range>";
 
     /// Create a timestamp from a count of milliseconds since epoch
-    pub fn new(value: u64) -> Self {
+    pub const fn new(value: u64) -> Self {
         Self {
             value: value & Self::MAX_VALUE,
         }
     }
 
     /// Minimum valid timestamp
-    pub fn min() -> Self {
+    pub const fn min() -> Self {
+        Self::zero()
+    }
+
+    pub(crate) const fn zero() -> Self {
         Self::new(0)
     }
 
@@ -49,7 +53,7 @@ impl Timestamp {
         ))
     }
 
-    /// Attempt to create a DateTime<Utc> from a Timestamp
+    /// Attempt to create a `DateTime<Utc>` from a Timestamp
     pub fn to_datetime_utc(self) -> Option<DateTime<Utc>> {
         Utc.timestamp_millis_opt(self.value as i64).single()
     }

--- a/dnp3/src/link/error.rs
+++ b/dnp3/src/link/error.rs
@@ -1,5 +1,4 @@
 use crate::util::BadWrite;
-use scursor::WriteError;
 
 /// these errors should never occur, but they are preferable to using
 /// functions that could panic. If they ever were to happen, they indicate
@@ -90,8 +89,8 @@ impl From<LogicError> for LinkError {
     }
 }
 
-impl From<WriteError> for LinkError {
-    fn from(_: WriteError) -> Self {
+impl From<scursor::WriteError> for LinkError {
+    fn from(_: scursor::WriteError) -> Self {
         LinkError::BadLogic(LogicError::BadWrite)
     }
 }

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -9,8 +9,6 @@ use crate::master::association::NoAssociation;
 use crate::master::session::{RunError, StateChange};
 use crate::transport::TransportResponseError;
 
-use scursor::WriteError;
-
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::oneshot::error::RecvError;
 
@@ -258,8 +256,8 @@ impl std::fmt::Display for WriteTaskError {
     }
 }
 
-impl From<WriteError> for TaskError {
-    fn from(_: WriteError) -> Self {
+impl From<scursor::WriteError> for TaskError {
+    fn from(_: scursor::WriteError) -> Self {
         TaskError::WriteError
     }
 }

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -84,10 +84,10 @@ pub enum CommandResponseError {
     ObjectValueMismatch,
 }
 
-/// Error type for tasks that don't return anything from the outstation but might
-/// fail b/c IIN2 has a bit set
+/// Error type for WRITE operations that don't return anything from the outstation but might fail
+/// b/c IIN2 has a bit set
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum IinTaskError {
+pub enum WriteTaskError {
     /// Error occurred during task execution
     Task(TaskError),
     /// Outstation returned an IIN.2 error
@@ -249,11 +249,11 @@ impl std::fmt::Display for TimeSyncError {
     }
 }
 
-impl std::fmt::Display for IinTaskError {
+impl std::fmt::Display for WriteTaskError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            IinTaskError::Task(err) => write!(f, "{err}"),
-            IinTaskError::IinError(iin2) => write!(f, "outstation indicated an error: {iin2}"),
+            WriteTaskError::Task(err) => write!(f, "{err}"),
+            WriteTaskError::IinError(iin2) => write!(f, "outstation indicated an error: {iin2}"),
         }
     }
 }
@@ -334,15 +334,15 @@ impl From<RecvError> for AssociationError {
     }
 }
 
-impl From<RecvError> for IinTaskError {
+impl From<RecvError> for WriteTaskError {
     fn from(_: RecvError) -> Self {
-        IinTaskError::Task(TaskError::Shutdown)
+        WriteTaskError::Task(TaskError::Shutdown)
     }
 }
 
-impl From<TaskError> for IinTaskError {
+impl From<TaskError> for WriteTaskError {
     fn from(err: TaskError) -> Self {
-        IinTaskError::Task(err)
+        WriteTaskError::Task(err)
     }
 }
 
@@ -409,9 +409,9 @@ impl From<Shutdown> for PollError {
     }
 }
 
-impl From<Shutdown> for IinTaskError {
+impl From<Shutdown> for WriteTaskError {
     fn from(_: Shutdown) -> Self {
-        IinTaskError::Task(TaskError::Shutdown)
+        WriteTaskError::Task(TaskError::Shutdown)
     }
 }
 
@@ -421,4 +421,4 @@ impl Error for PollError {}
 impl Error for CommandError {}
 impl Error for CommandResponseError {}
 impl Error for TimeSyncError {}
-impl Error for IinTaskError {}
+impl Error for WriteTaskError {}

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -82,10 +82,10 @@ pub enum CommandResponseError {
     ObjectValueMismatch,
 }
 
-/// Error type for WRITE operations that don't return anything from the outstation but might fail
-/// b/c IIN2 has a bit set
+/// Error type for operations that don't return anything from the outstation but might fail
+/// b/c IIN2 has an error bit set
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum WriteTaskError {
+pub enum WriteError {
     /// Error occurred during task execution
     Task(TaskError),
     /// Outstation returned an IIN.2 error
@@ -247,11 +247,11 @@ impl std::fmt::Display for TimeSyncError {
     }
 }
 
-impl std::fmt::Display for WriteTaskError {
+impl std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            WriteTaskError::Task(err) => write!(f, "{err}"),
-            WriteTaskError::IinError(iin2) => write!(f, "outstation indicated an error: {iin2}"),
+            WriteError::Task(err) => write!(f, "{err}"),
+            WriteError::IinError(iin2) => write!(f, "outstation indicated an error: {iin2}"),
         }
     }
 }
@@ -332,15 +332,15 @@ impl From<RecvError> for AssociationError {
     }
 }
 
-impl From<RecvError> for WriteTaskError {
+impl From<RecvError> for WriteError {
     fn from(_: RecvError) -> Self {
-        WriteTaskError::Task(TaskError::Shutdown)
+        WriteError::Task(TaskError::Shutdown)
     }
 }
 
-impl From<TaskError> for WriteTaskError {
+impl From<TaskError> for WriteError {
     fn from(err: TaskError) -> Self {
-        WriteTaskError::Task(err)
+        WriteError::Task(err)
     }
 }
 
@@ -407,9 +407,9 @@ impl From<Shutdown> for PollError {
     }
 }
 
-impl From<Shutdown> for WriteTaskError {
+impl From<Shutdown> for WriteError {
     fn from(_: Shutdown) -> Self {
-        WriteTaskError::Task(TaskError::Shutdown)
+        WriteError::Task(TaskError::Shutdown)
     }
 }
 
@@ -419,4 +419,4 @@ impl Error for PollError {}
 impl Error for CommandError {}
 impl Error for CommandResponseError {}
 impl Error for TimeSyncError {}
-impl Error for WriteTaskError {}
+impl Error for WriteError {}

--- a/dnp3/src/master/handler.rs
+++ b/dnp3/src/master/handler.rs
@@ -16,7 +16,7 @@ use crate::master::tasks::read::SingleReadTask;
 use crate::master::tasks::restart::{RestartTask, RestartType};
 use crate::master::tasks::time::TimeSyncTask;
 use crate::master::tasks::Task;
-use crate::master::{DeadBandHeader, IinTaskError};
+use crate::master::{DeadBandHeader, WriteTaskError};
 use crate::util::channel::Sender;
 
 /// Handle to a master communication channel. This handle controls
@@ -269,8 +269,8 @@ impl AssociationHandle {
     pub async fn write_dead_bands(
         &mut self,
         headers: Vec<DeadBandHeader>,
-    ) -> Result<(), IinTaskError> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), IinTaskError>>();
+    ) -> Result<(), WriteTaskError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), WriteTaskError>>();
         let task = WriteDeadBandsTask::new(headers, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?

--- a/dnp3/src/master/handler.rs
+++ b/dnp3/src/master/handler.rs
@@ -16,7 +16,7 @@ use crate::master::tasks::read::SingleReadTask;
 use crate::master::tasks::restart::{RestartTask, RestartType};
 use crate::master::tasks::time::TimeSyncTask;
 use crate::master::tasks::Task;
-use crate::master::{DeadBandHeader, WriteTaskError};
+use crate::master::{DeadBandHeader, WriteError};
 use crate::util::channel::Sender;
 
 /// Handle to a master communication channel. This handle controls
@@ -269,8 +269,8 @@ impl AssociationHandle {
     pub async fn write_dead_bands(
         &mut self,
         headers: Vec<DeadBandHeader>,
-    ) -> Result<(), WriteTaskError> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), WriteTaskError>>();
+    ) -> Result<(), WriteError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), WriteError>>();
         let task = WriteDeadBandsTask::new(headers, Promise::OneShot(tx));
         self.send_task(task.wrap().wrap()).await?;
         rx.await?

--- a/dnp3/src/master/handler.rs
+++ b/dnp3/src/master/handler.rs
@@ -12,11 +12,12 @@ use crate::master::poll::{PollHandle, PollMsg};
 use crate::master::request::{CommandHeaders, CommandMode, ReadRequest, TimeSyncProcedure};
 use crate::master::tasks::command::CommandTask;
 use crate::master::tasks::deadbands::WriteDeadBandsTask;
+use crate::master::tasks::empty_response::EmptyResponseTask;
 use crate::master::tasks::read::SingleReadTask;
 use crate::master::tasks::restart::{RestartTask, RestartType};
 use crate::master::tasks::time::TimeSyncTask;
 use crate::master::tasks::Task;
-use crate::master::{DeadBandHeader, WriteError};
+use crate::master::{DeadBandHeader, Headers, WriteError};
 use crate::util::channel::Sender;
 
 /// Handle to a master communication channel. This handle controls
@@ -206,6 +207,22 @@ impl AssociationHandle {
         rx.await?
     }
 
+    /// Perform an asynchronous request with the specified function code and object headers
+    ///
+    /// This is useful for constructing various types of WRITE and FREEZE operations where
+    /// an empty response is expected from the outstation, and the only indication of success
+    /// are bits in IIN.2
+    pub async fn request_expecting_empty_response(
+        &mut self,
+        function: FunctionCode,
+        headers: Headers,
+    ) -> Result<(), WriteError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), WriteError>>();
+        let task = EmptyResponseTask::new(function, headers, Promise::OneShot(tx));
+        self.send_task(task.wrap().wrap()).await?;
+        rx.await?
+    }
+
     /// Perform an asynchronous READ request with a custom read handler
     ///
     /// If successful, the custom [ReadHandler](crate::master::ReadHandler) will process the received measurement data
@@ -325,6 +342,7 @@ impl<T> Promise<T> {
 }
 
 /// Task types used in [`AssociationInformation`]
+#[cfg_attr(not(feature = "ffi"), non_exhaustive)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TaskType {
     /// User-defined read request
@@ -349,6 +367,8 @@ pub enum TaskType {
     Restart,
     /// Write dead-bands
     WriteDeadBands,
+    /// Generic task which
+    GenericEmptyResponse(FunctionCode),
 }
 
 /// callbacks associated with a single master to outstation association

--- a/dnp3/src/master/poll.rs
+++ b/dnp3/src/master/poll.rs
@@ -9,7 +9,6 @@ use crate::master::handler::{AssociationHandle, Promise};
 use crate::master::request::ReadRequest;
 use crate::util::Smallest;
 
-use scursor::WriteError;
 use tokio::time::Instant;
 
 /// Periodic poll representation
@@ -96,7 +95,7 @@ impl Poll {
         }
     }
 
-    pub(crate) fn format(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn format(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         self.request.format(writer)
     }
 

--- a/dnp3/src/master/request.rs
+++ b/dnp3/src/master/request.rs
@@ -461,8 +461,14 @@ impl Headers {
 
     /// Add a header to the collection
     #[cfg(feature = "ffi")]
-    pub fn add_read_header(&mut self, header: ReadHeader) {
+    pub fn push_read_header(&mut self, header: ReadHeader) {
         self.headers.push(header.into());
+    }
+
+    /// Add a header to the collection
+    #[cfg(feature = "ffi")]
+    pub fn push_freeze_interval(&mut self, interval: FreezeInterval) {
+        self.headers.push(Header::TimeAndInterval(interval));
     }
 
     /// Add an all objects header (0x06) with the specified variation

--- a/dnp3/src/master/request.rs
+++ b/dnp3/src/master/request.rs
@@ -10,8 +10,6 @@ use crate::app::parse::traits::{FixedSizeVariation, Index};
 use crate::app::variations::*;
 use crate::master::error::CommandResponseError;
 
-use scursor::WriteError;
-
 /// Controls how a command request is issued
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CommandMode {
@@ -227,7 +225,7 @@ impl EventClasses {
         }
     }
 
-    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         if self.class1 {
             writer.write_all_objects_header(Variation::Group60Var2)?;
         }
@@ -284,7 +282,7 @@ impl Classes {
         self.class0 || self.events.any()
     }
 
-    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         self.events.write(writer)?;
         if self.class0 {
             writer.write_all_objects_header(Variation::Group60Var1)?;
@@ -303,7 +301,7 @@ impl OneByteRangeScan {
         }
     }
 
-    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         writer.write_range_only(self.variation, self.start, self.stop)
     }
 }
@@ -318,7 +316,7 @@ impl TwoByteRangeScan {
         }
     }
 
-    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         writer.write_range_only(self.variation, self.start, self.stop)
     }
 }
@@ -329,7 +327,7 @@ impl AllObjectsScan {
         Self { variation }
     }
 
-    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         writer.write_all_objects_header(self.variation)
     }
 }
@@ -340,7 +338,7 @@ impl OneByteLimitedCountScan {
         Self { variation, count }
     }
 
-    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         writer.write_limited_count(self.variation, self.count)
     }
 }
@@ -351,7 +349,7 @@ impl TwoByteLimitedCountScan {
         Self { variation, count }
     }
 
-    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         writer.write_limited_count(self.variation, self.count)
     }
 }
@@ -397,7 +395,7 @@ impl ReadHeader {
         ReadHeader::LimitedCount16(TwoByteLimitedCountScan::new(variation, count))
     }
 
-    pub(crate) fn format(self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn format(self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         match self {
             ReadHeader::Range8(scan) => scan.write(writer),
             ReadHeader::Range16(scan) => scan.write(writer),
@@ -445,7 +443,7 @@ impl ReadRequest {
         Self::MultipleHeader(headers.to_vec())
     }
 
-    pub(crate) fn format(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn format(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         match self {
             ReadRequest::SingleHeader(req) => req.format(writer),
             ReadRequest::ClassScan(req) => req.write(writer),
@@ -556,7 +554,7 @@ impl CommandHeaders {
         }
     }
 
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         for header in self.headers.iter() {
             header.write(writer)?;
         }
@@ -866,7 +864,7 @@ impl Default for CommandBuilder {
 }
 
 impl CommandHeader {
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         match self {
             CommandHeader::G12V1U8(items) => writer.write_prefixed_items(items.iter()),
             CommandHeader::G41V1U8(items) => writer.write_prefixed_items(items.iter()),

--- a/dnp3/src/master/request.rs
+++ b/dnp3/src/master/request.rs
@@ -472,7 +472,7 @@ impl Headers {
     }
 
     /// Add an all objects header (0x06) with the specified variation
-    pub fn all_objects(self, variation: Variation) -> Self {
+    pub fn add_all_objects(self, variation: Variation) -> Self {
         self.add(ReadHeader::all_objects(variation).into())
     }
 

--- a/dnp3/src/master/tasks/auto.rs
+++ b/dnp3/src/master/tasks/auto.rs
@@ -7,8 +7,6 @@ use crate::master::error::TaskError;
 use crate::master::request::EventClasses;
 use crate::master::tasks::{NonReadTask, Task};
 
-use scursor::WriteError;
-
 #[derive(Clone)]
 pub(crate) enum AutoTask {
     ClearRestartBit,
@@ -21,7 +19,7 @@ impl AutoTask {
         Task::NonRead(NonReadTask::Auto(self))
     }
 
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         match self {
             AutoTask::ClearRestartBit => writer.write_clear_restart(),
             AutoTask::EnableUnsolicited(classes) => classes.write(writer),

--- a/dnp3/src/master/tasks/command.rs
+++ b/dnp3/src/master/tasks/command.rs
@@ -6,8 +6,6 @@ use crate::master::handler::Promise;
 use crate::master::request::*;
 use crate::master::tasks::NonReadTask;
 
-use scursor::WriteError;
-
 enum State {
     Select,
     Operate,
@@ -70,7 +68,7 @@ impl CommandTask {
         }
     }
 
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         self.headers.write(writer)
     }
 

--- a/dnp3/src/master/tasks/empty_response.rs
+++ b/dnp3/src/master/tasks/empty_response.rs
@@ -1,0 +1,59 @@
+use crate::app::format::write::HeaderWriter;
+use crate::app::parse::parser::Response;
+use crate::app::FunctionCode;
+use crate::master::tasks::NonReadTask;
+use crate::master::{Headers, Promise, TaskError, WriteError};
+
+pub(crate) struct EmptyResponseTask {
+    function: FunctionCode,
+    headers: Headers,
+    promise: Promise<Result<(), WriteError>>,
+}
+
+impl EmptyResponseTask {
+    pub(crate) fn new(
+        function: FunctionCode,
+        headers: Headers,
+        promise: Promise<Result<(), WriteError>>,
+    ) -> Self {
+        Self {
+            function,
+            headers,
+            promise,
+        }
+    }
+
+    pub(crate) fn wrap(self) -> NonReadTask {
+        NonReadTask::EmptyResponseTask(self)
+    }
+
+    pub(crate) const fn function(&self) -> FunctionCode {
+        self.function
+    }
+
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
+        self.headers.write(writer)
+    }
+
+    pub(crate) fn on_task_error(self, err: TaskError) {
+        self.promise.complete(Err(err.into()))
+    }
+
+    pub(crate) fn handle(self, response: Response) -> Option<NonReadTask> {
+        if !response.raw_objects.is_empty() {
+            self.promise
+                .complete(Err(WriteError::Task(TaskError::UnexpectedResponseHeaders)));
+            return None;
+        }
+
+        if response.header.iin.has_request_error() {
+            self.promise
+                .complete(Err(WriteError::IinError(response.header.iin.iin2)));
+            return None;
+        }
+
+        self.promise.complete(Ok(()));
+
+        None
+    }
+}

--- a/dnp3/src/master/tasks/freeze.rs
+++ b/dnp3/src/master/tasks/freeze.rs
@@ -1,0 +1,70 @@
+use crate::app::format::write::HeaderWriter;
+use crate::app::parse::parser::Response;
+use crate::app::FunctionCode;
+use crate::master::tasks::NonReadTask;
+use crate::master::{DeadBandHeader, DeadBandHeaderVariants, Promise, TaskError, WriteError};
+
+pub(crate) struct WriteDeadBandsTask {
+    headers: Vec<DeadBandHeader>,
+    promise: Promise<Result<(), WriteError>>,
+}
+
+impl DeadBandHeaderVariants {
+    fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
+        match self {
+            Self::G34V1U8(x) => writer.write_prefixed_items(x.iter()),
+            Self::G34V1U16(x) => writer.write_prefixed_items(x.iter()),
+            Self::G34V2U8(x) => writer.write_prefixed_items(x.iter()),
+            Self::G34V2U16(x) => writer.write_prefixed_items(x.iter()),
+            Self::G34V3U8(x) => writer.write_prefixed_items(x.iter()),
+            Self::G34V3U16(x) => writer.write_prefixed_items(x.iter()),
+        }
+    }
+}
+
+impl WriteDeadBandsTask {
+    pub(crate) fn new(
+        headers: Vec<DeadBandHeader>,
+        promise: Promise<Result<(), WriteError>>,
+    ) -> Self {
+        Self { headers, promise }
+    }
+
+    pub(crate) fn wrap(self) -> NonReadTask {
+        NonReadTask::DeadBands(self)
+    }
+
+    pub(crate) const fn function(&self) -> FunctionCode {
+        FunctionCode::Write
+    }
+
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
+        for header in self.headers.iter() {
+            header.inner.write(writer)?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn on_task_error(self, err: TaskError) {
+        self.promise.complete(Err(err.into()))
+    }
+
+    pub(crate) fn handle(self, response: Response) -> Option<NonReadTask> {
+        if !response.raw_objects.is_empty() {
+            self.promise
+                .complete(Err(WriteError::Task(TaskError::UnexpectedResponseHeaders)));
+            return None;
+        }
+
+        if response.header.iin.has_request_error() {
+            self.promise
+                .complete(Err(WriteError::IinError(response.header.iin.iin2)));
+            return None;
+        }
+
+        self.promise.complete(Ok(()));
+
+        None
+    }
+}

--- a/dnp3/src/master/tasks/mod.rs
+++ b/dnp3/src/master/tasks/mod.rs
@@ -17,7 +17,6 @@ use crate::master::tasks::time::TimeSyncTask;
 use crate::master::{ReadType, TaskType};
 
 use crate::master::tasks::deadbands::WriteDeadBandsTask;
-use scursor::WriteError;
 
 pub(crate) mod auto;
 pub(crate) mod command;
@@ -89,7 +88,7 @@ impl Task {
 
 pub(crate) trait RequestWriter {
     fn function(&self) -> FunctionCode;
-    fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError>;
+    fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError>;
 }
 
 pub(crate) enum ReadTask {
@@ -121,7 +120,7 @@ impl RequestWriter for ReadTask {
         FunctionCode::Read
     }
 
-    fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         match self {
             ReadTask::PeriodicPoll(poll) => poll.format(writer),
             ReadTask::StartupIntegrity(classes) => classes.write(writer),
@@ -136,7 +135,7 @@ impl RequestWriter for NonReadTask {
         self.function()
     }
 
-    fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         match self {
             NonReadTask::Auto(t) => t.write(writer),
             NonReadTask::Command(t) => t.write(writer),

--- a/dnp3/src/master/tasks/mod.rs
+++ b/dnp3/src/master/tasks/mod.rs
@@ -17,10 +17,12 @@ use crate::master::tasks::time::TimeSyncTask;
 use crate::master::{ReadType, TaskType};
 
 use crate::master::tasks::deadbands::WriteDeadBandsTask;
+use crate::master::tasks::empty_response::EmptyResponseTask;
 
 pub(crate) mod auto;
 pub(crate) mod command;
 pub(crate) mod deadbands;
+pub(crate) mod empty_response;
 pub(crate) mod read;
 pub(crate) mod restart;
 pub(crate) mod time;
@@ -113,6 +115,8 @@ pub(crate) enum NonReadTask {
     Restart(RestartTask),
     /// write dead-bands
     DeadBands(WriteDeadBandsTask),
+    /// Generic task for anything that doesn't have response object headers
+    EmptyResponseTask(EmptyResponseTask),
 }
 
 impl RequestWriter for ReadTask {
@@ -142,6 +146,7 @@ impl RequestWriter for NonReadTask {
             NonReadTask::TimeSync(t) => t.write(writer),
             NonReadTask::Restart(_) => Ok(()),
             NonReadTask::DeadBands(t) => t.write(writer),
+            NonReadTask::EmptyResponseTask(t) => t.write(writer),
         }
     }
 }
@@ -230,6 +235,7 @@ impl NonReadTask {
             NonReadTask::TimeSync(task) => task.start(association).map(|task| task.wrap()),
             NonReadTask::Restart(_) => Some(self),
             NonReadTask::DeadBands(_) => Some(self),
+            NonReadTask::EmptyResponseTask(_) => Some(self),
         }
     }
 
@@ -240,6 +246,7 @@ impl NonReadTask {
             NonReadTask::TimeSync(task) => task.function(),
             NonReadTask::Restart(task) => task.function(),
             NonReadTask::DeadBands(task) => task.function(),
+            NonReadTask::EmptyResponseTask(task) => task.function(),
         }
     }
 
@@ -250,6 +257,7 @@ impl NonReadTask {
             NonReadTask::Auto(task) => task.on_task_error(association, err),
             NonReadTask::Restart(task) => task.on_task_error(err),
             NonReadTask::DeadBands(task) => task.on_task_error(err),
+            NonReadTask::EmptyResponseTask(task) => task.on_task_error(err),
         }
     }
 
@@ -267,6 +275,7 @@ impl NonReadTask {
             NonReadTask::TimeSync(task) => task.handle(association, response),
             NonReadTask::Restart(task) => task.handle(response),
             NonReadTask::DeadBands(task) => task.handle(response),
+            NonReadTask::EmptyResponseTask(task) => task.handle(response),
         }
     }
 
@@ -281,6 +290,7 @@ impl NonReadTask {
             Self::TimeSync(_) => TaskType::TimeSync,
             Self::Restart(_) => TaskType::Restart,
             NonReadTask::DeadBands(_) => TaskType::WriteDeadBands,
+            NonReadTask::EmptyResponseTask(_) => TaskType::GenericEmptyResponse(self.function()),
         }
     }
 }

--- a/dnp3/src/master/tasks/read.rs
+++ b/dnp3/src/master/tasks/read.rs
@@ -5,8 +5,6 @@ use crate::master::request::ReadRequest;
 use crate::master::tasks::ReadTask;
 use crate::master::ReadHandler;
 
-use scursor::WriteError;
-
 pub(crate) struct SingleReadTask {
     request: ReadRequest,
     pub(crate) custom_handler: Option<Box<dyn ReadHandler>>,
@@ -38,7 +36,7 @@ impl SingleReadTask {
         ReadTask::SingleRead(self)
     }
 
-    pub(crate) fn format(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn format(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         self.request.format(writer)
     }
 

--- a/dnp3/src/master/tasks/time.rs
+++ b/dnp3/src/master/tasks/time.rs
@@ -12,8 +12,6 @@ use crate::master::handler::Promise;
 use crate::master::request::TimeSyncProcedure;
 use crate::master::tasks::NonReadTask;
 
-use scursor::WriteError;
-
 use tokio::time::Instant;
 
 enum State {
@@ -95,7 +93,7 @@ impl TimeSyncTask {
         }
     }
 
-    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), WriteError> {
+    pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {
         match self.state {
             State::MeasureDelay(_) => Ok(()),
             State::WriteAbsoluteTime(x) => writer.write_count_of_one(Group50Var1 { time: x }),

--- a/dnp3/src/outstation/database/read.rs
+++ b/dnp3/src/outstation/database/read.rs
@@ -862,6 +862,7 @@ impl ReadHeader {
                 .into(),
             ),
             CountVariation::Group50Var1(_) => None,
+            CountVariation::Group50Var2(_) => None,
             CountVariation::Group50Var3(_) => None,
             CountVariation::Group50Var4(_) => None,
             CountVariation::Group51Var1(_) => None,

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -1741,7 +1741,7 @@ impl OutstationSession {
             match header.details {
                 HeaderDetails::OneByteCount(_, CountVariation::Group50Var2(seq)) => {
                     match seq.single() {
-                        None => iin |= Iin2::PARAMETER_ERROR,
+                        None => iin.iin2.set(Iin2::PARAMETER_ERROR),
                         Some(x) => {
                             timing = Some(x.into());
                         }
@@ -1749,7 +1749,7 @@ impl OutstationSession {
                 }
                 HeaderDetails::TwoByteCount(_, CountVariation::Group50Var2(seq)) => {
                     match seq.single() {
-                        None => iin |= Iin2::PARAMETER_ERROR,
+                        None => iin.iin2.set(Iin2::PARAMETER_ERROR),
                         Some(x) => {
                             timing = Some(x.into());
                         }
@@ -1763,7 +1763,7 @@ impl OutstationSession {
                                 "freeze-at-time on {} w/o preceding g50v2",
                                 header.variation
                             );
-                            iin |= Iin2::PARAMETER_ERROR;
+                            iin.iin2.set(Iin2::PARAMETER_ERROR);
                         }
                         Some(x) => {
                             iin |= self.handle_freeze_header(

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -1157,34 +1157,20 @@ impl OutstationSession {
                 )
                 .await
             }
-            FunctionCode::ImmediateFreeze => self.handle_freeze(
-                database,
-                seq,
-                object_headers,
-                FreezeType::ImmediateFreeze,
-                true,
-            ),
-            FunctionCode::ImmediateFreezeNoResponse => self.handle_freeze(
-                database,
-                seq,
-                object_headers,
-                FreezeType::ImmediateFreeze,
-                false,
-            ),
-            FunctionCode::FreezeClear => self.handle_freeze(
-                database,
-                seq,
-                object_headers,
-                FreezeType::FreezeAndClear,
-                true,
-            ),
-            FunctionCode::FreezeClearNoResponse => self.handle_freeze(
-                database,
-                seq,
-                object_headers,
-                FreezeType::FreezeAndClear,
-                false,
-            ),
+            FunctionCode::ImmediateFreeze => {
+                self.handle_freeze(database, seq, object_headers, FreezeType::ImmediateFreeze)
+            }
+            FunctionCode::ImmediateFreezeNoResponse => {
+                self.handle_freeze(database, seq, object_headers, FreezeType::ImmediateFreeze);
+                None
+            }
+            FunctionCode::FreezeClear => {
+                self.handle_freeze(database, seq, object_headers, FreezeType::FreezeAndClear)
+            }
+            FunctionCode::FreezeClearNoResponse => {
+                self.handle_freeze(database, seq, object_headers, FreezeType::FreezeAndClear);
+                None
+            }
             FunctionCode::EnableUnsolicited => {
                 Some(self.handle_enable_or_disable_unsolicited(true, seq, object_headers))
             }
@@ -1724,7 +1710,6 @@ impl OutstationSession {
         seq: Sequence,
         object_headers: HeaderCollection,
         freeze_type: FreezeType,
-        respond: bool,
     ) -> Option<Response> {
         let mut iin = Iin::default();
 
@@ -1732,11 +1717,7 @@ impl OutstationSession {
             iin |= self.handle_freeze_header(database, freeze_type, header.details);
         }
 
-        if respond {
-            Some(Response::empty_solicited(seq, iin))
-        } else {
-            None
-        }
+        Some(Response::empty_solicited(seq, iin))
     }
 
     fn handle_freeze_header(
@@ -1865,11 +1846,11 @@ impl OutstationSession {
                 BroadcastAction::Processed
             }
             FunctionCode::ImmediateFreezeNoResponse => {
-                self.handle_freeze(database, seq, objects, FreezeType::ImmediateFreeze, false);
+                self.handle_freeze(database, seq, objects, FreezeType::ImmediateFreeze);
                 BroadcastAction::Processed
             }
             FunctionCode::FreezeClearNoResponse => {
-                self.handle_freeze(database, seq, objects, FreezeType::FreezeAndClear, false);
+                self.handle_freeze(database, seq, objects, FreezeType::FreezeAndClear);
                 BroadcastAction::Processed
             }
             FunctionCode::RecordCurrentTime => {

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -1735,7 +1735,7 @@ impl OutstationSession {
     ) -> Response {
         let mut iin = Iin::default();
 
-        let mut timing: Option<FreezeTiming> = None;
+        let mut timing: Option<FreezeInterval> = None;
 
         for header in object_headers.iter() {
             match header.details {

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -39,7 +39,6 @@ use crate::app::gen::prefixed::PrefixedVariation;
 use crate::app::parse::bit::BitSequence;
 use crate::app::parse::prefix::Prefix;
 use crate::app::parse::traits::{FixedSizeVariation, Index};
-use scursor::WriteError;
 
 #[derive(Copy, Clone)]
 enum TimeoutStatus {
@@ -1611,7 +1610,7 @@ impl OutstationSession {
             let _ = cursor.skip(ResponseHeader::LENGTH);
 
             let max_controls_per_request = self.config.max_controls_per_request;
-            let result: Result<CommandStatus, WriteError> = ControlTransaction::execute(
+            let result: Result<CommandStatus, scursor::WriteError> = ControlTransaction::execute(
                 self.control_handler.borrow_mut(),
                 database,
                 |tx, db| {

--- a/dnp3/src/outstation/tests/freeze.rs
+++ b/dnp3/src/outstation/tests/freeze.rs
@@ -1,5 +1,6 @@
+use crate::app::Timestamp;
 use crate::outstation::tests::harness::*;
-use crate::outstation::{FreezeIndices, FreezeType};
+use crate::outstation::{FreezeIndices, FreezeTiming, FreezeType};
 
 const EMPTY_RESPONSE: &[u8] = &[0xC0, 0x81, 0x80, 0x00];
 const EMPTY_RESPONSE_PARAM_ERROR: &[u8] = &[0xC0, 0x81, 0x80, 0x04];
@@ -128,4 +129,60 @@ async fn freeze_invalid_object() {
         FreezeIndices::All,
         FreezeType::ImmediateFreeze,
     )]);
+}
+
+#[tokio::test]
+async fn freeze_at_time_without_g50v1() {
+    let mut harness = new_harness(get_default_config());
+
+    harness
+        .test_request_response(&[0xC0, 0x0B, 20, 0, 0x06], EMPTY_RESPONSE_PARAM_ERROR)
+        .await;
+
+    harness.check_no_events();
+}
+
+#[tokio::test]
+async fn freeze_at_time() {
+    let mut harness = new_harness(get_default_config());
+
+    harness
+        .test_request_response(
+            &[
+                0xC0, 0x0B, 0x32, 0x02, 0x07, 0x01, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA, 0xBB,
+                0xCC, 0xDD, 20, 0, 0x06,
+            ],
+            EMPTY_RESPONSE,
+        )
+        .await;
+
+    harness.check_events(&[Event::Freeze(
+        FreezeIndices::All,
+        FreezeType::FreezeAtTime(FreezeTiming::PeriodicallyFreeze(
+            Timestamp::new(0xFF),
+            0xDDCCBBAA,
+        )),
+    )]);
+}
+
+#[tokio::test]
+async fn freeze_at_time_no_ack() {
+    let mut harness = new_harness(get_default_config());
+
+    harness
+        .send_and_process(&[
+            0xC0, 0x0C, 0x32, 0x02, 0x07, 0x01, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA, 0xBB,
+            0xCC, 0xDD, 20, 0, 0x06,
+        ])
+        .await;
+
+    harness.check_events(&[Event::Freeze(
+        FreezeIndices::All,
+        FreezeType::FreezeAtTime(FreezeTiming::PeriodicallyFreeze(
+            Timestamp::new(0xFF),
+            0xDDCCBBAA,
+        )),
+    )]);
+
+    assert_eq!(harness.io.pop_event(), None);
 }

--- a/dnp3/src/outstation/tests/freeze.rs
+++ b/dnp3/src/outstation/tests/freeze.rs
@@ -1,6 +1,6 @@
 use crate::app::Timestamp;
 use crate::outstation::tests::harness::*;
-use crate::outstation::{FreezeIndices, FreezeTiming, FreezeType};
+use crate::outstation::{FreezeIndices, FreezeInterval, FreezeType};
 
 const EMPTY_RESPONSE: &[u8] = &[0xC0, 0x81, 0x80, 0x00];
 const EMPTY_RESPONSE_PARAM_ERROR: &[u8] = &[0xC0, 0x81, 0x80, 0x04];
@@ -158,7 +158,7 @@ async fn freeze_at_time() {
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::All,
-        FreezeType::FreezeAtTime(FreezeTiming::PeriodicallyFreeze(
+        FreezeType::FreezeAtTime(FreezeInterval::PeriodicallyFreeze(
             Timestamp::new(0xFF),
             0xDDCCBBAA,
         )),
@@ -178,7 +178,7 @@ async fn freeze_at_time_no_ack() {
 
     harness.check_events(&[Event::Freeze(
         FreezeIndices::All,
-        FreezeType::FreezeAtTime(FreezeTiming::PeriodicallyFreeze(
+        FreezeType::FreezeAtTime(FreezeInterval::PeriodicallyFreeze(
             Timestamp::new(0xFF),
             0xDDCCBBAA,
         )),

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -258,7 +258,7 @@ pub enum FreezeIndices {
 ///
 /// There is a table on page 57 of 1815-2012 that describes these 4 permutations
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum FreezeTiming {
+pub enum FreezeInterval {
     /// Freeze once immediately
     FreezeOnceImmediately,
     /// Freeze once at the specified time
@@ -269,7 +269,7 @@ pub enum FreezeTiming {
     PeriodicallyFreezeRelative(u32),
 }
 
-impl FreezeTiming {
+impl FreezeInterval {
     /// construct a new FreezeTiming instance from the raw timestamp and interval fields
     pub fn new(timestamp: Timestamp, interval: u32) -> Self {
         match (timestamp.raw_value(), interval) {
@@ -283,22 +283,22 @@ impl FreezeTiming {
     /// decompose a FreezeTiming instance into the raw timestamp and interval fields
     pub fn get_time_and_interval(&self) -> (Timestamp, u32) {
         match self {
-            FreezeTiming::FreezeOnceImmediately => (Timestamp::zero(), 0),
-            FreezeTiming::FreezeOnceAtTime(t) => (*t, 0),
-            FreezeTiming::PeriodicallyFreeze(t, i) => (*t, *i),
-            FreezeTiming::PeriodicallyFreezeRelative(i) => (Timestamp::zero(), *i),
+            FreezeInterval::FreezeOnceImmediately => (Timestamp::zero(), 0),
+            FreezeInterval::FreezeOnceAtTime(t) => (*t, 0),
+            FreezeInterval::PeriodicallyFreeze(t, i) => (*t, *i),
+            FreezeInterval::PeriodicallyFreezeRelative(i) => (Timestamp::zero(), *i),
         }
     }
 }
 
-impl From<Group50Var2> for FreezeTiming {
+impl From<Group50Var2> for FreezeInterval {
     fn from(value: Group50Var2) -> Self {
         Self::new(value.time, value.interval)
     }
 }
 
-impl From<FreezeTiming> for Group50Var2 {
-    fn from(value: FreezeTiming) -> Self {
+impl From<FreezeInterval> for Group50Var2 {
+    fn from(value: FreezeInterval) -> Self {
         let (time, interval) = value.get_time_and_interval();
         Self { time, interval }
     }
@@ -314,7 +314,7 @@ pub enum FreezeType {
     /// clear the current value to 0
     FreezeAndClear,
     /// Freeze at a particular time
-    FreezeAtTime(FreezeTiming),
+    FreezeAtTime(FreezeInterval),
 }
 
 /// callbacks for handling controls

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -1,6 +1,7 @@
 use crate::app::parse::count::CountSequence;
 use crate::app::parse::prefix::Prefix;
 use crate::app::parse::traits::{FixedSizeVariation, Index};
+use crate::app::variations::Group50Var2;
 use crate::app::RequestHeader;
 use crate::app::Sequence;
 use crate::app::{control::*, Timestamp};
@@ -253,7 +254,47 @@ pub enum FreezeIndices {
     Range(u16, u16),
 }
 
+/// This object maps to the fields of g50v2
+///
+/// There is a table on page 57 of 1815-2012 that describes these 4 permutations
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FreezeTiming {
+    /// Freeze once immediately
+    FreezeOnceImmediately,
+    /// Freeze once at the specified time
+    FreezeOnceAtTime(Timestamp),
+    /// Periodically freeze at intervals relative to the timestamp
+    PeriodicallyFreeze(Timestamp, u32),
+    /// Periodically freeze at intervals relative to the beginning of the current hour
+    PeriodicallyFreezeRelative(u32),
+}
+
+impl From<Group50Var2> for FreezeTiming {
+    fn from(value: Group50Var2) -> Self {
+        match (value.time.raw_value(), value.interval) {
+            (0, 0) => Self::FreezeOnceImmediately,
+            (_, 0) => Self::FreezeOnceAtTime(value.time),
+            (0, _) => Self::PeriodicallyFreezeRelative(value.interval),
+            (_, _) => Self::PeriodicallyFreeze(value.time, value.interval),
+        }
+    }
+}
+
+impl From<FreezeTiming> for Group50Var2 {
+    fn from(value: FreezeTiming) -> Self {
+        let (time, interval) = match value {
+            FreezeTiming::FreezeOnceImmediately => (Timestamp::zero(), 0),
+            FreezeTiming::FreezeOnceAtTime(t) => (t, 0),
+            FreezeTiming::PeriodicallyFreeze(t, i) => (t, i),
+            FreezeTiming::PeriodicallyFreezeRelative(i) => (Timestamp::zero(), i),
+        };
+
+        Self { time, interval }
+    }
+}
+
 /// Freeze operation type
+#[cfg_attr(not(feature = "ffi"), non_exhaustive)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FreezeType {
     /// Copy the current value of a counter to the associated point
@@ -261,6 +302,8 @@ pub enum FreezeType {
     /// Copy the current value of a counter to the associated point and
     /// clear the current value to 0
     FreezeAndClear,
+    /// Freeze at a particular time
+    FreezeAtTime(FreezeTiming),
 }
 
 /// callbacks for handling controls

--- a/dnp3/src/util/mod.rs
+++ b/dnp3/src/util/mod.rs
@@ -1,5 +1,3 @@
-use scursor::WriteError;
-
 pub(crate) mod bit;
 pub(crate) mod buffer;
 pub(crate) mod channel;
@@ -45,8 +43,8 @@ where
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct BadWrite;
 
-impl From<WriteError> for BadWrite {
-    fn from(_: WriteError) -> Self {
+impl From<scursor::WriteError> for BadWrite {
+    fn from(_: scursor::WriteError) -> Self {
         Self
     }
 }

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -202,13 +202,16 @@ void on_time_sync_error(dnp3_time_sync_error_t error, void *arg) { printf("Time 
 void on_restart_success(uint64_t delay, void *arg) { printf("restart success: %" PRIu64 "\n", delay); }
 void on_restart_failure(dnp3_restart_error_t error, void* arg) { printf("Restart failure: %s\n", dnp3_restart_error_to_string(error)); }
 
-// write dead-band callbacks
-void on_write_dead_band_success(dnp3_nothing_t delay, void *arg) { printf("Write dead-bands success! \n"); }
-void on_write_dead_band_failure(dnp3_empty_response_error_t error, void *arg) { printf("Write dead-bands failure: %s\n", dnp3_empty_response_error_to_string(error)); }
-
 // link status callbacks
 void on_link_status_success(dnp3_nothing_t nothing, void *arg) { printf("link status success!\n"); }
 void on_link_status_failure(dnp3_link_status_error_t error, void* arg) { printf("link status error: %s\n", dnp3_link_status_error_to_string(error)); }
+
+// generic callbacks
+void on_generic_success(dnp3_nothing_t delay, void *arg) { printf("%s success! \n", (const char*) arg); }
+void on_generic_failure(dnp3_empty_response_error_t error, void *arg)
+{
+    printf("%s failure: %s\n", (const char *)arg, dnp3_empty_response_error_to_string(error));
+}
 
 // ANCHOR: master_channel_config
 dnp3_master_channel_config_t get_master_channel_config()
@@ -424,10 +427,10 @@ int run_channel(dnp3_master_channel_t *channel)
         else if (strcmp(cbuf, "wad\n") == 0) {
             // ANCHOR: write_dead_bands
             dnp3_empty_response_callback_t cb = {
-                .on_complete = &on_write_dead_band_success,
-                .on_failure = &on_write_dead_band_failure,
+                .on_complete = &on_generic_success,
+                .on_failure = &on_generic_failure,
                 .on_destroy = NULL,
-                .ctx = NULL,
+                .ctx = "write dead-bands",
             };
 
             dnp3_write_dead_band_request_t *request = dnp3_write_dead_band_request_create();
@@ -437,6 +440,22 @@ int run_channel(dnp3_master_channel_t *channel)
             dnp3_master_channel_write_dead_bands(channel, association_id, request, cb);
             dnp3_write_dead_band_request_destroy(request);
             // ANCHOR_END: write_dead_bands
+        }
+        else if (strcmp(cbuf, "fat\n") == 0) {            
+            dnp3_empty_response_callback_t cb = {
+                .on_complete = &on_generic_success,
+                .on_failure = &on_generic_failure,
+                .on_destroy = NULL,
+                .ctx = "freeze-at-time",
+            };
+
+            dnp3_request_t *request = dnp3_request_create();
+            dnp3_request_add_time_and_interval(request, 0xFF0000000000, 865000000);
+            dnp3_request_add_all_objects_header(request, DNP3_VARIATION_GROUP20_VAR0);
+                     
+            
+            dnp3_master_channel_request_expect_empty_response(channel, association_id, DNP3_FUNCTION_CODE_FREEZE_AT_TIME, request, cb);
+            dnp3_request_destroy(request);            
         }
         else if (strcmp(cbuf, "crt\n") == 0) {
             dnp3_restart_task_callback_t cb = {

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -204,7 +204,7 @@ void on_restart_failure(dnp3_restart_error_t error, void* arg) { printf("Restart
 
 // write dead-band callbacks
 void on_write_dead_band_success(dnp3_nothing_t delay, void *arg) { printf("Write dead-bands success! \n"); }
-void on_write_dead_band_failure(dnp3_write_dead_bands_error_t error, void *arg) { printf("Write dead-bands failure: %s\n", dnp3_write_dead_bands_error_to_string(error)); }
+void on_write_dead_band_failure(dnp3_write_error_t error, void *arg) { printf("Write dead-bands failure: %s\n", dnp3_write_error_to_string(error)); }
 
 // link status callbacks
 void on_link_status_success(dnp3_nothing_t nothing, void *arg) { printf("link status success!\n"); }

--- a/ffi/bindings/c/master_example.c
+++ b/ffi/bindings/c/master_example.c
@@ -204,7 +204,7 @@ void on_restart_failure(dnp3_restart_error_t error, void* arg) { printf("Restart
 
 // write dead-band callbacks
 void on_write_dead_band_success(dnp3_nothing_t delay, void *arg) { printf("Write dead-bands success! \n"); }
-void on_write_dead_band_failure(dnp3_write_error_t error, void *arg) { printf("Write dead-bands failure: %s\n", dnp3_write_error_to_string(error)); }
+void on_write_dead_band_failure(dnp3_empty_response_error_t error, void *arg) { printf("Write dead-bands failure: %s\n", dnp3_empty_response_error_to_string(error)); }
 
 // link status callbacks
 void on_link_status_success(dnp3_nothing_t nothing, void *arg) { printf("link status success!\n"); }
@@ -423,7 +423,7 @@ int run_channel(dnp3_master_channel_t *channel)
         }
         else if (strcmp(cbuf, "wad\n") == 0) {
             // ANCHOR: write_dead_bands
-            dnp3_write_analog_dead_bands_callback_t cb = {
+            dnp3_empty_response_callback_t cb = {
                 .on_complete = &on_write_dead_band_success,
                 .on_failure = &on_write_dead_band_failure,
                 .on_destroy = NULL,

--- a/ffi/bindings/c/master_example.cpp
+++ b/ffi/bindings/c/master_example.cpp
@@ -201,7 +201,7 @@ class WriteDeadBandsCallback : public dnp3::WriteAnalogDeadBandsCallback {
         std::cout << "write dead-bands succeeded" << std::endl;
     }
 
-    void on_failure(dnp3::WriteDeadBandsError error) override { std::cout << "write dead-bands failed: " << dnp3::to_string(error) << std::endl; }
+    void on_failure(dnp3::WriteError error) override { std::cout << "write dead-bands failed: " << dnp3::to_string(error) << std::endl; }
 };
 
 class LinkStatusCallback : public dnp3::LinkStatusCallback {

--- a/ffi/bindings/c/master_example.cpp
+++ b/ffi/bindings/c/master_example.cpp
@@ -194,14 +194,14 @@ class RestartTaskCallback : public dnp3::RestartTaskCallback {
     }
 };
 
-class WriteDeadBandsCallback : public dnp3::WriteAnalogDeadBandsCallback { 
+class WriteDeadBandsCallback : public dnp3::EmptyResponseCallback { 
 
     void on_complete(dnp3::Nothing) override
     {
         std::cout << "write dead-bands succeeded" << std::endl;
     }
 
-    void on_failure(dnp3::WriteError error) override { std::cout << "write dead-bands failed: " << dnp3::to_string(error) << std::endl; }
+    void on_failure(dnp3::EmptyResponseError error) override { std::cout << "write dead-bands failed: " << dnp3::to_string(error) << std::endl; }
 };
 
 class LinkStatusCallback : public dnp3::LinkStatusCallback {

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -470,7 +470,16 @@ class MainClass
                     request.AddG34v1U8(3, 5);
                     request.AddG34v3U16(4, 2.5f);
                     await channel.WriteDeadBands(association, request);
-                    Console.WriteLine($"Write dead-bands sucess");
+                    Console.WriteLine($"Write dead-bands success");
+                    return true;
+                }
+            case "fat":
+                {
+                    var request = new Request();                    
+                    request.AddTimeAndInterval(0, 86400000);
+                    request.AddAllObjectsHeader(Variation.Group20Var0);
+                    await channel.RequestExpectEmptyResponse(association, FunctionCode.FreezeAtTime, request);
+                    Console.WriteLine($"Freeze-at-time success");
                     return true;
                 }
             case "crt":

--- a/ffi/bindings/dotnet/examples/outstation/Program.cs
+++ b/ffi/bindings/dotnet/examples/outstation/Program.cs
@@ -40,9 +40,19 @@ class ExampleOutstation
             return RestartDelay.NotSupported();
         }
 
-        public FreezeResult FreezeCountersAll(FreezeType freezeType, DatabaseHandle database) { return FreezeResult.NotSupported; }
+        FreezeResult IOutstationApplication.FreezeCountersAll(FreezeType freezeType, DatabaseHandle database) { return FreezeResult.NotSupported; }
 
-        public FreezeResult FreezeCountersRange(ushort start, ushort stop, FreezeType freezeType, DatabaseHandle database) { return FreezeResult.NotSupported; }
+        FreezeResult IOutstationApplication.FreezeCountersRange(ushort start, ushort stop, FreezeType freezeType, DatabaseHandle database) { return FreezeResult.NotSupported; }
+
+        FreezeResult IOutstationApplication.FreezeCountersAllAtTime(DatabaseHandle databaseHandle, ulong time, uint interval)
+        {
+            return FreezeResult.NotSupported;
+        }
+
+        FreezeResult IOutstationApplication.FreezeCountersRangeAtTime(ushort start, ushort stop, DatabaseHandle databaseHandle, ulong time, uint interval)
+        {
+            return FreezeResult.NotSupported;
+        }
 
         bool IOutstationApplication.SupportWriteAnalogDeadBands()
         {
@@ -54,6 +64,8 @@ class ExampleOutstation
         void IOutstationApplication.WriteAnalogDeadBand(ushort index, double deadBand) {}
 
         void IOutstationApplication.EndWriteAnalogDeadBands() {}
+
+        
     }
 
     class TestOutstationInformation : IOutstationInformation

--- a/ffi/dnp3-ffi/src/handler.rs
+++ b/ffi/dnp3-ffi/src/handler.rs
@@ -233,6 +233,7 @@ impl From<TaskType> for ffi::TaskType {
             TaskType::TimeSync => ffi::TaskType::TimeSync,
             TaskType::Restart => ffi::TaskType::Restart,
             TaskType::WriteDeadBands => ffi::TaskType::WriteDeadBands,
+            TaskType::GenericEmptyResponse(_) => ffi::TaskType::GenericEmptyResponse,
         }
     }
 }

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -805,11 +805,11 @@ impl From<PollError> for ffi::ParamError {
     }
 }
 
-impl From<IinTaskError> for ffi::WriteDeadBandsError {
-    fn from(value: IinTaskError) -> Self {
+impl From<WriteTaskError> for ffi::WriteError {
+    fn from(value: WriteTaskError) -> Self {
         match value {
-            IinTaskError::Task(x) => x.into(),
-            IinTaskError::IinError(_) => ffi::WriteDeadBandsError::RejectedByIin2,
+            WriteTaskError::Task(x) => x.into(),
+            WriteTaskError::IinError(_) => ffi::WriteError::RejectedByIin2,
         }
     }
 }
@@ -879,4 +879,4 @@ define_task_from_impl!(RestartError);
 define_task_from_impl!(ReadError);
 define_task_from_impl!(LinkStatusError);
 define_task_from_impl!(TaskError);
-define_task_from_impl!(WriteDeadBandsError);
+define_task_from_impl!(WriteError);

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -805,11 +805,11 @@ impl From<PollError> for ffi::ParamError {
     }
 }
 
-impl From<WriteTaskError> for ffi::WriteError {
-    fn from(value: WriteTaskError) -> Self {
+impl From<WriteError> for ffi::WriteError {
+    fn from(value: WriteError) -> Self {
         match value {
-            WriteTaskError::Task(x) => x.into(),
-            WriteTaskError::IinError(_) => ffi::WriteError::RejectedByIin2,
+            WriteError::Task(x) => x.into(),
+            WriteError::IinError(_) => ffi::WriteError::RejectedByIin2,
         }
     }
 }

--- a/ffi/dnp3-ffi/src/master.rs
+++ b/ffi/dnp3-ffi/src/master.rs
@@ -332,7 +332,7 @@ pub(crate) unsafe fn master_channel_add_poll(
     let mut association = AssociationHandle::create(address, channel.handle.clone());
     let handle = channel
         .runtime
-        .block_on(association.add_poll(request.build(), period))??;
+        .block_on(association.add_poll(request.build_read_request(), period))??;
 
     Ok(ffi::PollId {
         association_id: id.address,
@@ -385,7 +385,7 @@ pub(crate) unsafe fn master_channel_read(
     let request = request
         .as_ref()
         .ok_or(ffi::ParamError::NullParameter)?
-        .build();
+        .build_read_request();
 
     let mut handle = AssociationHandle::create(address, channel.handle.clone());
 
@@ -404,7 +404,7 @@ pub(crate) unsafe fn master_channel_write_dead_bands(
     channel: *mut crate::MasterChannel,
     association: ffi::AssociationId,
     request: *mut crate::WriteDeadBandRequest,
-    callback: ffi::WriteAnalogDeadBandsCallback,
+    callback: ffi::EmptyResponseCallback,
 ) -> Result<(), ffi::ParamError> {
     let channel = channel.as_mut().ok_or(ffi::ParamError::NullParameter)?;
     let address = EndpointAddress::try_new(association.address)?;
@@ -415,6 +415,35 @@ pub(crate) unsafe fn master_channel_write_dead_bands(
 
     let task = async move {
         match handle.write_dead_bands(headers).await {
+            Ok(()) => callback.on_complete(ffi::Nothing::Nothing),
+            Err(err) => callback.on_failure(err.into()),
+        }
+    };
+
+    channel.runtime.spawn(task)?;
+    Ok(())
+}
+
+pub(crate) unsafe fn master_channel_request_expect_empty_response(
+    channel: *mut crate::MasterChannel,
+    association: ffi::AssociationId,
+    function: ffi::FunctionCode,
+    headers: *mut crate::Request,
+    callback: ffi::EmptyResponseCallback,
+) -> Result<(), ffi::ParamError> {
+    let channel = channel.as_mut().ok_or(ffi::ParamError::NullParameter)?;
+    let address = EndpointAddress::try_new(association.address)?;
+    let function: dnp3::app::FunctionCode = function.into();
+    let headers = headers.as_mut().ok_or(ffi::ParamError::NullParameter)?;
+    let headers = headers.build_headers();
+
+    let mut handle = AssociationHandle::create(address, channel.handle.clone());
+
+    let task = async move {
+        match handle
+            .request_expecting_empty_response(function, headers)
+            .await
+        {
             Ok(()) => callback.on_complete(ffi::Nothing::Nothing),
             Err(err) => callback.on_failure(err.into()),
         }
@@ -436,7 +465,7 @@ pub(crate) unsafe fn master_channel_read_with_handler(
     let request = request
         .as_ref()
         .ok_or(ffi::ParamError::NullParameter)?
-        .build();
+        .build_read_request();
 
     let mut handle = AssociationHandle::create(address, channel.handle.clone());
 
@@ -805,11 +834,11 @@ impl From<PollError> for ffi::ParamError {
     }
 }
 
-impl From<WriteError> for ffi::WriteError {
+impl From<WriteError> for ffi::EmptyResponseError {
     fn from(value: WriteError) -> Self {
         match value {
             WriteError::Task(x) => x.into(),
-            WriteError::IinError(_) => ffi::WriteError::RejectedByIin2,
+            WriteError::IinError(_) => ffi::EmptyResponseError::RejectedByIin2,
         }
     }
 }
@@ -879,4 +908,54 @@ define_task_from_impl!(RestartError);
 define_task_from_impl!(ReadError);
 define_task_from_impl!(LinkStatusError);
 define_task_from_impl!(TaskError);
-define_task_from_impl!(WriteError);
+define_task_from_impl!(EmptyResponseError);
+
+impl From<ffi::FunctionCode> for dnp3::app::FunctionCode {
+    fn from(value: ffi::FunctionCode) -> Self {
+        match value {
+            ffi::FunctionCode::Confirm => dnp3::app::FunctionCode::Confirm,
+            ffi::FunctionCode::Read => dnp3::app::FunctionCode::Read,
+            ffi::FunctionCode::Write => dnp3::app::FunctionCode::Write,
+            ffi::FunctionCode::Select => dnp3::app::FunctionCode::Select,
+            ffi::FunctionCode::Operate => dnp3::app::FunctionCode::Operate,
+            ffi::FunctionCode::DirectOperate => dnp3::app::FunctionCode::DirectOperate,
+            ffi::FunctionCode::DirectOperateNoResponse => {
+                dnp3::app::FunctionCode::DirectOperateNoResponse
+            }
+            ffi::FunctionCode::ImmediateFreeze => dnp3::app::FunctionCode::ImmediateFreeze,
+            ffi::FunctionCode::ImmediateFreezeNoResponse => {
+                dnp3::app::FunctionCode::ImmediateFreezeNoResponse
+            }
+            ffi::FunctionCode::FreezeClear => dnp3::app::FunctionCode::FreezeClear,
+            ffi::FunctionCode::FreezeClearNoResponse => {
+                dnp3::app::FunctionCode::FreezeClearNoResponse
+            }
+            ffi::FunctionCode::FreezeAtTime => dnp3::app::FunctionCode::FreezeAtTime,
+            ffi::FunctionCode::FreezeAtTimeNoResponse => {
+                dnp3::app::FunctionCode::FreezeAtTimeNoResponse
+            }
+            ffi::FunctionCode::ColdRestart => dnp3::app::FunctionCode::ColdRestart,
+            ffi::FunctionCode::WarmRestart => dnp3::app::FunctionCode::WarmRestart,
+            ffi::FunctionCode::InitializeData => dnp3::app::FunctionCode::InitializeData,
+            ffi::FunctionCode::InitializeApplication => {
+                dnp3::app::FunctionCode::InitializeApplication
+            }
+            ffi::FunctionCode::StartApplication => dnp3::app::FunctionCode::StartApplication,
+            ffi::FunctionCode::StopApplication => dnp3::app::FunctionCode::StopApplication,
+            ffi::FunctionCode::SaveConfiguration => dnp3::app::FunctionCode::SaveConfiguration,
+            ffi::FunctionCode::EnableUnsolicited => dnp3::app::FunctionCode::EnableUnsolicited,
+            ffi::FunctionCode::DisableUnsolicited => dnp3::app::FunctionCode::DisableUnsolicited,
+            ffi::FunctionCode::AssignClass => dnp3::app::FunctionCode::AssignClass,
+            ffi::FunctionCode::DelayMeasure => dnp3::app::FunctionCode::DelayMeasure,
+            ffi::FunctionCode::RecordCurrentTime => dnp3::app::FunctionCode::RecordCurrentTime,
+            ffi::FunctionCode::OpenFile => dnp3::app::FunctionCode::OpenFile,
+            ffi::FunctionCode::CloseFile => dnp3::app::FunctionCode::CloseFile,
+            ffi::FunctionCode::DeleteFile => dnp3::app::FunctionCode::DeleteFile,
+            ffi::FunctionCode::GetFileInfo => dnp3::app::FunctionCode::GetFileInfo,
+            ffi::FunctionCode::AuthenticateFile => dnp3::app::FunctionCode::AuthenticateFile,
+            ffi::FunctionCode::AbortFile => dnp3::app::FunctionCode::AbortFile,
+            ffi::FunctionCode::Response => dnp3::app::FunctionCode::Response,
+            ffi::FunctionCode::UnsolicitedResponse => dnp3::app::FunctionCode::UnsolicitedResponse,
+        }
+    }
+}

--- a/ffi/dnp3-ffi/src/outstation/adapters.rs
+++ b/ffi/dnp3-ffi/src/outstation/adapters.rs
@@ -36,6 +36,13 @@ impl OutstationApplication for ffi::OutstationApplication {
         freeze_type: FreezeType,
         database: &mut DatabaseHandle,
     ) -> Result<(), RequestError> {
+        let freeze_type = match freeze_type {
+            FreezeType::ImmediateFreeze => ffi::FreezeType::ImmediateFreeze,
+            FreezeType::FreezeAndClear => ffi::FreezeType::FreezeAndClear,
+            // TODO
+            FreezeType::FreezeAtTime(_) => return Err(RequestError::NotSupported),
+        };
+
         match indices {
             FreezeIndices::All => ffi::OutstationApplication::freeze_counters_all(
                 self,
@@ -173,15 +180,6 @@ impl ControlHandler for ffi::ControlHandler {
     fn end_fragment(&mut self, database: &mut DatabaseHandle) -> MaybeAsync<()> {
         ffi::ControlHandler::end_fragment(self, database as *mut _);
         MaybeAsync::ready(())
-    }
-}
-
-impl From<FreezeType> for ffi::FreezeType {
-    fn from(from: FreezeType) -> Self {
-        match from {
-            FreezeType::ImmediateFreeze => ffi::FreezeType::ImmediateFreeze,
-            FreezeType::FreezeAndClear => ffi::FreezeType::FreezeAndClear,
-        }
     }
 }
 

--- a/ffi/dnp3-ffi/src/outstation/adapters.rs
+++ b/ffi/dnp3-ffi/src/outstation/adapters.rs
@@ -5,15 +5,6 @@ use dnp3::outstation::*;
 
 use crate::ffi;
 
-fn get_values(timing: FreezeTiming) -> (u64, u32) {
-    match timing {
-        FreezeTiming::FreezeOnceImmediately => (0, 0),
-        FreezeTiming::FreezeOnceAtTime(x) => (x.raw_value(), 0),
-        FreezeTiming::PeriodicallyFreeze(x, i) => (x.raw_value(), i),
-        FreezeTiming::PeriodicallyFreezeRelative(i) => (0, i),
-    }
-}
-
 impl OutstationApplication for ffi::OutstationApplication {
     fn get_processing_delay_ms(&self) -> u16 {
         ffi::OutstationApplication::get_processing_delay_ms(self).unwrap_or(0)
@@ -79,22 +70,22 @@ impl OutstationApplication for ffi::OutstationApplication {
                 )
             }
             (FreezeIndices::All, FreezeType::FreezeAtTime(timing)) => {
-                let (time, interval) = get_values(timing);
+                let (time, interval) = timing.get_time_and_interval();
                 ffi::OutstationApplication::freeze_counters_all_at_time(
                     self,
                     database as *mut _,
-                    time,
+                    time.raw_value(),
                     interval,
                 )
             }
             (FreezeIndices::Range(start, stop), FreezeType::FreezeAtTime(timing)) => {
-                let (time, interval) = get_values(timing);
+                let (time, interval) = timing.get_time_and_interval();
                 ffi::OutstationApplication::freeze_counters_range_at_time(
                     self,
                     start,
                     stop,
                     database as *mut _,
-                    time,
+                    time.raw_value(),
                     interval,
                 )
             }

--- a/ffi/dnp3-ffi/src/request.rs
+++ b/ffi/dnp3-ffi/src/request.rs
@@ -280,6 +280,7 @@ impl From<ffi::Variation> for Variation {
             ffi::Variation::Group43Var8 => Variation::Group43Var8,
              */
             ffi::Variation::Group50Var1 => Variation::Group50Var1,
+            ffi::Variation::Group50Var2 => Variation::Group50Var2,
             ffi::Variation::Group50Var3 => Variation::Group50Var3,
             ffi::Variation::Group50Var4 => Variation::Group50Var4,
             ffi::Variation::Group51Var1 => Variation::Group51Var1,
@@ -425,6 +426,7 @@ impl From<Variation> for ffi::Variation {
             Variation::Group43Var8 => ffi::Variation::Group43Var8,
              */
             Variation::Group50Var1 => ffi::Variation::Group50Var1,
+            Variation::Group50Var2 => ffi::Variation::Group50Var2,
             Variation::Group50Var3 => ffi::Variation::Group50Var3,
             Variation::Group50Var4 => ffi::Variation::Group50Var4,
             Variation::Group51Var1 => ffi::Variation::Group51Var1,

--- a/ffi/dnp3-ffi/src/request.rs
+++ b/ffi/dnp3-ffi/src/request.rs
@@ -1,25 +1,29 @@
 use dnp3::app::Variation;
-use dnp3::master::{ReadHeader, ReadRequest};
+use dnp3::master::{Headers, ReadHeader, ReadRequest};
 
 use crate::ffi;
 
 pub struct Request {
-    headers: Vec<ReadHeader>,
+    headers: Headers,
 }
 
 impl Request {
     fn new() -> Self {
         Self {
-            headers: Vec::new(),
+            headers: Default::default(),
         }
     }
 
     fn add(&mut self, header: ReadHeader) {
-        self.headers.push(header);
+        self.headers.add_read_header(header);
     }
 
-    pub(crate) fn build(&self) -> ReadRequest {
-        ReadRequest::MultipleHeader(self.headers.clone())
+    pub(crate) fn build_read_request(&self) -> ReadRequest {
+        self.headers.to_read_request()
+    }
+
+    pub(crate) fn build_headers(&self) -> Headers {
+        self.headers.clone()
     }
 }
 

--- a/ffi/dnp3-schema/src/master.rs
+++ b/ffi/dnp3-schema/src/master.rs
@@ -923,6 +923,10 @@ fn define_association_information(
         .push("time_sync", "Time synchronisation task")?
         .push("restart", "Cold or warm restart task")?
         .push("write_dead_bands", "Write analog input dead-bands")?
+        .push(
+            "generic_empty_response",
+            "Generic request that expects an empty response",
+        )?
         .doc("Task type used in {interface:association_information}")?
         .build()?;
 

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -675,6 +675,8 @@ fn define_outstation_application(
 
     let application_iin = define_application_iin(lib)?;
 
+    let freeze_not_supported = freeze_result.value("not_supported")?;
+
     let application = lib.define_interface("outstation_application", "Dynamic information required by the outstation from the user application")?
         .begin_callback("get_processing_delay_ms", doc("Returns the DELAY_MEASUREMENT delay")
             .details("The value returned by this method is used in conjunction with the DELAY_MEASUREMENT function code and returned in a g52v2 time delay object as part of a non-LAN time synchronization procedure.")
@@ -700,15 +702,35 @@ fn define_outstation_application(
         .begin_callback("freeze_counters_all", "Freeze all the counters")?
             .param("freeze_type", freeze_type.clone(), "Type of freeze operation")?
             .param("database_handle",database_handle.declaration(), "Database handle")?
-            .returns(freeze_result.clone(), "Result of the freeze operation")?
+            .returns_with_default(freeze_not_supported.clone(), "Result of the freeze operation")?
+            .end_callback()?
+        .begin_callback("freeze_counters_all_at_time",
+                        doc("Freeze all the counters at a requested time and interval")
+                            .details("Refer to the table on page 57 of IEEE 1815-2012 to interpret the time and interval parameters correctly")
+             )?
+            .param("database_handle",database_handle.declaration(), "Database handle")?
+            .param("time", Primitive::U64, "48-bit DNP3 timestamp in milliseconds since epoch UTC")?
+            .param("interval", Primitive::U32, "Count of milliseconds representing the interval between freezes relative to the timestamp")?
+            .returns_with_default(freeze_not_supported.clone(), "Result of the freeze operation")?
             .end_callback()?
         .begin_callback("freeze_counters_range", "Freeze a range of counters")?
             .param("start", Primitive::U16, "Start index to freeze (inclusive)")?
             .param("stop", Primitive::U16, "Stop index to freeze (inclusive)")?
             .param("freeze_type", freeze_type, "Type of freeze operation")?
             .param("database_handle",database_handle.declaration(), "Database handle")?
-            .returns(freeze_result, "Result of the freeze operation")?
+            .returns_with_default(freeze_not_supported.clone(), "Result of the freeze operation")?
             .end_callback()?
+        .begin_callback("freeze_counters_range_at_time",
+                        doc("Freeze a range of counters at a requested time and interval")
+                            .details("Refer to the table on page 57 of IEEE 1815-2012 to interpret the time and interval parameters correctly")
+             )?
+            .param("start", Primitive::U16, "Start index to freeze (inclusive)")?
+            .param("stop", Primitive::U16, "Stop index to freeze (inclusive)")?
+            .param("database_handle",database_handle.declaration(), "Database handle")?
+           .param("time", Primitive::U64, "48-bit DNP3 timestamp in milliseconds since epoch UTC")?
+            .param("interval", Primitive::U32, "Count of milliseconds representing the interval between freezes relative to the timestamp")?
+            .returns_with_default(freeze_not_supported, "Result of the freeze operation")?
+        .end_callback()?
         .begin_callback("support_write_analog_dead_bands",
                         doc("Controls outstation support for writing group 34, analog input dead-bands")
                             .details("Returning false, indicates that the writes to group34 should not be processed and requests to do so should be rejected with IIN2.NO_FUNC_CODE_SUPPORT")

--- a/ffi/dnp3-schema/src/request.rs
+++ b/ffi/dnp3-schema/src/request.rs
@@ -179,6 +179,24 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         .doc("Add a two-byte limited count variation interrogation")?
         .build()?;
 
+    let add_time_and_interval = lib
+        .define_method("add_time_and_interval", request.clone())?
+        .param(
+            "time",
+            Primitive::U64,
+            "DNP3 48-bit timestamp representing count of milliseconds since epoch UTC",
+        )?
+        .param(
+            "interval_ms",
+            Primitive::U32,
+            "Interval expressed in milliseconds",
+        )?
+        .doc(
+            doc("Add a single g51v1 time-and-interval")
+                .details("This is useful when constructing freeze-at-time requests"),
+        )?
+        .build()?;
+
     let request = lib
         .define_class(&request)?
         .constructor(constructor)?
@@ -194,6 +212,7 @@ pub fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> BackTrace
         .method(add_all_objects_header)?
         .method(add_one_byte_limited_count_header)?
         .method(add_two_byte_limited_count_header)?
+        .method(add_time_and_interval)?
         .doc(
             doc("Custom request")
             .details("Whenever a method takes a request as a parameter, the request is internally copied. Therefore, it is possible to reuse the same requests over and over.")

--- a/ffi/dnp3-schema/src/variation.rs
+++ b/ffi/dnp3-schema/src/variation.rs
@@ -187,11 +187,11 @@ pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<EnumHandle> {
         )?
         .push(
             gv(42, 7),
-            "Analog Output Event - Single-preicions floating point with time",
+            "Analog Output Event - Single-precision floating point with time",
         )?
         .push(
             gv(42, 8),
-            "Analog Output Event - Double-preicions floating point with time",
+            "Analog Output Event - Double-precision floating point with time",
         )?
         /*
         .push(
@@ -228,6 +228,7 @@ pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<EnumHandle> {
         )?
          */
         .push(gv(50, 1), "Time and Date - Absolute time")?
+        .push(gv(50, 2), "Time and Date - Absolute time and interval")?
         .push(
             gv(50, 3),
             "Time and Date - Absolute time at last recorded time",


### PR DESCRIPTION
- Adds support for `FreezeAtTime` to the outstation
- Master can now build and all types of freeze requests using the new `request_expect_empty_response` method:
  * Takes an arbitrary function code
  * Takes an arbitrary set of headers
  * There are examples for building freeze-at-time requests for all languages.