### PR TITLE
Outstation client modes

### DIFF
--- a/dnp3/src/tcp/master.rs
+++ b/dnp3/src/tcp/master.rs
@@ -53,7 +53,7 @@ pub fn spawn_master_tcp_client_2(
     );
     let future = async move {
         task.run()
-            .instrument(tracing::info_span!("dnp3-master-tcp", "endpoint" = ?main_addr))
+            .instrument(tracing::info_span!("dnp3-master-tcp-client", "endpoint" = ?main_addr))
             .await;
     };
     tokio::spawn(future);

--- a/dnp3/src/tcp/outstation.rs
+++ b/dnp3/src/tcp/outstation.rs
@@ -14,7 +14,7 @@ use crate::util::channel::Sender;
 use crate::util::phys::PhysLayer;
 use crate::util::session::{Enabled, Session};
 
-/// Spawn a tcp client task onto the `Tokio` runtime. The task runs until the returned handle is dropped.
+/// Spawn a TCP client task onto the `Tokio` runtime. The task runs until the returned handle is dropped.
 ///
 /// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
 /// Use Runtime::enter() if required.

--- a/dnp3/src/tcp/outstation.rs
+++ b/dnp3/src/tcp/outstation.rs
@@ -1,15 +1,63 @@
 use tracing::Instrument;
 
-use crate::app::{Listener, Shutdown};
+use crate::app::{ConnectStrategy, Listener, Shutdown};
 use crate::link::LinkErrorMode;
 use crate::outstation::task::OutstationTask;
 use crate::outstation::OutstationHandle;
 use crate::outstation::*;
+use crate::tcp::client::ClientTask;
 use crate::tcp::server::{NewSession, ServerTask};
-use crate::tcp::{AddressFilter, FilterError};
+use crate::tcp::{
+    AddressFilter, ClientState, ConnectOptions, EndpointList, FilterError, PostConnectionHandler,
+};
 use crate::util::channel::Sender;
 use crate::util::phys::PhysLayer;
 use crate::util::session::{Enabled, Session};
