### PR TITLE
Add optional serde support for public config types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         feature-args:
           - "--no-default-features"
+          - "--no-default-features serialization"
           - "--no-default-features --features serial"
           - "--no-default-features --features tls"
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "futures",
  "rand",
  "scursor",
+ "serde",
  "sfio-rustls-config",
  "sfio-tokio-mock-io",
  "tokio",

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -24,21 +24,28 @@ sfio-rustls-config = { version = "0.1.1", optional = true }
 tokio-rustls = { version = "0.24", features = ["dangerous_configuration", "tls12"], default-features = false, optional = true }
 
 # serial dependencies
-tokio-serial = { version = "=5.4.3", optional = true }
+tokio-serial = { version = "=5.4.3", default-features = false, optional = true }
+
+# serde support
+serde =  { version = "^1.0", features = ["derive"], default-features = false, optional = true }
 
 [dev-dependencies]
-futures = { version = "0.3.24" }
-clap = { version = "4.0", features = ["derive"] }
-sfio-tokio-mock-io = "0.2.0"
 assert_matches = "1.2"
-tracing-subscriber = "0.3"
+clap = { version = "4.0", features = ["derive"] }
+futures = { version = "0.3.24" }
+rand = "0.8"
+sfio-tokio-mock-io = "0.2.0"
+tokio = { version = "1", features = ["test-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-stream = { version = "0.1.1" }
-rand = "0.8"
-tokio = { version = "1", features = ["test-util"] }
+tracing-subscriber = "0.3"
+
+
 
 [features]
 default = ["tls", "serial"]
 ffi = [] # this feature flag is only used when building the FFI
 tls = ["sfio-rustls-config", "tokio-rustls"]
 serial = ["tokio-serial"]
+# Public configuration types dervie both serde::Deserialize and serde::Serialize
+serialization = ["serde"]

--- a/dnp3/README.md
+++ b/dnp3/README.md
@@ -24,6 +24,9 @@ Default features can be disabled at compile time:
 * `tls` - Build the library with support for mutually authenticated TLS
 * `serial` - Build the library with support for serial ports
 
+Optional features that may be enabled at compile time:
+* `serialize` - Add [serde](https://docs.rs/crate/serde/latest) de(serialization) support for public configuration types.
+
 # License
 
 This crate is made available under a non-commercial / non-production license.

--- a/dnp3/codegen/src/main/scala/dev/gridio/dnp3/codegen/render/modules/EnumModule.scala
+++ b/dnp3/codegen/src/main/scala/dev/gridio/dnp3/codegen/render/modules/EnumModule.scala
@@ -72,9 +72,14 @@ class EnumModule(enums: List[EnumModel]) extends Module {
         "#[derive(Copy, Clone, Debug, PartialEq, Eq)]"
       }
 
+      def serde = {
+        "#[cfg_attr(feature = \"serialization\", derive(serde::Serialize, serde::Deserialize))]"
+      }
+
 
       model.comments.map(commented).iterator ++
         derives.eol ++
+        serde.eol ++
         bracket(s"pub enum ${model.name}") {
           if(model.captureUnknownValues) {
             values ++ Iterator(commented("captures any value not defined in the enumeration"), "Unknown(u8),")

--- a/dnp3/src/app/app_enums.rs
+++ b/dnp3/src/app/app_enums.rs
@@ -14,6 +14,7 @@ use scursor::{WriteCursor, WriteError};
 
 /// Application object header types
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum QualifierCode {
     ///  8-bit start stop (value == 0x00)
     Range8,
@@ -71,6 +72,7 @@ impl QualifierCode {
 
 /// Application layer function code enumeration
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum FunctionCode {
     ///  Master sends this to an outstation to confirm the receipt of an Application Layer fragment (value == 0)
     Confirm,

--- a/dnp3/src/app/buffer_size.rs
+++ b/dnp3/src/app/buffer_size.rs
@@ -2,6 +2,7 @@ use crate::util::buffer::Buffer;
 
 /// Validated buffer size for use in configuration structs
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferSize<const MIN_SIZE: usize = 249, const DEFAULT_SIZE: usize = 2048> {
     size: usize,
 }

--- a/dnp3/src/app/buffer_size.rs
+++ b/dnp3/src/app/buffer_size.rs
@@ -2,7 +2,10 @@ use crate::util::buffer::Buffer;
 
 /// Validated buffer size for use in configuration structs
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct BufferSize<const MIN_SIZE: usize = 249, const DEFAULT_SIZE: usize = 2048> {
     size: usize,
 }

--- a/dnp3/src/app/control_enums.rs
+++ b/dnp3/src/app/control_enums.rs
@@ -14,6 +14,10 @@ use scursor::{WriteCursor, WriteError};
 
 /// Field is used in conjunction with the `OpType` field to specify a control operation
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum TripCloseCode {
     ///  not specified (value == 0)
     Nul,
@@ -53,6 +57,10 @@ impl TripCloseCode {
 
 /// Field used in conjunction with the `TCC` field to specify a control operation
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum OpType {
     ///  not specified (value == 0)
     Nul,
@@ -96,6 +104,10 @@ impl OpType {
 
 /// Enumeration received from an outstation in response to command request
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum CommandStatus {
     ///  command was accepted, initiated, or queued (value == 0)
     Success,

--- a/dnp3/src/app/control_types.rs
+++ b/dnp3/src/app/control_types.rs
@@ -2,6 +2,10 @@ use crate::app::control_enums::{OpType, TripCloseCode};
 
 /// Control code field used within g12v1
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct ControlCode {
     /// This field is used in conjunction with the `op_type` field to specify a control operation
     pub tcc: TripCloseCode,

--- a/dnp3/src/app/timeout.rs
+++ b/dnp3/src/app/timeout.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 /// A wrapper around a std::time::Duration
 /// that ensures values are in the range `[1ms .. 1hour]`
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialization", serde(transparent))]
 pub struct Timeout {
     pub(crate) value: Duration,
 }

--- a/dnp3/src/app/timeout.rs
+++ b/dnp3/src/app/timeout.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 /// A wrapper around a std::time::Duration
 /// that ensures values are in the range `[1ms .. 1hour]`
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[cfg_attr(feature = "serialization", serde(transparent))]
 pub struct Timeout {
     pub(crate) value: Duration,

--- a/dnp3/src/decode.rs
+++ b/dnp3/src/decode.rs
@@ -1,6 +1,9 @@
 /// Controls the decoding of transmitted and received data at the application, transport, and link layer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct DecodeLevel {
     /// Controls application layer decoding
     pub application: AppDecodeLevel,
@@ -14,7 +17,10 @@ pub struct DecodeLevel {
 
 /// Controls how transmitted and received application-layer fragments are decoded at the INFO log level
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum AppDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -28,7 +34,10 @@ pub enum AppDecodeLevel {
 
 /// Controls how transmitted and received transport segments are decoded at the INFO log level
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum TransportDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -40,7 +49,10 @@ pub enum TransportDecodeLevel {
 
 /// Controls how transmitted and received link frames are decoded at the INFO log level
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum LinkDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -52,7 +64,10 @@ pub enum LinkDecodeLevel {
 
 /// Controls how data transmitted at the physical layer (TCP, serial, etc) is logged
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum PhysDecodeLevel {
     /// Log nothing
     Nothing,

--- a/dnp3/src/decode.rs
+++ b/dnp3/src/decode.rs
@@ -1,5 +1,6 @@
 /// Controls the decoding of transmitted and received data at the application, transport, and link layer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecodeLevel {
     /// Controls application layer decoding
     pub application: AppDecodeLevel,
@@ -13,6 +14,7 @@ pub struct DecodeLevel {
 
 /// Controls how transmitted and received application-layer fragments are decoded at the INFO log level
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum AppDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -26,6 +28,7 @@ pub enum AppDecodeLevel {
 
 /// Controls how transmitted and received transport segments are decoded at the INFO log level
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum TransportDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -37,6 +40,7 @@ pub enum TransportDecodeLevel {
 
 /// Controls how transmitted and received link frames are decoded at the INFO log level
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum LinkDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -48,6 +52,7 @@ pub enum LinkDecodeLevel {
 
 /// Controls how data transmitted at the physical layer (TCP, serial, etc) is logged
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum PhysDecodeLevel {
     /// Log nothing
     Nothing,

--- a/dnp3/src/link/mod.rs
+++ b/dnp3/src/link/mod.rs
@@ -41,7 +41,10 @@ pub enum LinkErrorMode {
 /// Certain special addresses are not allowed by the standard to be used
 /// as endpoint addresses.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct EndpointAddress {
     address: u16,
 }

--- a/dnp3/src/link/mod.rs
+++ b/dnp3/src/link/mod.rs
@@ -41,6 +41,7 @@ pub enum LinkErrorMode {
 /// Certain special addresses are not allowed by the standard to be used
 /// as endpoint addresses.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndpointAddress {
     address: u16,
 }

--- a/dnp3/src/outstation/config.rs
+++ b/dnp3/src/outstation/config.rs
@@ -5,6 +5,7 @@ use crate::outstation::database::{ClassZeroConfig, EventBufferConfig};
 
 /// describes whether an optional feature is enabled or disabled
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum Feature {
     /// feature is enabled
     Enabled,
@@ -14,6 +15,7 @@ pub enum Feature {
 
 /// Optional features that can be enabled or disabled
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub struct Features {
     /// if enabled, the outstation responds to the self address (default == Disabled)
     pub self_address: Feature,
@@ -35,6 +37,7 @@ impl Default for Features {
 
 /// Outstation configuration parameters
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutstationConfig {
     /// address of the outstation
     pub outstation_address: EndpointAddress,
@@ -49,20 +52,24 @@ pub struct OutstationConfig {
     /// buffer size for received requests, i.e. the transport reassembly buffer
     pub rx_buffer_size: BufferSize,
     /// initial decoding level
+    #[cfg_attr(feature = "serialization", serde(default))]
     pub decode_level: DecodeLevel,
     /// confirm timeout for solicited and unsolicited responses
     pub confirm_timeout: Timeout,
     /// timeout after which a matching OPERATE will fail with SELECT_TIMEOUT
     pub select_timeout: Timeout,
     /// optional features that can be enabled
+    #[cfg_attr(feature = "serialization", serde(default))]
     pub features: Features,
     /// number of non-regenerated unsolicited retries to perform
+    #[cfg_attr(feature = "serialization", serde(default))]
     pub max_unsolicited_retries: Option<usize>,
     /// amount of time to wait after a failed unsolicited response series before starting another series
     pub unsolicited_retry_delay: std::time::Duration,
     /// time without any link activity before the outstation will send REQUEST_LINK_STATES
     ///
     /// A value of `None` will disable this feature
+    #[cfg_attr(feature = "serialization", serde(default))]
     pub keep_alive_timeout: Option<std::time::Duration>,
     /// Maximum number of headers that will be processed
     /// in a READ request. Internally, this controls the size of a
@@ -70,10 +77,13 @@ pub struct OutstationConfig {
     /// value of `DEFAULT_READ_REQUEST_HEADERS` is always enforced.
     /// Requesting more than this number will result in the PARAMETER_ERROR
     /// IIN bit being set in the response.
+    #[cfg_attr(feature = "serialization", serde(default))]
     pub max_read_request_headers: Option<u16>,
     /// Maximum number of controls in a single request
+    #[cfg_attr(feature = "serialization", serde(default))]
     pub max_controls_per_request: Option<u16>,
     /// controls responses to class 0 READ requests
+    #[cfg_attr(feature = "serialization", serde(default))]
     pub class_zero: ClassZeroConfig,
 }
 

--- a/dnp3/src/outstation/config.rs
+++ b/dnp3/src/outstation/config.rs
@@ -5,7 +5,10 @@ use crate::outstation::database::{ClassZeroConfig, EventBufferConfig};
 
 /// describes whether an optional feature is enabled or disabled
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum Feature {
     /// feature is enabled
     Enabled,
@@ -15,7 +18,10 @@ pub enum Feature {
 
 /// Optional features that can be enabled or disabled
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct Features {
     /// if enabled, the outstation responds to the self address (default == Disabled)
     pub self_address: Feature,
@@ -37,7 +43,10 @@ impl Default for Features {
 
 /// Outstation configuration parameters
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct OutstationConfig {
     /// address of the outstation
     pub outstation_address: EndpointAddress,

--- a/dnp3/src/outstation/database/config.rs
+++ b/dnp3/src/outstation/database/config.rs
@@ -1,5 +1,9 @@
 /// Enum representing all possible `BinaryInput` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventBinaryInputVariation {
     /// Binary Input Event - without time
     Group2Var1,
@@ -11,6 +15,10 @@ pub enum EventBinaryInputVariation {
 
 /// Enum representing all possible `BinaryOutputStatus` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventBinaryOutputStatusVariation {
     /// Binary Output Event - Output Status without time
     Group11Var1,
@@ -20,6 +28,10 @@ pub enum EventBinaryOutputStatusVariation {
 
 /// Enum representing all possible `DoubleBitBinaryInput` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventDoubleBitBinaryInputVariation {
     /// Double-bit Binary Input Event - without time
     Group4Var1,
@@ -31,6 +43,10 @@ pub enum EventDoubleBitBinaryInputVariation {
 
 /// Enum representing all possible `Counter` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventCounterVariation {
     /// Counter Event - 32-bit with flag
     Group22Var1,
@@ -44,6 +60,10 @@ pub enum EventCounterVariation {
 
 /// Enum representing all possible `FrozenCounter` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventFrozenCounterVariation {
     /// Frozen Counter Event - 32-bit with flag
     Group23Var1,
@@ -57,6 +77,10 @@ pub enum EventFrozenCounterVariation {
 
 /// Enum representing all possible `AnalogInput` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventAnalogInputVariation {
     /// Analog Input Event - 32-bit with flag
     Group32Var1,
@@ -78,6 +102,10 @@ pub enum EventAnalogInputVariation {
 
 /// Enum representing all possible `FrozenAnalogInput` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventFrozenAnalogInputVariation {
     /// Frozen Analog Input Event - 32-bit with flag
     Group33Var1,
@@ -99,6 +127,10 @@ pub enum EventFrozenAnalogInputVariation {
 
 /// Enum representing all possible `AnalogOutputStatus` event variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum EventAnalogOutputStatusVariation {
     /// Analog Output Event - 32-bit with flag
     Group42Var1,
@@ -120,10 +152,18 @@ pub enum EventAnalogOutputStatusVariation {
 
 // This is always g111vX
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub(crate) struct EventOctetStringVariation;
 
 /// Enum representing all possible `BinaryInput` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticBinaryInputVariation {
     /// Binary Input - Packed Format
     Group1Var1,
@@ -133,6 +173,10 @@ pub enum StaticBinaryInputVariation {
 
 /// Enum representing all possible `BinaryOutputStatus` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticBinaryOutputStatusVariation {
     /// Binary Output - Packed Format
     Group10Var1,
@@ -142,6 +186,10 @@ pub enum StaticBinaryOutputStatusVariation {
 
 /// Enum representing all possible `DoubleBitBinaryInput` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticDoubleBitBinaryInputVariation {
     /// Double-bit Binary Input - Packed Format
     Group3Var1,
@@ -151,6 +199,10 @@ pub enum StaticDoubleBitBinaryInputVariation {
 
 /// Enum representing all possible `Counter` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticCounterVariation {
     /// Counter - 32-bit with flag
     Group20Var1,
@@ -164,6 +216,10 @@ pub enum StaticCounterVariation {
 
 /// Enum representing all possible `FrozenCounter` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticFrozenCounterVariation {
     /// Frozen Counter - 32-bit with flag
     Group21Var1,
@@ -181,6 +237,10 @@ pub enum StaticFrozenCounterVariation {
 
 /// Enum representing all possible `AnalogInput` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticAnalogInputVariation {
     /// Analog Input - 32-bit with flag
     Group30Var1,
@@ -198,6 +258,10 @@ pub enum StaticAnalogInputVariation {
 
 /// Enum representing all possible `FrozenAnalogInput` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticFrozenAnalogInputVariation {
     /// Frozen Analog Input - 32-bit with flag
     Group31Var1,
@@ -219,6 +283,10 @@ pub enum StaticFrozenAnalogInputVariation {
 
 /// Enum representing all possible `AnalogOutputStatus` static variations
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum StaticAnalogOutputStatusVariation {
     /// Analog Output Status - 32-bit with flag
     Group40Var1,
@@ -232,6 +300,10 @@ pub enum StaticAnalogOutputStatusVariation {
 
 /// this is not currently public, but it could be a future release
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub(crate) enum AnalogInputDeadBandVariation {
     /// Analog Input Dead-band - 16-bit
     Group34Var1,
@@ -243,10 +315,18 @@ pub(crate) enum AnalogInputDeadBandVariation {
 
 // This is always g110vX
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub(crate) struct StaticOctetStringVariation;
 
 /// configuration for a `BinaryInput` point
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct BinaryInputConfig {
     /// default static variation
     pub s_var: StaticBinaryInputVariation,
@@ -256,6 +336,10 @@ pub struct BinaryInputConfig {
 
 /// configuration for a `DoubleBitBinaryInput` point
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct DoubleBitBinaryInputConfig {
     /// default static variation
     pub s_var: StaticDoubleBitBinaryInputVariation,
@@ -265,6 +349,10 @@ pub struct DoubleBitBinaryInputConfig {
 
 /// configuration for a `BinaryOutputStatus` point
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct BinaryOutputStatusConfig {
     /// default static variation
     pub s_var: StaticBinaryOutputStatusVariation,
@@ -274,6 +362,10 @@ pub struct BinaryOutputStatusConfig {
 
 /// configuration for a `Counter` point
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct CounterConfig {
     /// default static variation
     pub s_var: StaticCounterVariation,
@@ -285,6 +377,10 @@ pub struct CounterConfig {
 
 /// configuration for a `FrozenCounter` point
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct FrozenCounterConfig {
     /// default static variation
     pub s_var: StaticFrozenCounterVariation,
@@ -296,6 +392,10 @@ pub struct FrozenCounterConfig {
 
 /// configuration for an `AnalogInput` point
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct AnalogInputConfig {
     /// default static variation
     pub s_var: StaticAnalogInputVariation,
@@ -307,6 +407,10 @@ pub struct AnalogInputConfig {
 
 /// configuration for an `AnalogOutputStatus` point
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct AnalogOutputStatusConfig {
     /// default static variation
     pub s_var: StaticAnalogOutputStatusVariation,
@@ -319,6 +423,10 @@ pub struct AnalogOutputStatusConfig {
 /// Octet strings don't actually need any configuration b/c the transmitted variation is determined
 /// by the size. This struct is more of a placeholder required by a couple of internal traits.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct OctetStringConfig;
 
 impl BinaryInputConfig {

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -43,6 +43,7 @@ pub enum EventClass {
 
 /// Controls which types are reported during a class 0 READ
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClassZeroConfig {
     /// If true, Binary Inputs are reported in Class 0 READ requests
     pub binary: bool,
@@ -108,6 +109,7 @@ impl Default for ClassZeroConfig {
 ///
 /// A value of zero means that events will not be buffered for that type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventBufferConfig {
     /// maximum number of binary input events (g2)
     pub max_binary: u16,

--- a/dnp3/src/outstation/database/mod.rs
+++ b/dnp3/src/outstation/database/mod.rs
@@ -43,7 +43,10 @@ pub enum EventClass {
 
 /// Controls which types are reported during a class 0 READ
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct ClassZeroConfig {
     /// If true, Binary Inputs are reported in Class 0 READ requests
     pub binary: bool,
@@ -109,7 +112,10 @@ impl Default for ClassZeroConfig {
 ///
 /// A value of zero means that events will not be buffered for that type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct EventBufferConfig {
     /// maximum number of binary input events (g2)
     pub max_binary: u16,


### PR DESCRIPTION
This is extremely useful for avoiding duplication and mapping if you want to write a Rust application that uses the master or outstation and are using config files.