### PR TITLE
Refactor/external promise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "lazy_static",
  "num_cpus",
  "oo-bindgen",
+ "sfio-promise",
  "sfio-tokio-ffi",
  "sfio-tracing-ffi",
  "tokio",
@@ -878,9 +879,8 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oo-bindgen"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853bdca8e13eff040ebc7ed4d120bc989c09d157018987f50de04ecb819388e1"
+version = "0.7.1"
+source = "git+https://github.com/stepfunc/oo_bindgen.git?branch=feature/more-generic-promise#c0e8f92fa4d90d9e2105f1d2868f1bc91022215e"
 dependencies = [
  "backtrace",
  "clap",
@@ -1247,6 +1247,12 @@ dependencies = [
  "regex",
  "winapi",
 ]
+
+[[package]]
+name = "sfio-promise"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7633b2c7b0c49ea920d4f49226dc90149e5eb7e93ede49bc7f482c0ff4c4f2"
 
 [[package]]
 name = "sfio-tokio-ffi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,8 +879,9 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oo-bindgen"
-version = "0.7.1"
-source = "git+https://github.com/stepfunc/oo_bindgen.git?branch=feature/more-generic-promise#c0e8f92fa4d90d9e2105f1d2868f1bc91022215e"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51dcf81e8585d49764404a4a8eece2a1aa77bc1c19644baf6371694c6c7f3dd3"
 dependencies = [
  "backtrace",
  "clap",
@@ -1250,15 +1251,15 @@ dependencies = [
 
 [[package]]
 name = "sfio-promise"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7633b2c7b0c49ea920d4f49226dc90149e5eb7e93ede49bc7f482c0ff4c4f2"
+checksum = "91547be5cac1551a6401a7cfa571524bbcb4d9d818b2756cbe3012b48cc79aaf"
 
 [[package]]
 name = "sfio-tokio-ffi"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a16029060d63c415c8de5ad158d468e3b3babb6e9342db5b3386fcd211b2f1a"
+checksum = "7264a1340f2fa1d79e749b85c1f9965dedbd811d1dfb32a6b354e8253cad2286"
 dependencies = [
  "oo-bindgen",
 ]
@@ -1274,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "sfio-tracing-ffi"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7945dc84282559575ddbb2d894ca10cbf23dda1df8c9f2a6b915b8863b32fd26"
+checksum = "94955ac2db413b6f32297e862581db2c05f6312881939393f4b68f173a8be8b4"
 dependencies = [
  "oo-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
 
 [profile.release]
 lto=true
+
+[patch.crates-io]
+oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", branch = "feature/more-generic-promise" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,3 @@ members = [
 
 [profile.release]
 lto=true
-
-[patch.crates-io]
-oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", branch = "feature/more-generic-promise" }

--- a/dep_config.json
+++ b/dep_config.json
@@ -56,6 +56,9 @@
     "scursor": {
       "url": "https://github.com/stepfunc/scursor"
     },
+    "sfio-promise": {
+      "url": "https://github.com/stepfunc/promise"
+    },
     "sfio-tokio-ffi": {
       "url": "https://github.com/stepfunc/tokio-ffi"
     },

--- a/ffi/dnp3-bindings/Cargo.toml
+++ b/ffi/dnp3-bindings/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 
 [dependencies]
-oo-bindgen = "0.7"
+oo-bindgen = "0.8"
 dnp3-schema = { path = "../dnp3-schema" }
 tracing-subscriber = "0.3"
 tracing = "0.1"

--- a/ffi/dnp3-ffi-java/Cargo.toml
+++ b/ffi/dnp3-ffi-java/Cargo.toml
@@ -19,4 +19,4 @@ serial = ["dnp3-ffi/serial"]
 
 [build-dependencies]
 dnp3-schema = { path = "../dnp3-schema" }
-oo-bindgen = "0.7"
+oo-bindgen = "0.8"

--- a/ffi/dnp3-ffi/Cargo.toml
+++ b/ffi/dnp3-ffi/Cargo.toml
@@ -15,6 +15,7 @@ tracing-subscriber = "0.2"
 dnp3 = { path = "../../dnp3", default-features = false, features = ["ffi"] }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 num_cpus = "1"
+sfio-promise = "0.1"
 
 [features]
 default = ["tls", "serial"]

--- a/ffi/dnp3-ffi/Cargo.toml
+++ b/ffi/dnp3-ffi/Cargo.toml
@@ -15,7 +15,7 @@ tracing-subscriber = "0.2"
 dnp3 = { path = "../../dnp3", default-features = false, features = ["ffi"] }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 num_cpus = "1"
-sfio-promise = "0.1"
+sfio-promise = "0.2"
 
 [features]
 default = ["tls", "serial"]
@@ -24,6 +24,6 @@ serial = ["dnp3/serial"]
 
 [build-dependencies]
 dnp3-schema = { path = "../dnp3-schema" }
-oo-bindgen = "0.7"
-sfio-tracing-ffi = "0.7"
-sfio-tokio-ffi = "0.7"
+oo-bindgen = "0.8"
+sfio-tracing-ffi = "0.8"
+sfio-tokio-ffi = "0.8"

--- a/ffi/dnp3-ffi/src/lib.rs
+++ b/ffi/dnp3-ffi/src/lib.rs
@@ -6,7 +6,6 @@ pub(crate) use crate::tracing::*;
 pub use command::*;
 pub use connect::*;
 pub use decoding::*;
-use dnp3::app::Shutdown;
 pub use handler::*;
 pub use master::*;
 pub use outstation::*;
@@ -54,7 +53,7 @@ impl From<crate::runtime::RuntimeError> for std::os::raw::c_int {
 }
 
 impl From<dnp3::app::Shutdown> for crate::ffi::ParamError {
-    fn from(_: Shutdown) -> Self {
+    fn from(_: dnp3::app::Shutdown) -> Self {
         crate::ffi::ParamError::MasterAlreadyShutdown
     }
 }
@@ -73,30 +72,4 @@ impl From<crate::runtime::RuntimeError> for crate::ffi::ParamError {
             }
         }
     }
-}
-
-/// these implementations are required for all error types on future interfaces:
-
-impl crate::ffi::promise::DropError for crate::ffi::EmptyResponseError {
-    const ERROR_ON_DROP: Self = Self::Shutdown;
-}
-
-impl crate::ffi::promise::DropError for crate::ffi::ReadError {
-    const ERROR_ON_DROP: Self = Self::Shutdown;
-}
-
-impl crate::ffi::promise::DropError for crate::ffi::CommandError {
-    const ERROR_ON_DROP: Self = Self::Shutdown;
-}
-
-impl crate::ffi::promise::DropError for crate::ffi::TimeSyncError {
-    const ERROR_ON_DROP: Self = Self::Shutdown;
-}
-
-impl crate::ffi::promise::DropError for crate::ffi::RestartError {
-    const ERROR_ON_DROP: Self = Self::Shutdown;
-}
-
-impl crate::ffi::promise::DropError for crate::ffi::LinkStatusError {
-    const ERROR_ON_DROP: Self = Self::Shutdown;
 }

--- a/ffi/dnp3-ffi/src/master/functions.rs
+++ b/ffi/dnp3-ffi/src/master/functions.rs
@@ -387,7 +387,7 @@ pub(crate) unsafe fn master_channel_read(
         .ok_or(ffi::ParamError::NullParameter)?
         .build_read_request();
 
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let mut handle = AssociationHandle::create(address, channel.handle.clone());
 
@@ -409,7 +409,7 @@ pub(crate) unsafe fn master_channel_write_dead_bands(
     let channel = channel.as_mut().ok_or(ffi::ParamError::NullParameter)?;
     let address = EndpointAddress::try_new(association.address)?;
     let request = request.as_mut().ok_or(ffi::ParamError::NullParameter)?;
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
     let headers = request.build();
 
     let mut handle = AssociationHandle::create(address, channel.handle.clone());
@@ -437,7 +437,7 @@ pub(crate) unsafe fn master_channel_send_and_expect_empty_response(
         .as_mut()
         .ok_or(ffi::ParamError::NullParameter)?
         .build_headers();
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let mut handle = AssociationHandle::create(address, channel.handle.clone());
 
@@ -466,7 +466,7 @@ pub(crate) unsafe fn master_channel_read_with_handler(
         .ok_or(ffi::ParamError::NullParameter)?
         .build_read_request();
 
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let mut handle = AssociationHandle::create(address, channel.handle.clone());
 
@@ -494,7 +494,7 @@ pub(crate) unsafe fn master_channel_operate(
         .clone()
         .build();
 
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let mut handle = AssociationHandle::create(address, channel.handle.clone());
 
@@ -548,7 +548,7 @@ pub(crate) unsafe fn master_channel_synchronize_time(
     let address = EndpointAddress::try_new(association.address)?;
 
     let mut association = AssociationHandle::create(address, channel.handle.clone());
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let task = async move {
         let res = association.synchronize_time(mode.into()).await;
@@ -568,7 +568,7 @@ pub(crate) unsafe fn master_channel_cold_restart(
     let address = EndpointAddress::try_new(association.address)?;
 
     let mut association = AssociationHandle::create(address, channel.handle.clone());
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let task = async move {
         let res = association.cold_restart().await;
@@ -588,7 +588,7 @@ pub(crate) unsafe fn master_channel_warm_restart(
     let address = EndpointAddress::try_new(association.address)?;
 
     let mut association = AssociationHandle::create(address, channel.handle.clone());
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let task = async move {
         let res = association.warm_restart().await;
@@ -608,7 +608,7 @@ pub(crate) unsafe fn master_channel_check_link_status(
     let address = EndpointAddress::try_new(association.address)?;
 
     let mut association = AssociationHandle::create(address, channel.handle.clone());
-    let promise = sfio_promise::Promise::new(callback);
+    let promise = sfio_promise::wrap(callback);
 
     let task = async move {
         let res = association.check_link_status().await;

--- a/ffi/dnp3-ffi/src/master/futures.rs
+++ b/ffi/dnp3-ffi/src/master/futures.rs
@@ -1,0 +1,104 @@
+use dnp3::master::*;
+use std::time::Duration;
+
+impl<T> sfio_promise::FutureType<Result<T, WriteError>> for crate::ffi::EmptyResponseCallback {
+    fn on_drop() -> Result<T, WriteError> {
+        Err(TaskError::Shutdown.into())
+    }
+
+    fn complete(self, result: Result<T, WriteError>) {
+        match result {
+            Ok(_) => {
+                self.on_complete(crate::ffi::Nothing::Nothing);
+            }
+            Err(err) => {
+                self.on_failure(err.into());
+            }
+        }
+    }
+}
+
+impl sfio_promise::FutureType<Result<(), TaskError>> for crate::ffi::ReadTaskCallback {
+    fn on_drop() -> Result<(), TaskError> {
+        Err(TaskError::Shutdown)
+    }
+
+    fn complete(self, result: Result<(), TaskError>) {
+        match result {
+            Ok(_) => {
+                self.on_complete(crate::ffi::Nothing::Nothing);
+            }
+            Err(err) => {
+                self.on_failure(err.into());
+            }
+        }
+    }
+}
+
+impl sfio_promise::FutureType<Result<(), CommandError>> for crate::ffi::CommandTaskCallback {
+    fn on_drop() -> Result<(), CommandError> {
+        Err(TaskError::Shutdown.into())
+    }
+
+    fn complete(self, result: Result<(), CommandError>) {
+        match result {
+            Ok(_) => {
+                self.on_complete(crate::ffi::Nothing::Nothing);
+            }
+            Err(err) => {
+                self.on_failure(err.into());
+            }
+        }
+    }
+}
+
+impl sfio_promise::FutureType<Result<(), TimeSyncError>> for crate::ffi::TimeSyncTaskCallback {
+    fn on_drop() -> Result<(), TimeSyncError> {
+        Err(TaskError::Shutdown.into())
+    }
+
+    fn complete(self, result: Result<(), TimeSyncError>) {
+        match result {
+            Ok(_) => {
+                self.on_complete(crate::ffi::Nothing::Nothing);
+            }
+            Err(err) => {
+                self.on_failure(err.into());
+            }
+        }
+    }
+}
+
+impl sfio_promise::FutureType<Result<Duration, TaskError>> for crate::ffi::RestartTaskCallback {
+    fn on_drop() -> Result<Duration, TaskError> {
+        Err(TaskError::Shutdown)
+    }
+
+    fn complete(self, result: Result<Duration, TaskError>) {
+        match result {
+            Ok(x) => {
+                self.on_complete(x);
+            }
+            Err(err) => {
+                self.on_failure(err.into());
+            }
+        }
+    }
+}
+
+impl sfio_promise::FutureType<Result<(), TaskError>> for crate::ffi::LinkStatusCallback {
+    fn on_drop() -> Result<(), TaskError> {
+        Err(TaskError::Shutdown)
+    }
+
+    fn complete(self, result: Result<(), TaskError>) {
+        match result {
+            Ok(()) => {
+                self.on_complete(crate::ffi::Nothing::Nothing);
+            }
+            Err(err) => {
+                self.on_failure(err.into());
+            }
+        }
+    }
+}

--- a/ffi/dnp3-ffi/src/master/mod.rs
+++ b/ffi/dnp3-ffi/src/master/mod.rs
@@ -1,0 +1,4 @@
+mod functions;
+mod futures;
+
+pub use functions::*;

--- a/ffi/dnp3-schema/Cargo.toml
+++ b/ffi/dnp3-schema/Cargo.toml
@@ -6,6 +6,6 @@ authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 
 [dependencies]
-oo-bindgen = "0.7"
-sfio-tracing-ffi = "0.7"
-sfio-tokio-ffi = "0.7"
+oo-bindgen = "0.8"
+sfio-tracing-ffi = "0.8"
+sfio-tokio-ffi = "0.8"


### PR DESCRIPTION
Use external crate to create drop-safe promises before spawning in FFI