+
+/// Spawn a tcp client task onto the `Tokio` runtime. The task runs until the returned handle is dropped.
+///
+/// **Note**: This function may only be called from within the runtime itself, and panics otherwise.
+/// Use Runtime::enter() if required.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_outstation_tcp_client(
+    link_error_mode: LinkErrorMode,
+    endpoints: EndpointList,
+    connect_strategy: ConnectStrategy,
+    connect_options: ConnectOptions,
+    listener: Box<dyn Listener<ClientState>>,
+    config: OutstationConfig,
+    application: Box<dyn OutstationApplication>,
+    information: Box<dyn OutstationInformation>,
+    control_handler: Box<dyn ControlHandler>,
+) -> OutstationHandle {
+    let main_addr = endpoints.main_addr().to_string();
+    let (task, handle) = OutstationTask::create(
+        Enabled::No,
+        link_error_mode,
+        config,
+        application,
+        information,
+        control_handler,
+    );
+    let session = Session::outstation(task);
+    let mut client = ClientTask::new(
+        session,
+        endpoints,
+        connect_strategy,
+        connect_options,
+        PostConnectionHandler::Tcp,
+        listener,
+    );
+
+    let future = async move {
+        client
+            .run()
+            .instrument(tracing::info_span!("dnp3-outstation-tcp-client", "endpoint" = ?main_addr))
+            .await;
+    };
+    tokio::spawn(future);
+    handle
+}
 
 struct OutstationInfo {
     filter: AddressFilter,

--- a/dnp3/src/tcp/outstation.rs
+++ b/dnp3/src/tcp/outstation.rs
@@ -24,11 +24,11 @@ pub fn spawn_outstation_tcp_client(
     endpoints: EndpointList,
     connect_strategy: ConnectStrategy,
     connect_options: ConnectOptions,
-    listener: Box<dyn Listener<ClientState>>,
     config: OutstationConfig,
     application: Box<dyn OutstationApplication>,
     information: Box<dyn OutstationInformation>,
     control_handler: Box<dyn ControlHandler>,
+    listener: Box<dyn Listener<ClientState>>,
 ) -> OutstationHandle {
     let main_addr = endpoints.main_addr().to_string();
     let (task, handle) = OutstationTask::create(

--- a/dnp3/src/tcp/tls/master.rs
+++ b/dnp3/src/tcp/tls/master.rs
@@ -70,7 +70,7 @@ pub fn spawn_master_tls_client_2(
     );
     let future = async move {
         task.run()
-            .instrument(tracing::info_span!("dnp3-master-tls", "endpoint" = ?main_addr))
+            .instrument(tracing::info_span!("dnp3-master-tls-client", "endpoint" = ?main_addr))
             .await;
     };
     tokio::spawn(future);

--- a/ffi/bindings/c/outstation_example.cpp
+++ b/ffi/bindings/c/outstation_example.cpp
@@ -336,6 +336,26 @@ void run_tcp_server(dnp3::Runtime &runtime)
     run_server(server);
 }
 
+void run_tcp_client(dnp3::Runtime &runtime)
+{
+    dnp3::EndpointList endpoints(std::string("127.0.0.1:20000"));
+    dnp3::ConnectOptions options;
+
+    auto outstation = Outstation::create_tcp_client(
+        runtime, LinkErrorMode::discard,
+        endpoints,
+        dnp3::ConnectStrategy(),
+        options,
+        get_outstation_config(),
+        std::make_unique<MyOutstationApplication>(),
+        std::make_unique<MyOutstationInformation>(),
+        std::make_unique<MyControlHandler>(),
+        client_state_listener([](ClientState state) { std::cout << "ClientState: " << to_string(state) << std::endl; })
+    );
+
+    run_outstation(outstation);
+}
+
 void run_serial(dnp3::Runtime &runtime)
 {
     // ANCHOR: create_serial_server
@@ -416,6 +436,9 @@ int main(int argc, char *argv[])
 
     if (strcmp(type, "tcp") == 0) {
         run_tcp_server(runtime);
+    }
+    else if (strcmp(type, "tcp-client") == 0) {
+        run_tcp_client(runtime);
     }
     else if (strcmp(type, "serial") == 0) {
         run_serial(runtime);

--- a/ffi/dnp3-ffi/src/master/functions.rs
+++ b/ffi/dnp3-ffi/src/master/functions.rs
@@ -58,12 +58,6 @@ pub(crate) unsafe fn master_channel_create_tcp_2(
         .map(|x| x.inner)
         .unwrap_or_else(Default::default);
 
-    let connect_strategy = ConnectStrategy::new(
-        connect_strategy.min_connect_delay(),
-        connect_strategy.max_connect_delay(),
-        connect_strategy.reconnect_delay(),
-    );
-
     // enter the runtime context so that we can spawn
     let _enter = runtime.enter();
 
@@ -71,7 +65,7 @@ pub(crate) unsafe fn master_channel_create_tcp_2(
         link_error_mode.into(),
         config,
         endpoints.clone(),
-        connect_strategy,
+        connect_strategy.into(),
         connect_options,
         Box::new(listener),
     );
@@ -162,12 +156,6 @@ pub(crate) unsafe fn master_channel_create_tls_2(
         err
     })?;
 
-    let connect_strategy = ConnectStrategy::new(
-        connect_strategy.min_connect_delay(),
-        connect_strategy.max_connect_delay(),
-        connect_strategy.reconnect_delay(),
-    );
-
     // enter the runtime context so that we can spawn
     let _enter = runtime.enter();
 
@@ -175,7 +163,7 @@ pub(crate) unsafe fn master_channel_create_tls_2(
         link_error_mode.into(),
         config,
         endpoints.clone(),
-        connect_strategy,
+        connect_strategy.into(),
         connect_options,
         Box::new(listener),
         tls_config,
@@ -858,6 +846,16 @@ impl From<ffi::CertificateMode> for CertificateMode {
             ffi::CertificateMode::AuthorityBased => Self::AuthorityBased,
             ffi::CertificateMode::SelfSigned => Self::SelfSigned,
         }
+    }
+}
+
+impl From<ffi::ConnectStrategy> for ConnectStrategy {
+    fn from(value: ffi::ConnectStrategy) -> Self {
+        ConnectStrategy::new(
+            value.min_connect_delay(),
+            value.max_connect_delay(),
+            value.reconnect_delay(),
+        )
     }
 }
 

--- a/ffi/dnp3-ffi/src/outstation/mod.rs
+++ b/ffi/dnp3-ffi/src/outstation/mod.rs
@@ -214,6 +214,71 @@ pub(crate) unsafe fn outstation_create_tcp_client(
     Ok(Box::into_raw(handle))
 }
 
+#[cfg(not(feature = "tls"))]
+#[allow(clippy::too_many_arguments)] // TODO
+pub(crate) unsafe fn outstation_create_tls_client(
+    _runtime: *mut crate::Runtime,
+    _link_error_mode: ffi::LinkErrorMode,
+    _endpoints: *mut crate::EndpointList,
+    _connect_strategy: ffi::ConnectStrategy,
+    _connect_options: *mut crate::ConnectOptions,
+    _config: ffi::OutstationConfig,
+    _application: ffi::OutstationApplication,
+    _information: ffi::OutstationInformation,
+    _control_handler: ffi::ControlHandler,
+    _listener: ffi::ClientStateListener,
+    _tls_config: ffi::TlsClientConfig,
+) -> Result<*mut crate::Outstation, ffi::ParamError> {
+    Err(ffi::ParamError::NoSupport)
+}
+
+#[cfg(feature = "tls")]
+#[allow(clippy::too_many_arguments)] // TODO
+pub(crate) unsafe fn outstation_create_tls_client(
+    runtime: *mut crate::Runtime,
+    link_error_mode: ffi::LinkErrorMode,
+    endpoints: *mut crate::EndpointList,
+    connect_strategy: ffi::ConnectStrategy,
+    connect_options: *mut crate::ConnectOptions,
+    config: ffi::OutstationConfig,
+    application: ffi::OutstationApplication,
+    information: ffi::OutstationInformation,
+    control_handler: ffi::ControlHandler,
+    listener: ffi::ClientStateListener,
+    tls_config: ffi::TlsClientConfig,
+) -> Result<*mut crate::Outstation, ffi::ParamError> {
+    let runtime = runtime.as_ref().ok_or(ffi::ParamError::NullParameter)?;
+    let endpoints = endpoints.as_ref().ok_or(ffi::ParamError::NullParameter)?;
+    let connect_options = connect_options
+        .as_ref()
+        .map(|x| x.inner)
+        .unwrap_or_else(Default::default);
+
+    let config = convert_outstation_config(config)?;
+    let tls_config = tls_config.try_into()?;
+
+    let _enter = runtime.enter();
+    let handle = dnp3::tcp::tls::spawn_outstation_tls_client(
+        link_error_mode.into(),
+        endpoints.clone(),
+        connect_strategy.into(),
+        connect_options,
+        config,
+        Box::new(application),
+        Box::new(information),
+        Box::new(control_handler),
+        Box::new(listener),
+        tls_config,
+    );
+
+    let handle = Box::new(crate::Outstation {
+        handle,
+        runtime: runtime.handle(),
+    });
+
+    Ok(Box::into_raw(handle))
+}
+
 #[cfg(not(feature = "serial"))]
 #[allow(clippy::too_many_arguments)] // TODO
 pub unsafe fn outstation_create_serial_session(

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -212,12 +212,74 @@ fn define_outstation(
         .param(
             "listener",
             shared.client_state_listener.clone(),
-            "TCP connection listener used to receive updates on the status of the connection",
+            "Connection listener used to receive updates on the status of the connection",
         )?
         .returns(outstation.clone(), "Outstation instance")?
         .fails_with(shared.error_type.clone())?
         .doc(doc("Create an outstation instance running as a TCP client"))?
         .build_static("create_tcp_client")?;
+
+    let outstation_create_tls_client_fn = lib
+        .define_function("outstation_create_tls_client")?
+        .param(
+            "runtime",
+            shared.runtime_class.clone(),
+            "runtime on which to spawn the outstation",
+        )?
+        .param(
+            "link_error_mode",
+            shared.link_error_mode.clone(),
+            "Controls how link errors are handled with respect to the TCP session",
+        )?
+        .param(
+            "endpoints",
+            shared.endpoint_list.declaration(),
+            "List of IP endpoints.",
+        )?
+        .param(
+            "connect_strategy",
+            shared.connect_strategy.clone(),
+            "Controls the timing of (re)connection attempts",
+        )?
+        .param(
+            "connect_options",
+            shared.connect_options.declaration(),
+            "Options that control the TCP connection process",
+        )?
+        .param(
+            "config",
+            types.outstation_config.clone(),
+            "outstation configuration",
+        )?
+        .param(
+            "application",
+            types.outstation_application.clone(),
+            "application interface",
+        )?
+        .param(
+            "information",
+            types.outstation_information.clone(),
+            "informational events interface",
+        )?
+        .param(
+            "control_handler",
+            types.control_handler.clone(),
+            "control handler interface",
+        )?
+        .param(
+            "listener",
+            shared.client_state_listener.clone(),
+            "Connection listener used to receive updates on the status of the connection",
+        )?
+        .param(
+            "tls_config",
+            shared.tls_client_config.clone(),
+            "TLS client configuration",
+        )?
+        .returns(outstation.clone(), "Outstation instance")?
+        .fails_with(shared.error_type.clone())?
+        .doc(doc("Create an outstation instance running as a TLS client"))?
+        .build_static("create_tls_client")?;
 
     let outstation_create_serial_session_fn = lib
         .define_function("outstation_create_serial_session")?
@@ -397,6 +459,7 @@ fn define_outstation(
         .static_method(outstation_create_serial_session_fault_tolerant_fn)?
         .static_method(outstation_create_serial_session_2_fn)?
         .static_method(outstation_create_tcp_client_fn)?
+        .static_method(outstation_create_tls_client_fn)?
         .method(enable)?
         .method(disable)?
         .method(execute_transaction)?

--- a/ffi/dnp3-schema/src/outstation.rs
+++ b/ffi/dnp3-schema/src/outstation.rs
@@ -157,22 +157,79 @@ pub(crate) fn define(lib: &mut LibraryBuilder, shared_def: &SharedDefinitions) -
 
 fn define_outstation(
     lib: &mut LibraryBuilder,
-    shared_def: &SharedDefinitions,
+    shared: &SharedDefinitions,
     types: &OutstationTypes,
 ) -> BackTraced<ClassHandle> {
     let outstation = lib.declare_class("outstation")?;
+
+    let outstation_create_tcp_client_fn = lib
+        .define_function("outstation_create_tcp_client")?
+        .param(
+            "runtime",
+            shared.runtime_class.clone(),
+            "runtime on which to spawn the outstation",
+        )?
+        .param(
+            "link_error_mode",
+            shared.link_error_mode.clone(),
+            "Controls how link errors are handled with respect to the TCP session",
+        )?
+        .param(
+            "endpoints",
+            shared.endpoint_list.declaration(),
+            "List of IP endpoints.",
+        )?
+        .param(
+            "connect_strategy",
+            shared.connect_strategy.clone(),
+            "Controls the timing of (re)connection attempts",
+        )?
+        .param(
+            "connect_options",
+            shared.connect_options.declaration(),
+            "Options that control the TCP connection process",
+        )?
+        .param(
+            "config",
+            types.outstation_config.clone(),
+            "outstation configuration",
+        )?
+        .param(
+            "application",
+            types.outstation_application.clone(),
+            "application interface",
+        )?
+        .param(
+            "information",
+            types.outstation_information.clone(),
+            "informational events interface",
+        )?
+        .param(
+            "control_handler",
+            types.control_handler.clone(),
+            "control handler interface",
+        )?
+        .param(
+            "listener",
+            shared.client_state_listener.clone(),
+            "TCP connection listener used to receive updates on the status of the connection",
+        )?
+        .returns(outstation.clone(), "Outstation instance")?
+        .fails_with(shared.error_type.clone())?
+        .doc(doc("Create an outstation instance running as a TCP client"))?
+        .build_static("create_tcp_client")?;
 
     let outstation_create_serial_session_fn = lib
         .define_function("outstation_create_serial_session")?
         .param(
             "runtime",
-            shared_def.runtime_class.clone(),
+            shared.runtime_class.clone(),
             "runtime on which to spawn the outstation",
         )?
         .param("serial_path", StringType, "Path of the serial device")?
         .param(
             "settings",
-            shared_def.serial_port_settings.clone(),
+            shared.serial_port_settings.clone(),
             "settings for the serial port",
         )?
         .param(
@@ -199,7 +256,7 @@ fn define_outstation(
             outstation.clone(),
             "Outstation instance or {null} if the port cannot be opened",
         )?
-        .fails_with(shared_def.error_type.clone())?
+        .fails_with(shared.error_type.clone())?
         .doc(
             doc("Create an outstation instance running on a serial port")
                 .details("The port is opened immediately on the calling thread and fails if not successful")
@@ -211,13 +268,13 @@ fn define_outstation(
         .define_function("outstation_create_serial_session_fault_tolerant")?
         .param(
             "runtime",
-            shared_def.runtime_class.clone(),
+            shared.runtime_class.clone(),
             "runtime on which to spawn the outstation",
         )?
         .param("serial_path", StringType, "Path of the serial device")?
         .param(
             "settings",
-            shared_def.serial_port_settings.clone(),
+            shared.serial_port_settings.clone(),
             "settings for the serial port",
         )?
         .param("open_retry_delay", DurationType::Milliseconds, "delay between attempts to open the serial port")?
@@ -245,23 +302,23 @@ fn define_outstation(
             outstation.clone(),
             "Outstation instance or {null} if the port cannot be opened",
         )?
-        .fails_with(shared_def.error_type.clone())?
+        .fails_with(shared.error_type.clone())?
         .doc(
             doc("This method is implemented in terms of {class:outstation.create_serial_session_2()} but without a port listener")
         )?
         .build_static("create_serial_session_fault_tolerant")?;
 
-    let outstation_create_serial_session_2 = lib
+    let outstation_create_serial_session_2_fn = lib
         .define_function("outstation_create_serial_session_2")?
         .param(
             "runtime",
-            shared_def.runtime_class.clone(),
+            shared.runtime_class.clone(),
             "runtime on which to spawn the outstation",
         )?
         .param("serial_path", StringType, "Path of the serial device")?
         .param(
             "settings",
-            shared_def.serial_port_settings.clone(),
+            shared.serial_port_settings.clone(),
             "settings for the serial port",
         )?
         .param("open_retry_delay", DurationType::Milliseconds, "delay between attempts to open the serial port")?
@@ -286,14 +343,14 @@ fn define_outstation(
             "control handler interface",
         )?
         .param("port_listener",
-            shared_def.port_state_listener.clone(),
+               shared.port_state_listener.clone(),
             "port state listener"
         )?
         .returns(
             outstation.clone(),
             "Outstation instance or {null} if the port cannot be opened",
         )?
-        .fails_with(shared_def.error_type.clone())?
+        .fails_with(shared.error_type.clone())?
         .doc(
             doc("Create an outstation instance running on a serial port which is tolerant to the serial port being added and removed")
         )?
@@ -316,20 +373,20 @@ fn define_outstation(
 
     let set_decode_level = lib
         .define_method("set_decode_level", outstation.clone())?
-        .param("level", shared_def.decode_level.clone(), "Decode log")?
-        .fails_with(shared_def.error_type.clone())?
+        .param("level", shared.decode_level.clone(), "Decode log")?
+        .fails_with(shared.error_type.clone())?
         .doc("Set decoding log level")?
         .build()?;
 
     let enable = lib
         .define_method("enable", outstation.clone())?
-        .fails_with(shared_def.error_type.clone())?
+        .fails_with(shared.error_type.clone())?
         .doc("enable communications")?
         .build()?;
 
     let disable = lib
         .define_method("disable", outstation.clone())?
-        .fails_with(shared_def.error_type.clone())?
+        .fails_with(shared.error_type.clone())?
         .doc("disable communications")?
         .build()?;
 
@@ -338,7 +395,8 @@ fn define_outstation(
         .destructor(destructor)?
         .static_method(outstation_create_serial_session_fn)?
         .static_method(outstation_create_serial_session_fault_tolerant_fn)?
-        .static_method(outstation_create_serial_session_2)?
+        .static_method(outstation_create_serial_session_2_fn)?
+        .static_method(outstation_create_tcp_client_fn)?
         .method(enable)?
         .method(disable)?
         .method(execute_transaction)?


### PR DESCRIPTION
Add `TCP` and `TLS` client modes for the outstation in Rust and the FFI.

