### PR TITLE
Bugfix/309

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,3 @@ members = [
     "ffi/dnp3-ffi-java",
 ]
 
-[profile.release]
-lto=true

--- a/dnp3/src/app/header.rs
+++ b/dnp3/src/app/header.rs
@@ -483,7 +483,7 @@ impl Iin {
         })
     }
 
-    pub(crate) fn has_request_error(self) -> bool {
+    pub(crate) fn has_bad_request_error(self) -> bool {
         self.iin2.get_no_func_code_support()
             || self.iin2.get_object_unknown()
             || self.iin2.get_parameter_error()

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -53,7 +53,7 @@ pub enum TaskError {
     RejectedByIin2(Iin),
     /// A response to the task's request was malformed
     MalformedResponse(ObjectParseError),
-    /// The response contains headers that don't match the request
+    /// The response contains unexpected or invalid headers or data that don't match the request
     UnexpectedResponseHeaders,
     /// Non-final response not requesting confirmation
     NonFinWithoutCon,
@@ -135,19 +135,6 @@ pub enum TimeSyncError {
     /// Outstation returned an IIN.2 error
     IinError(Iin2),
 }
-
-impl TimeSyncError {
-    pub(crate) fn from_iin(iin: Iin) -> Result<(), TimeSyncError> {
-        if iin.iin1.get_need_time() {
-            return Err(TimeSyncError::StillNeedsTime);
-        }
-        if iin.has_request_error() {
-            return Err(TimeSyncError::IinError(iin.iin2));
-        }
-        Ok(())
-    }
-}
-
 /// Parent error type for command tasks
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CommandError {

--- a/dnp3/src/master/error.rs
+++ b/dnp3/src/master/error.rs
@@ -49,6 +49,8 @@ pub enum TaskError {
     Link(LinkError),
     /// An error occurred at the transport/app level
     Transport,
+    /// Outstation returned IIN.2 bit(s) indicating failure
+    RejectedByIin2(Iin),
     /// A response to the task's request was malformed
     MalformedResponse(ObjectParseError),
     /// The response contains headers that don't match the request
@@ -247,6 +249,9 @@ impl std::fmt::Display for TaskError {
             TaskError::NoSuchAssociation(x) => write!(f, "no association with address: {x}"),
             TaskError::BadEncoding(x) => {
                 write!(f, "Encoding error: {x}")
+            }
+            TaskError::RejectedByIin2(iin) => {
+                write!(f, "Rejected by IIN2: {}", iin.iin2)
             }
         }
     }

--- a/dnp3/src/master/handler.rs
+++ b/dnp3/src/master/handler.rs
@@ -20,7 +20,7 @@ use crate::master::tasks::get_file_info::GetFileInfoTask;
 use crate::master::tasks::read::SingleReadTask;
 use crate::master::tasks::restart::{RestartTask, RestartType};
 use crate::master::tasks::time::TimeSyncTask;
-use crate::master::tasks::{NonReadTask, Task};
+use crate::master::tasks::{AppTask, NonReadTask, Task};
 use crate::master::{
     DeadBandHeader, DirReadConfig, DirectoryReader, FileCredentials, FileError, FileInfo,
     FileReadConfig, FileReader, Headers, WriteError,
@@ -336,7 +336,7 @@ impl AssociationHandle {
             FileReaderType::from_reader(reader),
             credentials,
         );
-        self.send_task(Task::NonRead(NonReadTask::FileRead(task)))
+        self.send_task(Task::App(AppTask::NonRead(NonReadTask::FileRead(task))))
             .await
     }
 
@@ -361,7 +361,7 @@ impl AssociationHandle {
     ) -> Result<FileInfo, FileError> {
         let (promise, reply) = Promise::one_shot();
         let task = GetFileInfoTask::new(file_path.to_string(), promise);
-        self.send_task(Task::NonRead(NonReadTask::GetFileInfo(task)))
+        self.send_task(Task::App(AppTask::NonRead(NonReadTask::GetFileInfo(task))))
             .await?;
         reply.await?
     }

--- a/dnp3/src/master/task.rs
+++ b/dnp3/src/master/task.rs
@@ -418,7 +418,7 @@ impl MasterSession {
                                         }
                                         Ok(association) => {
                                             association.process_iin(response.header.iin);
-                                            return match task.handle(association, response).await {
+                                            return match task.handle_response(association, response).await? {
                                                 Some(next) => {
                                                     Ok(NextStep::Continue(next))
                                                 }
@@ -492,7 +492,7 @@ impl MasterSession {
             return Err(TaskError::MultiFragmentResponse);
         }
 
-        if response.header.iin.has_request_error() {
+        if response.header.iin.has_bad_request_error() {
             return Err(TaskError::RejectedByIin2(response.header.iin));
         }
 

--- a/dnp3/src/master/task.rs
+++ b/dnp3/src/master/task.rs
@@ -631,6 +631,10 @@ impl MasterSession {
             return Err(TaskError::NonFinWithoutCon);
         }
 
+        if response.header.iin.has_bad_request_error() {
+            return Err(TaskError::RejectedByIin2(response.header.iin));
+        }
+
         let association = self.associations.get_mut(destination)?;
         association.process_iin(response.header.iin);
         task.process_response(association, response.header, response.objects?)

--- a/dnp3/src/master/task.rs
+++ b/dnp3/src/master/task.rs
@@ -492,6 +492,10 @@ impl MasterSession {
             return Err(TaskError::MultiFragmentResponse);
         }
 
+        if response.header.iin.has_request_error() {
+            return Err(TaskError::RejectedByIin2(response.header.iin));
+        }
+
         Ok(Some(response))
     }
 

--- a/dnp3/src/master/task.rs
+++ b/dnp3/src/master/task.rs
@@ -2,14 +2,14 @@ use tracing::Instrument;
 
 use crate::app::format::write;
 use crate::app::parse::parser::Response;
-use crate::app::{BufferSize, ControlField, FunctionCode, Sequence};
+use crate::app::{BufferSize, ControlField, Sequence};
 use crate::decode::DecodeLevel;
 use crate::link::error::LinkError;
 use crate::link::{EndpointAddress, LinkErrorMode};
 use crate::master::association::{AssociationMap, Next};
 use crate::master::error::TaskError;
 use crate::master::messages::{MasterMsg, Message};
-use crate::master::tasks::{AssociationTask, NonReadTask, ReadTask, RequestWriter, Task};
+use crate::master::tasks::{AppTask, AssociationTask, NonReadTask, ReadTask, RequestWriter, Task};
 use crate::master::{Association, MasterChannelConfig};
 use crate::transport::{TransportReader, TransportResponse, TransportWriter};
 use crate::util::buffer::Buffer;
@@ -274,7 +274,7 @@ impl MasterSession {
 
     /// Run a specific task.
     ///
-    /// Returns an error only if shutdown or link layer error occured.
+    /// Returns an error only if shutdown or link layer error occurred.
     async fn run_task(
         &mut self,
         io: &mut PhysLayer,
@@ -283,13 +283,37 @@ impl MasterSession {
         reader: &mut TransportReader,
     ) -> Result<(), RunError> {
         let result = match task.details {
-            Task::Read(t) => {
-                self.run_read_task(io, task.address, t, writer, reader)
-                    .await
-            }
-            Task::NonRead(t) => {
-                self.run_non_read_task(io, task.address, t, writer, reader)
-                    .await
+            Task::App(t) => {
+                let task_type = t.as_task_type();
+                let function = t.function();
+
+                if let Ok(assoc) = self.associations.get_mut(task.address) {
+                    assoc.notify_task_start(task_type, function, assoc.seq());
+                }
+
+                let res: Result<Sequence, TaskError> = match t {
+                    AppTask::Read(t) => {
+                        self.run_read_task(io, task.address, t, writer, reader)
+                            .await
+                    }
+                    AppTask::NonRead(t) => {
+                        self.run_non_read_task(io, task.address, t, writer, reader)
+                            .await
+                    }
+                };
+
+                if let Ok(assoc) = self.associations.get_mut(task.address) {
+                    match res {
+                        Ok(seq) => {
+                            assoc.notify_task_success(task_type, function, seq);
+                        }
+                        Err(err) => {
+                            assoc.notify_task_fail(task_type, err);
+                        }
+                    }
+                }
+
+                res.map(|_| ())
             }
             Task::LinkStatus(promise) => {
                 match self
@@ -327,39 +351,20 @@ impl MasterSession {
         task: NonReadTask,
         writer: &mut TransportWriter,
         reader: &mut TransportReader,
-    ) -> Result<(), TaskError> {
-        let mut next_task = Some(task);
-        while let Some(task) = next_task {
-            let task_type = task.as_task_type();
-            let task_fc = task.function();
+    ) -> Result<Sequence, TaskError> {
+        let mut next = NextStep::Continue(task);
 
-            // Notify task start
-            if let Ok(association) = self.associations.get_mut(destination) {
-                association.notify_task_start(task_type, task_fc);
-            }
-
-            // Execute task
-            let result = self
-                .run_single_non_read_task(io, destination, task, writer, reader)
-                .await;
-
-            // Notify task result
-            if let Ok(association) = self.associations.get_mut(destination) {
-                match result {
-                    Ok(_) => {
-                        association.notify_task_success(task_type, task_fc);
-                    }
-                    Err(err) => {
-                        association.notify_task_fail(task_type, err);
-                    }
+        loop {
+            next = match next {
+                NextStep::Continue(task) => {
+                    self.run_single_non_read_task(io, destination, task, writer, reader)
+                        .await?
+                }
+                NextStep::Complete(seq) => {
+                    return Ok(seq);
                 }
             }
-
-            // Continue to next task (if there's one)
-            next_task = result?;
         }
-
-        Ok(())
     }
 
     async fn run_single_non_read_task(
@@ -369,7 +374,7 @@ impl MasterSession {
         task: NonReadTask,
         writer: &mut TransportWriter,
         reader: &mut TransportReader,
-    ) -> Result<Option<NonReadTask>, TaskError> {
+    ) -> Result<NextStep, TaskError> {
         let seq = match self.send_request(io, destination, &task, writer).await {
             Ok(seq) => seq,
             Err(err) => {
@@ -413,7 +418,14 @@ impl MasterSession {
                                         }
                                         Ok(association) => {
                                             association.process_iin(response.header.iin);
-                                            return Ok(task.handle(association, response).await);
+                                            return match task.handle(association, response).await {
+                                                Some(next) => {
+                                                    Ok(NextStep::Continue(next))
+                                                }
+                                                None => {
+                                                    Ok(NextStep::Complete(seq))
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -490,32 +502,22 @@ impl MasterSession {
         mut task: ReadTask,
         writer: &mut TransportWriter,
         reader: &mut TransportReader,
-    ) -> Result<(), TaskError> {
-        if let Ok(association) = self.associations.get_mut(destination) {
-            association.notify_task_start(task.as_task_type(), FunctionCode::Read);
-        }
-
+    ) -> Result<Sequence, TaskError> {
         let result = self
             .execute_read_task(io, destination, &mut task, writer, reader)
             .await;
 
-        let mut association = self.associations.get_mut(destination).ok();
+        let association = self.associations.get_mut(destination).ok();
 
         match result {
             Ok(_) => {
                 if let Some(association) = association {
-                    association.notify_task_success(task.as_task_type(), task.function());
                     task.complete(association);
                 } else {
                     task.on_task_error(None, TaskError::NoSuchAssociation(destination));
                 }
             }
-            Err(err) => {
-                if let Some(association) = &mut association {
-                    association.notify_task_fail(task.as_task_type(), err);
-                }
-                task.on_task_error(association, err)
-            }
+            Err(err) => task.on_task_error(association, err),
         }
 
         result
@@ -528,7 +530,7 @@ impl MasterSession {
         task: &mut ReadTask,
         writer: &mut TransportWriter,
         reader: &mut TransportReader,
-    ) -> Result<(), TaskError> {
+    ) -> Result<Sequence, TaskError> {
         let mut seq = self.send_request(io, destination, task, writer).await?;
         let mut is_first = true;
 
@@ -553,7 +555,7 @@ impl MasterSession {
                                     // continue reading responses on the inner loop
                                     ReadResponseAction::Ignore => continue,
                                     // read task complete
-                                    ReadResponseAction::Complete => return Ok(()),
+                                    ReadResponseAction::Complete => return Ok(seq),
                                     // break to the outer loop and read another response
                                     ReadResponseAction::ReadNext => {
                                         is_first = false;
@@ -808,4 +810,9 @@ impl MasterSession {
             association.on_link_activity();
         }
     }
+}
+
+enum NextStep {
+    Continue(NonReadTask),
+    Complete(Sequence),
 }

--- a/dnp3/src/master/tasks/auto.rs
+++ b/dnp3/src/master/tasks/auto.rs
@@ -5,7 +5,7 @@ use crate::app::ResponseHeader;
 use crate::master::association::Association;
 use crate::master::error::TaskError;
 use crate::master::request::EventClasses;
-use crate::master::tasks::{NonReadTask, Task};
+use crate::master::tasks::{AppTask, NonReadTask, Task};
 
 #[derive(Clone)]
 pub(crate) enum AutoTask {
@@ -16,7 +16,7 @@ pub(crate) enum AutoTask {
 
 impl AutoTask {
     pub(crate) fn wrap(self) -> Task {
-        Task::NonRead(NonReadTask::Auto(self))
+        Task::App(AppTask::NonRead(NonReadTask::Auto(self)))
     }
 
     pub(crate) fn write(&self, writer: &mut HeaderWriter) -> Result<(), scursor::WriteError> {

--- a/dnp3/src/master/tasks/deadbands.rs
+++ b/dnp3/src/master/tasks/deadbands.rs
@@ -50,21 +50,14 @@ impl WriteDeadBandsTask {
         self.promise.complete(Err(err.into()))
     }
 
-    pub(crate) fn handle(self, response: Response) -> Option<NonReadTask> {
-        if !response.raw_objects.is_empty() {
+    pub(crate) fn handle(self, response: Response) -> Result<Option<NonReadTask>, TaskError> {
+        if response.raw_objects.is_empty() {
+            self.promise.complete(Ok(()));
+            Ok(None)
+        } else {
             self.promise
                 .complete(Err(WriteError::Task(TaskError::UnexpectedResponseHeaders)));
-            return None;
+            Err(TaskError::UnexpectedResponseHeaders)
         }
-
-        if response.header.iin.has_request_error() {
-            self.promise
-                .complete(Err(WriteError::IinError(response.header.iin.iin2)));
-            return None;
-        }
-
-        self.promise.complete(Ok(()));
-
-        None
     }
 }

--- a/dnp3/src/master/tasks/empty_response.rs
+++ b/dnp3/src/master/tasks/empty_response.rs
@@ -39,21 +39,15 @@ impl EmptyResponseTask {
         self.promise.complete(Err(err.into()))
     }
 
-    pub(crate) fn handle(self, response: Response) -> Option<NonReadTask> {
+    pub(crate) fn handle(self, response: Response) -> Result<Option<NonReadTask>, TaskError> {
         if !response.raw_objects.is_empty() {
             self.promise
                 .complete(Err(WriteError::Task(TaskError::UnexpectedResponseHeaders)));
-            return None;
-        }
-
-        if response.header.iin.has_request_error() {
-            self.promise
-                .complete(Err(WriteError::IinError(response.header.iin.iin2)));
-            return None;
+            return Err(TaskError::UnexpectedResponseHeaders);
         }
 
         self.promise.complete(Ok(()));
 
-        None
+        Ok(None)
     }
 }

--- a/dnp3/src/master/tasks/mod.rs
+++ b/dnp3/src/master/tasks/mod.rs
@@ -318,17 +318,14 @@ impl NonReadTask {
         }
     }
 
-    pub(crate) async fn handle(
+    pub(crate) async fn handle_response(
         self,
         association: &mut Association,
         response: Response<'_>,
-    ) -> Option<NonReadTask> {
+    ) -> Result<Option<NonReadTask>, TaskError> {
         match self {
             Self::Command(task) => task.handle(response),
-            Self::Auto(task) => match response.objects.ok() {
-                Some(headers) => task.handle(association, response.header, headers),
-                None => None,
-            },
+            Self::Auto(task) => task.handle(association, response),
             Self::TimeSync(task) => task.handle(association, response),
             Self::Restart(task) => task.handle(response),
             Self::DeadBands(task) => task.handle(response),

--- a/dnp3/src/master/tasks/mod.rs
+++ b/dnp3/src/master/tasks/mod.rs
@@ -47,11 +47,16 @@ impl AssociationTask {
 
 /// There are two broad categories of tasks. Reads
 /// require handling for multi-fragmented responses.
-pub(crate) enum Task {
+pub(crate) enum AppTask {
     /// Reads require handling for multi-fragmented responses
     Read(ReadTask),
     /// NonRead tasks always require FIR/FIN == 1, but might require multiple read/response cycles, e.g. SBO
     NonRead(NonReadTask),
+}
+
+pub(crate) enum Task {
+    /// An application layer task
+    App(AppTask),
     /// Send link status request
     LinkStatus(Promise<Result<(), TaskError>>),
 }
@@ -62,12 +67,41 @@ pub(crate) enum TaskId {
     Function(FunctionCode),
 }
 
+impl AppTask {
+    pub(crate) fn as_task_type(&self) -> TaskType {
+        match self {
+            AppTask::Read(t) => t.as_task_type(),
+            AppTask::NonRead(t) => t.as_task_type(),
+        }
+    }
+
+    pub(crate) fn function(&self) -> FunctionCode {
+        match self {
+            AppTask::Read(t) => t.function(),
+            AppTask::NonRead(t) => t.function(),
+        }
+    }
+
+    pub(crate) fn on_task_error(self, association: Option<&mut Association>, err: TaskError) {
+        match self {
+            Self::NonRead(task) => task.on_task_error(association, err),
+            Self::Read(task) => task.on_task_error(association, err),
+        }
+    }
+
+    pub(crate) fn get_id(&self) -> TaskId {
+        match self {
+            AppTask::Read(_) => TaskId::Function(FunctionCode::Read),
+            AppTask::NonRead(t) => TaskId::Function(t.function()),
+        }
+    }
+}
+
 impl Task {
     pub(crate) fn on_task_error(self, association: Option<&mut Association>, err: TaskError) {
         match self {
-            Task::NonRead(task) => task.on_task_error(association, err),
-            Task::Read(task) => task.on_task_error(association, err),
-            Task::LinkStatus(promise) => promise.complete(Err(err)),
+            Self::App(task) => task.on_task_error(association, err),
+            Self::LinkStatus(promise) => promise.complete(Err(err)),
         }
     }
 
@@ -76,7 +110,7 @@ impl Task {
     /// Returning Some means the task should proceed, returning None means
     /// the task was cancelled, forget about it.
     pub(crate) fn start(self, association: &mut Association) -> Option<Task> {
-        if let Task::NonRead(task) = self {
+        if let Task::App(AppTask::NonRead(task)) = self {
             return task.start(association).map(|task| task.wrap());
         }
 
@@ -86,8 +120,7 @@ impl Task {
     pub(crate) fn get_id(&self) -> TaskId {
         match self {
             Task::LinkStatus(_) => TaskId::LinkStatus,
-            Task::Read(_) => TaskId::Function(FunctionCode::Read),
-            Task::NonRead(t) => TaskId::Function(t.function()),
+            Task::App(task) => task.get_id(),
         }
     }
 }
@@ -171,7 +204,7 @@ impl From<crate::app::format::WriteError> for TaskError {
 
 impl ReadTask {
     pub(crate) fn wrap(self) -> Task {
-        Task::Read(self)
+        Task::App(AppTask::Read(self))
     }
 
     pub(crate) async fn process_response(
@@ -243,7 +276,7 @@ impl ReadTask {
 
 impl NonReadTask {
     pub(crate) fn wrap(self) -> Task {
-        Task::NonRead(self)
+        Task::App(AppTask::NonRead(self))
     }
 
     pub(crate) fn start(self, association: &mut Association) -> Option<NonReadTask> {

--- a/dnp3/src/master/tests/startup.rs
+++ b/dnp3/src/master/tests/startup.rs
@@ -23,7 +23,7 @@ async fn master_startup_procedure() {
         &[AssocInfoEvent::TaskStart(
             TaskType::DisableUnsolicited,
             FunctionCode::DisableUnsolicited,
-            Sequence::new(1)
+            Sequence::new(0)
         )]
     );
 
@@ -37,12 +37,12 @@ async fn master_startup_procedure() {
             AssocInfoEvent::TaskSuccess(
                 TaskType::DisableUnsolicited,
                 FunctionCode::DisableUnsolicited,
-                Sequence::new(1)
+                Sequence::new(0)
             ),
             AssocInfoEvent::TaskStart(
                 TaskType::StartupIntegrity,
                 FunctionCode::Read,
-                Sequence::new(2)
+                Sequence::new(1)
             ),
         ]
     );
@@ -57,12 +57,12 @@ async fn master_startup_procedure() {
             AssocInfoEvent::TaskSuccess(
                 TaskType::StartupIntegrity,
                 FunctionCode::Read,
-                Sequence::new(2)
+                Sequence::new(1)
             ),
             AssocInfoEvent::TaskStart(
                 TaskType::EnableUnsolicited,
                 FunctionCode::EnableUnsolicited,
-                Sequence::new(3)
+                Sequence::new(2)
             ),
         ]
     );
@@ -76,7 +76,7 @@ async fn master_startup_procedure() {
         &[AssocInfoEvent::TaskSuccess(
             TaskType::EnableUnsolicited,
             FunctionCode::EnableUnsolicited,
-            Sequence::new(3)
+            Sequence::new(2)
         ),]
     );
 }

--- a/ffi/dnp3-ffi/src/master/functions.rs
+++ b/ffi/dnp3-ffi/src/master/functions.rs
@@ -1124,6 +1124,7 @@ macro_rules! define_task_from_impl {
                     TaskError::Shutdown => Self::Shutdown,
                     TaskError::Disabled => Self::NoConnection,
                     TaskError::BadEncoding(_) => Self::BadEncoding,
+                    TaskError::RejectedByIin2(_) => Self::IinError,
                 }
             }
         }

--- a/ffi/dnp3-schema/src/master/mod.rs
+++ b/ffi/dnp3-schema/src/master/mod.rs
@@ -1057,6 +1057,7 @@ fn define_command_mode(lib: &mut LibraryBuilder) -> BackTraced<EnumHandle> {
 
 const TASK_ERRORS: &[(&str, &str)] = &[
     ("too_many_requests", "too many user requests queued"),
+    ("iin_error", "outstation returned an IIN.2 error bit"),
     (
         "bad_response",
         "response was malformed or contained object headers",
@@ -1325,7 +1326,6 @@ fn define_time_sync_callback(
             "Outstation did not clear the NEED_TIME IIN bit",
         )?
         .add_error("system_time_not_available", "System time not available")?
-        .add_error("iin_error", "Outstation indicated an error")?
         .add_task_errors()?
         .doc("Possible errors that can occur during a time synchronization procedure")?
         .build()?;


### PR DESCRIPTION
Refactoring to ensure that all tasks properly call `AssociationInformation::task_fail` when they received any of the IIN.2 error bits. This applies to read and non-read tasks alike. It does NOT apply to link status checks which have no callbacks at all.

Fixes https://github.com/stepfunc/dnp3/issues/309.