### PR TITLE
Event lifetime tracking

### DIFF
--- a/dnp3/src/app/measurement.rs
+++ b/dnp3/src/app/measurement.rs
@@ -143,7 +143,7 @@ pub struct BinaryInput {
 
 impl BinaryInput {
     /// construct a `BinaryInput` from its fields
-    pub fn new(value: bool, flags: Flags, time: Time) -> Self {
+    pub const fn new(value: bool, flags: Flags, time: Time) -> Self {
         Self {
             value,
             flags,
@@ -165,7 +165,7 @@ pub struct DoubleBitBinaryInput {
 
 impl DoubleBitBinaryInput {
     /// construct a `DoubleBitBinaryInput` from its fields
-    pub fn new(value: DoubleBit, flags: Flags, time: Time) -> Self {
+    pub const fn new(value: DoubleBit, flags: Flags, time: Time) -> Self {
         Self {
             value,
             flags,
@@ -187,7 +187,7 @@ pub struct BinaryOutputStatus {
 
 impl BinaryOutputStatus {
     /// construct a `BinaryOutputStatus` from its fields
-    pub fn new(value: bool, flags: Flags, time: Time) -> Self {
+    pub const fn new(value: bool, flags: Flags, time: Time) -> Self {
         Self {
             value,
             flags,
@@ -209,7 +209,7 @@ pub struct Counter {
 
 impl Counter {
     /// construct a `Counter` from its fields
-    pub fn new(value: u32, flags: Flags, time: Time) -> Self {
+    pub const fn new(value: u32, flags: Flags, time: Time) -> Self {
         Self {
             value,
             flags,
@@ -231,7 +231,7 @@ pub struct FrozenCounter {
 
 impl FrozenCounter {
     /// construct a `FrozenCounter` from its fields
-    pub fn new(value: u32, flags: Flags, time: Time) -> Self {
+    pub const fn new(value: u32, flags: Flags, time: Time) -> Self {
         Self {
             value,
             flags,
@@ -253,7 +253,7 @@ pub struct AnalogInput {
 
 impl AnalogInput {
     /// construct an `AnalogInput` from its fields
-    pub fn new(value: f64, flags: Flags, time: Time) -> Self {
+    pub const fn new(value: f64, flags: Flags, time: Time) -> Self {
         Self {
             value,
             flags,
@@ -275,7 +275,7 @@ pub struct FrozenAnalogInput {
 
 impl FrozenAnalogInput {
     /// construct an `AnalogInput` from its fields
-    pub fn new(value: f64, flags: Flags, time: Time) -> Self {
+    pub const fn new(value: f64, flags: Flags, time: Time) -> Self {
         Self {
             value,
             flags,

--- a/dnp3/src/outstation/database/details/database.rs
+++ b/dnp3/src/outstation/database/details/database.rs
@@ -10,6 +10,7 @@ use crate::outstation::database::{
 };
 
 use crate::outstation::database::details::attrs::map::SetMap;
+use crate::outstation::{BufferState, OutstationApplication};
 use scursor::WriteCursor;
 
 pub(crate) struct Database {
@@ -45,8 +46,12 @@ impl Database {
         self.static_db.set_analog_deadband(index, deadband)
     }
 
-    pub(crate) fn clear_written_events(&mut self) {
-        self.event_buffer.clear_written();
+    pub(crate) fn clear_written_events(
+        &mut self,
+        app: &mut dyn OutstationApplication,
+    ) -> BufferState {
+        self.event_buffer.clear_written(app);
+        self.event_buffer.class_state()
     }
 
     pub(crate) fn unwritten_classes(&self) -> EventClasses {

--- a/dnp3/src/outstation/database/details/event/buffer.rs
+++ b/dnp3/src/outstation/database/details/event/buffer.rs
@@ -990,13 +990,13 @@ mod tests {
     }
 
     impl OutstationApplication for MockApplication {
-        fn begin_ack(&mut self) {
+        fn begin_confirm(&mut self) {
             unreachable!()
         }
         fn event_cleared(&mut self, id: u64) {
             self.events.push_back(Event::Clear(id));
         }
-        fn end_ack(&mut self, _state: BufferState) -> MaybeAsync<()> {
+        fn end_confirm(&mut self, _state: BufferState) -> MaybeAsync<()> {
             unreachable!()
         }
     }

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -238,7 +238,7 @@ impl ResponseInfo {
     }
 }
 
-/// trait for adding a type to the database by index/class/configuration
+/// Trait for adding a type to the database by index/class/configuration
 ///
 /// Setting class to None means that the value will not produce events (static only).
 /// The value is initialized to the default of 0.0/false with flags == RESTART.
@@ -283,7 +283,7 @@ pub trait Update<T> {
         self.update2(index, value, options) != UpdateInfo::NoPoint
     }
 
-    /// An overload of [update] that provides more information about what occurred
+    /// An overload of [`Update::update()`] that provides more information about what occurred
     fn update2(&mut self, index: u16, value: &T, options: UpdateOptions) -> UpdateInfo;
 }
 

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -10,6 +10,7 @@ use crate::master::EventClasses;
 use crate::outstation::database::read::ReadHeader;
 
 use crate::app::attr::{AttrProp, AttrSet, OwnedAttribute, TypeError};
+use crate::outstation::OutstationApplication;
 use scursor::WriteCursor;
 
 mod config;
@@ -404,8 +405,10 @@ impl DatabaseHandle {
         }
     }
 
-    pub(crate) fn clear_written_events(&mut self) {
-        self.inner.lock().unwrap().inner.clear_written_events();
+    pub(crate) async fn clear_written_events(&mut self, app: &mut dyn OutstationApplication) {
+        app.begin_ack();
+        let state = self.inner.lock().unwrap().inner.clear_written_events(app);
+        app.end_ack(state).get().await;
     }
 
     pub(crate) fn get_events_info(&self) -> EventsInfo {

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -406,9 +406,9 @@ impl DatabaseHandle {
     }
 
     pub(crate) async fn clear_written_events(&mut self, app: &mut dyn OutstationApplication) {
-        app.begin_ack();
+        app.begin_confirm();
         let state = self.inner.lock().unwrap().inner.clear_written_events(app);
-        app.end_ack(state).get().await;
+        app.end_confirm(state).get().await;
     }
 
     pub(crate) fn get_events_info(&self) -> EventsInfo {

--- a/dnp3/src/outstation/session.rs
+++ b/dnp3/src/outstation/session.rs
@@ -535,7 +535,9 @@ impl OutstationSession {
                         Ok(Some(retry_at))
                     }
                     Some(UnsolicitedResult::Confirmed) => {
-                        database.clear_written_events();
+                        database
+                            .clear_written_events(self.application.as_mut())
+                            .await;
                         self.state.unsolicited = UnsolicitedState::Ready(None);
                         Ok(None)
                     }
@@ -1989,7 +1991,11 @@ impl OutstationSession {
             {
                 Confirm::Yes => {
                     self.state.last_broadcast_type = None;
-                    database.clear_written_events();
+
+                    database
+                        .clear_written_events(self.application.as_mut())
+                        .await;
+
                     if series.fin {
                         // done with response series
                         return Ok(());

--- a/dnp3/src/outstation/tests/harness/application.rs
+++ b/dnp3/src/outstation/tests/harness/application.rs
@@ -4,7 +4,7 @@ use crate::app::{MaybeAsync, Timestamp};
 use crate::outstation::database::DatabaseHandle;
 use crate::outstation::tests::harness::{Event, EventSender};
 use crate::outstation::traits::{OutstationApplication, RequestError, RestartDelay};
-use crate::outstation::{FreezeIndices, FreezeType};
+use crate::outstation::{BufferState, FreezeIndices, FreezeType};
 
 pub(crate) struct MockOutstationApplication {
     events: EventSender,
@@ -80,6 +80,19 @@ impl OutstationApplication for MockOutstationApplication {
 
     fn end_write_analog_dead_bands(&mut self) -> MaybeAsync<()> {
         self.events.send(Event::EndWriteDeadBands);
+        MaybeAsync::ready(())
+    }
+
+    fn begin_ack(&mut self) {
+        self.events.send(Event::BeginAck);
+    }
+
+    fn event_cleared(&mut self, id: u64) {
+        self.events.send(Event::Cleared(id));
+    }
+
+    fn end_ack(&mut self, state: BufferState) -> MaybeAsync<()> {
+        self.events.send(Event::EndAck(state));
         MaybeAsync::ready(())
     }
 }

--- a/dnp3/src/outstation/tests/harness/application.rs
+++ b/dnp3/src/outstation/tests/harness/application.rs
@@ -83,16 +83,16 @@ impl OutstationApplication for MockOutstationApplication {
         MaybeAsync::ready(())
     }
 
-    fn begin_ack(&mut self) {
-        self.events.send(Event::BeginAck);
+    fn begin_confirm(&mut self) {
+        self.events.send(Event::BeginConfirm);
     }
 
     fn event_cleared(&mut self, id: u64) {
         self.events.send(Event::Cleared(id));
     }
 
-    fn end_ack(&mut self, state: BufferState) -> MaybeAsync<()> {
-        self.events.send(Event::EndAck(state));
+    fn end_confirm(&mut self, state: BufferState) -> MaybeAsync<()> {
+        self.events.send(Event::EndConfirm(state));
         MaybeAsync::ready(())
     }
 }

--- a/dnp3/src/outstation/tests/harness/event.rs
+++ b/dnp3/src/outstation/tests/harness/event.rs
@@ -37,9 +37,9 @@ pub(crate) enum Event {
     BeginWriteDeadBands,
     WriteDeadBand(u16, f64),
     EndWriteDeadBands,
-    BeginAck,
+    BeginConfirm,
     Cleared(u64),
-    EndAck(BufferState),
+    EndConfirm(BufferState),
 }
 
 #[derive(Clone)]

--- a/dnp3/src/outstation/tests/harness/event.rs
+++ b/dnp3/src/outstation/tests/harness/event.rs
@@ -1,6 +1,6 @@
 use crate::app::variations::{Group12Var1, Group41Var1, Group41Var2, Group41Var3, Group41Var4};
 use crate::outstation::traits::{BroadcastAction, OperateType, RestartDelay};
-use crate::outstation::{FreezeIndices, FreezeType};
+use crate::outstation::{BufferState, FreezeIndices, FreezeType};
 
 use crate::app::{FunctionCode, Timestamp};
 
@@ -37,6 +37,9 @@ pub(crate) enum Event {
     BeginWriteDeadBands,
     WriteDeadBand(u16, f64),
     EndWriteDeadBands,
+    BeginAck,
+    Cleared(u64),
+    EndAck(BufferState),
 }
 
 #[derive(Clone)]

--- a/dnp3/src/outstation/tests/read_states.rs
+++ b/dnp3/src/outstation/tests/read_states.rs
@@ -204,31 +204,3 @@ async fn confirm_can_time_out() {
         .wait_for_events(&[Event::SolicitedConfirmTimeout(0)])
         .await;
 }
-
-/*
-#[test]
-fn sol_confirm_wait_goes_back_to_idle_with_new_request() {
-    let mut harness = new_harness(get_default_config());
-
-    harness.handle.database.transaction(create_binary_and_event);
-    harness.test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE);
-    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
-    // start a new request
-    harness.test_request_response(EMPTY_READ, EMPTY_RESPONSE_WITH_PENDING_EVENTS);
-    harness.check_events(&[Event::SolicitedConfirmWaitNewRequest]);
-}
-
-#[test]
-fn sol_confirm_wait_goes_back_to_idle_with_new_invalid_request() {
-    let mut harness = new_harness(get_default_config());
-
-    harness.handle.database.transaction(create_binary_and_event);
-    harness.test_request_response(READ_CLASS_123, BINARY_EVENT_RESPONSE);
-    harness.check_events(&[Event::EnterSolicitedConfirmWait(0)]);
-    harness.test_request_response(
-        &[0xC0, 0x70],             // Invalid function code
-        &[0xC0, 0x81, 0x82, 0x01], // NO_FUNC_CODE_SUPPORT
-    );
-    harness.check_events(&[Event::SolicitedConfirmWaitNewRequest]);
-}
-*/

--- a/dnp3/src/outstation/tests/unsolicited.rs
+++ b/dnp3/src/outstation/tests/unsolicited.rs
@@ -189,9 +189,9 @@ async fn defers_read_during_unsol_confirm_wait() {
     harness.check_events(&[Event::UnsolicitedConfirmReceived(1)]);
     harness.expect_response(CLASS_0_RESPONSE_SEQ0).await;
     harness.check_events(&[
-        Event::BeginAck,
+        Event::BeginConfirm,
         Event::Cleared(0),
-        Event::EndAck(BufferState {
+        Event::EndConfirm(BufferState {
             remaining_class_1: 0,
             remaining_class_2: 0,
             remaining_class_3: 0,

--- a/dnp3/src/outstation/tests/unsolicited.rs
+++ b/dnp3/src/outstation/tests/unsolicited.rs
@@ -2,6 +2,7 @@ use crate::app::measurement::*;
 use crate::app::Timestamp;
 use crate::outstation::config::OutstationConfig;
 use crate::outstation::database::*;
+use crate::outstation::BufferState;
 
 use super::harness::*;
 
@@ -187,6 +188,15 @@ async fn defers_read_during_unsol_confirm_wait() {
     harness.send_and_process(UNS_CONFIRM_SEQ_1).await;
     harness.check_events(&[Event::UnsolicitedConfirmReceived(1)]);
     harness.expect_response(CLASS_0_RESPONSE_SEQ0).await;
+    harness.check_events(&[
+        Event::BeginAck,
+        Event::Cleared(0),
+        Event::EndAck(BufferState {
+            remaining_class_1: 0,
+            remaining_class_2: 0,
+            remaining_class_3: 0,
+        }),
+    ]);
     harness.check_no_events();
 }
 

--- a/dnp3/src/outstation/traits.rs
+++ b/dnp3/src/outstation/traits.rs
@@ -182,19 +182,19 @@ pub trait OutstationApplication: Sync + Send + 'static {
         MaybeAsync::ready(true)
     }
 
-    /// Called when an ACK is received to a response or unsolicited response, but before any
+    /// Called when a CONFIRM is received to a response or unsolicited response, but before any
     /// previously transmitted events are cleared from the buffer
-    fn begin_ack(&mut self) {}
+    fn begin_confirm(&mut self) {}
 
-    /// Called when an event is cleared from the buffer due to master acknowledgement
+    /// Called when an event is cleared from the buffer due to master confirmation
     #[allow(unused_variables)]
     fn event_cleared(&mut self, id: u64) {}
 
-    /// Called when all relevant events have been cleared due to acknowledgement
+    /// Called when all relevant events have been cleared due to confirmation
     ///
     /// * state - number of events remaining in the buffer for Class 1, 2, and 3
     #[allow(unused_variables)]
-    fn end_ack(&mut self, state: BufferState) -> MaybeAsync<()> {
+    fn end_confirm(&mut self, state: BufferState) -> MaybeAsync<()> {
         MaybeAsync::ready(())
     }
 }

--- a/ffi/bindings/dotnet/examples/outstation/Program.cs
+++ b/ffi/bindings/dotnet/examples/outstation/Program.cs
@@ -105,6 +105,21 @@ class ExampleOutstation
         {
             return false;
         }
+
+        void IOutstationApplication.BeginConfirm()
+        {
+
+        }
+
+        void IOutstationApplication.EventCleared(ulong id)
+        {
+
+        }
+
+        void IOutstationApplication.EndConfirm(BufferState state)
+        {
+
+        }
     }
 
     class TestOutstationInformation : IOutstationInformation

--- a/ffi/dnp3-ffi/src/outstation/adapters.rs
+++ b/ffi/dnp3-ffi/src/outstation/adapters.rs
@@ -193,7 +193,7 @@ impl OutstationApplication for ffi::OutstationApplication {
         }
     }
 
-    fn begin_ack(&mut self) {
+    fn begin_confirm(&mut self) {
         ffi::OutstationApplication::begin_confirm(self)
     }
 
@@ -201,7 +201,7 @@ impl OutstationApplication for ffi::OutstationApplication {
         ffi::OutstationApplication::event_cleared(self, id);
     }
 
-    fn end_ack(&mut self, state: BufferState) -> MaybeAsync<()> {
+    fn end_confirm(&mut self, state: BufferState) -> MaybeAsync<()> {
         ffi::OutstationApplication::end_confirm(self, state.into());
         MaybeAsync::ready(())
     }

--- a/ffi/dnp3-ffi/src/outstation/adapters.rs
+++ b/ffi/dnp3-ffi/src/outstation/adapters.rs
@@ -192,6 +192,29 @@ impl OutstationApplication for ffi::OutstationApplication {
             }
         }
     }
+
+    fn begin_ack(&mut self) {
+        ffi::OutstationApplication::begin_confirm(self)
+    }
+
+    fn event_cleared(&mut self, id: u64) {
+        ffi::OutstationApplication::event_cleared(self, id);
+    }
+
+    fn end_ack(&mut self, state: BufferState) -> MaybeAsync<()> {
+        ffi::OutstationApplication::end_confirm(self, state.into());
+        MaybeAsync::ready(())
+    }
+}
+
+impl From<dnp3::outstation::BufferState> for ffi::BufferState {
+    fn from(value: BufferState) -> Self {
+        Self {
+            remaining_class_1: value.remaining_class_1 as u32,
+            remaining_class_2: value.remaining_class_2 as u32,
+            remaining_class_3: value.remaining_class_3 as u32,
+        }
+    }
 }
 
 impl From<ffi::ApplicationIin> for ApplicationIin {

--- a/ffi/dnp3-ffi/src/outstation/database.rs
+++ b/ffi/dnp3-ffi/src/outstation/database.rs
@@ -199,7 +199,7 @@ implement_database_point_operations!(
     ffi::AnalogOutputStatusConfig,
 );
 
-pub unsafe fn database_add_octet_string(
+pub(crate) unsafe fn database_add_octet_string(
     database: *mut Database,
     index: u16,
     point_class: ffi::EventClass,
@@ -210,14 +210,14 @@ pub unsafe fn database_add_octet_string(
     false
 }
 
-pub unsafe fn database_remove_octet_string(database: *mut Database, index: u16) -> bool {
+pub(crate) unsafe fn database_remove_octet_string(database: *mut Database, index: u16) -> bool {
     if let Some(database) = database.as_mut() {
         return Remove::<OctetString>::remove(database, index);
     }
     false
 }
 
-pub unsafe fn database_update_octet_string(
+pub(crate) unsafe fn database_update_octet_string(
     database: *mut Database,
     index: u16,
     value: *mut OctetStringValue,
@@ -231,6 +231,22 @@ pub unsafe fn database_update_octet_string(
         }
     }
     false
+}
+
+pub(crate) unsafe fn database_update_octet_string_2(
+    database: *mut crate::Database,
+    index: u16,
+    value: *mut crate::OctetStringValue,
+    options: ffi::UpdateOptions,
+) -> ffi::UpdateInfo {
+    if let Some(database) = database.as_mut() {
+        if let Some(value) = value.as_ref() {
+            if let Some(value) = value.into() {
+                return database.update2(index, &value, options.into()).into();
+            }
+        }
+    }
+    ffi::UpdateInfoFields::default().into()
 }
 
 pub(crate) unsafe fn database_define_string_attr(

--- a/ffi/dnp3-schema/src/database.rs
+++ b/ffi/dnp3-schema/src/database.rs
@@ -649,6 +649,21 @@ pub(crate) fn define_database(
         .doc("Update a Double-Bit Binary Input point")?
         .build()?;
 
+    let update_double_bit_binary_2 = lib
+        .define_method("update_double_bit_binary_input_2", database.clone())?
+        .param(
+            "value",
+            shared_def.double_bit_binary_point.clone(),
+            "New value of the point",
+        )?
+        .param("options", update_options.clone(), "Update options")?
+        .returns(
+            update_info.clone(),
+            "Provides detailed information about what occurred during the update operation",
+        )?
+        .doc("Update a Double-Bit Binary Input point")?
+        .build()?;
+
     let get_double_bit_binary = lib
         .define_method("get_double_bit_binary_input", database.clone())?
         .param("index", Primitive::U16, "Index of the point to get")?
@@ -696,6 +711,21 @@ pub(crate) fn define_database(
         .returns(
             Primitive::Bool,
             "True if the point was successfully updated, false otherwise",
+        )?
+        .doc("Update a Binary Output Status point")?
+        .build()?;
+
+    let update_binary_output_status_2 = lib
+        .define_method("update_binary_output_status_2", database.clone())?
+        .param(
+            "value",
+            shared_def.binary_output_status_point.clone(),
+            "New value of the point",
+        )?
+        .param("options", update_options.clone(), "Update options")?
+        .returns(
+            update_info.clone(),
+            "Provides detailed information about what occurred during the update operation",
         )?
         .doc("Update a Binary Output Status point")?
         .build()?;
@@ -751,6 +781,21 @@ pub(crate) fn define_database(
         .doc("Update a Counter point")?
         .build()?;
 
+    let update_counter_2 = lib
+        .define_method("update_counter_2", database.clone())?
+        .param(
+            "value",
+            shared_def.counter_point.clone(),
+            "New value of the point",
+        )?
+        .param("options", update_options.clone(), "Update options")?
+        .returns(
+            update_info.clone(),
+            "Provides detailed information about what occurred during the update operation",
+        )?
+        .doc("Update a Counter point")?
+        .build()?;
+
     let get_counter = lib
         .define_method("get_counter", database.clone())?
         .param("index", Primitive::U16, "Index of the point to get")?
@@ -795,6 +840,21 @@ pub(crate) fn define_database(
         .returns(
             Primitive::Bool,
             "True if the point was successfully updated, false otherwise",
+        )?
+        .doc("Update an Frozen Counter point")?
+        .build()?;
+
+    let update_frozen_counter_2 = lib
+        .define_method("update_frozen_counter_2", database.clone())?
+        .param(
+            "value",
+            shared_def.frozen_counter_point.clone(),
+            "New value of the point",
+        )?
+        .param("options", update_options.clone(), "Update options")?
+        .returns(
+            update_info.clone(),
+            "Provides detailed information about what occurred during the update operation",
         )?
         .doc("Update an Frozen Counter point")?
         .build()?;
@@ -850,6 +910,21 @@ pub(crate) fn define_database(
         .doc("Update a AnalogInput point")?
         .build()?;
 
+    let update_analog_2 = lib
+        .define_method("update_analog_input_2", database.clone())?
+        .param(
+            "value",
+            shared_def.analog_point.clone(),
+            "New value of the point",
+        )?
+        .param("options", update_options.clone(), "Update options")?
+        .returns(
+            update_info.clone(),
+            "Provides detailed information about what occurred during the update operation",
+        )?
+        .doc("Update a AnalogInput point")?
+        .build()?;
+
     let get_analog = lib
         .define_method("get_analog_input", database.clone())?
         .param("index", Primitive::U16, "Index of the point to get")?
@@ -897,6 +972,21 @@ pub(crate) fn define_database(
         .doc("Update a Analog Output Status point")?
         .build()?;
 
+    let update_analog_output_status_2 = lib
+        .define_method("update_analog_output_status_2", database.clone())?
+        .param(
+            "value",
+            shared_def.analog_output_status_point.clone(),
+            "New value of the point",
+        )?
+        .param("options", update_options.clone(), "Update options")?
+        .returns(
+            update_info.clone(),
+            "Provides detailed information about what occurred during the update operation",
+        )?
+        .doc("Update a Analog Output Status point")?
+        .build()?;
+
     let get_analog_output_status = lib
         .define_method("get_analog_output_status", database.clone())?
         .param("index", Primitive::U16, "Index of the point to get")?
@@ -935,11 +1025,23 @@ pub(crate) fn define_database(
     let update_octet_string = lib
         .define_method("update_octet_string", database.clone())?
         .param("index", Primitive::U16, "Index of the octet string")?
-        .param("value", octet_string, "New value of the point")?
-        .param("options", update_options, "Update options")?
+        .param("value", octet_string.clone(), "New value of the point")?
+        .param("options", update_options.clone(), "Update options")?
         .returns(
             Primitive::Bool,
             "True if the point was successfully updated, false otherwise",
+        )?
+        .doc("Update an Octet String point")?
+        .build()?;
+
+    let update_octet_string_2 = lib
+        .define_method("update_octet_string_2", database.clone())?
+        .param("index", Primitive::U16, "Index of the octet string")?
+        .param("value", octet_string, "New value of the point")?
+        .param("options", update_options, "Update options")?
+        .returns(
+            update_info,
+            "Provides detailed information about what occurred during the update operation",
         )?
         .doc("Update an Octet String point")?
         .build()?;
@@ -1128,36 +1230,43 @@ pub(crate) fn define_database(
         .method(add_double_bit_binary)?
         .method(remove_double_bit_binary)?
         .method(update_double_bit_binary)?
+        .method(update_double_bit_binary_2)?
         .method(get_double_bit_binary)?
         // binary output status methods
         .method(add_binary_output_status)?
         .method(remove_binary_output_status)?
         .method(update_binary_output_status)?
+        .method(update_binary_output_status_2)?
         .method(get_binary_output_status)?
         // counter methods
         .method(add_counter)?
         .method(remove_counter)?
         .method(update_counter)?
+        .method(update_counter_2)?
         .method(get_counter)?
         // frozen-counter methods
         .method(add_frozen_counter)?
         .method(remove_frozen_counter)?
         .method(update_frozen_counter)?
+        .method(update_frozen_counter_2)?
         .method(get_frozen_counter)?
         // analog methods
         .method(add_analog)?
         .method(remove_analog)?
         .method(update_analog)?
+        .method(update_analog_2)?
         .method(get_analog)?
         // analog output status methods
         .method(add_analog_output_status)?
         .method(remove_analog_output_status)?
         .method(update_analog_output_status)?
+        .method(update_analog_output_status_2)?
         .method(get_analog_output_status)?
         // octet-string methods
         .method(add_octet_string)?
         .method(remove_octet_string)?
         .method(update_octet_string)?
+        .method(update_octet_string_2)?
         // device attributes
         .method(define_string_attr)?
         .method(define_int_attr)?


### PR DESCRIPTION
This PR allows user code to track the lifetime of events via incrementing 64-bit ids to all events.

1. The `Database` now implements overloaded update methods (with the suffix "2") that return information about event creation and overflow.
2. The `OutstationApplication` interface provide 3 new callbacks `begin_confirm`, `event_cleared`, and `end_confirm` allowing user code to detect when previously created events have been confirmed by the master and cleared from the event buffer.

In a future 2.0 release, the overloaded update methods will become the only available update methods.

