### PR TITLE
Master as a tcp server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,9 +1137,9 @@ dependencies = [
 
 [[package]]
 name = "sfio-tokio-ffi"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264a1340f2fa1d79e749b85c1f9965dedbd811d1dfb32a6b354e8253cad2286"
+checksum = "f18d418ee525a2027c0b3e1ab34dc050e1f676834b93389829d40aed2bfefecb"
 dependencies = [
  "oo-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.dependencies]
-sfio-tokio-ffi = "0.8"
+sfio-tokio-ffi = "0.9.0"
 sfio-tracing-ffi = "0.9.0"
 oo-bindgen = "0.8.6"
 tracing = "0.1"

--- a/dnp3/examples/master_tcp_server.rs
+++ b/dnp3/examples/master_tcp_server.rs
@@ -1,12 +1,10 @@
 //! Example of running a master as a TCP server
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::num::NonZeroUsize;
 
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
 
-use dnp3::app::*;
 use dnp3::decode::*;
 use dnp3::link::*;
 use dnp3::master::*;
@@ -65,9 +63,7 @@ impl ConnectionHandler {
 
 impl dnp3::tcp::ConnectionHandler for ConnectionHandler {
     async fn accept(&mut self, _: SocketAddr) -> Result<AcceptAction, Reject> {
-        Ok(AcceptAction::GetLinkIdentity(
-            Timeout::from_secs(1).unwrap(),
-        ))
+        Ok(AcceptAction::GetLinkIdentity)
     }
 
     async fn start(&mut self, _: MasterChannel, _: SocketAddr) {
@@ -124,8 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let _server = spawn_master_tcp_server(
         "127.0.0.1:20000".parse()?,
-        NonZeroUsize::new(10).unwrap(),
-        PhysDecodeLevel::Data,
+        LinkIdConfig::default().decode_level(PhysDecodeLevel::Data),
         ConnectionHandler {
             channels: Default::default(),
         },

--- a/dnp3/examples/master_tcp_server.rs
+++ b/dnp3/examples/master_tcp_server.rs
@@ -1,0 +1,143 @@
+//! Example of running a master as a TCP server
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+
+use tokio_stream::StreamExt;
+use tokio_util::codec::{FramedRead, LinesCodec};
+
+use dnp3::app::*;
+use dnp3::decode::*;
+use dnp3::link::*;
+use dnp3::master::*;
+use dnp3::tcp::*;
+
+/// read handler that does nothing
+#[derive(Copy, Clone)]
+pub struct NullReadHandler;
+
+impl NullReadHandler {
+    /// create a boxed instance of the NullReadHandler
+    pub fn boxed() -> Box<dyn ReadHandler> {
+        Box::new(Self {})
+    }
+}
+
+impl ReadHandler for NullReadHandler {}
+
+#[derive(Copy, Clone)]
+struct NullAssociationHandler;
+
+impl AssociationHandler for NullAssociationHandler {}
+
+#[derive(Copy, Clone)]
+struct NullAssociationInformation;
+
+impl AssociationInformation for NullAssociationInformation {}
+
+struct ConnectionHandler {
+    channels: HashMap<u16, MasterChannel>,
+}
+
+impl ConnectionHandler {
+    async fn setup_channel(
+        channel: &mut MasterChannel,
+        source: u16,
+    ) -> Result<AssociationHandle, Box<dyn std::error::Error>> {
+        let assoc = channel
+            .add_association(
+                EndpointAddress::try_new(source)?,
+                AssociationConfig::new(
+                    EventClasses::all(),
+                    EventClasses::all(),
+                    Classes::all(),
+                    EventClasses::none(),
+                ),
+                Box::new(NullReadHandler),
+                Box::new(NullAssociationHandler),
+                Box::new(NullAssociationInformation),
+            )
+            .await?;
+        channel.enable().await?;
+        Ok(assoc)
+    }
+}
+
+impl dnp3::tcp::ConnectionHandler for ConnectionHandler {
+    async fn accept(&mut self, _: SocketAddr) -> Result<AcceptAction, Reject> {
+        Ok(AcceptAction::GetLinkIdentity(
+            Timeout::from_secs(1).unwrap(),
+        ))
+    }
+
+    async fn start(&mut self, _: MasterChannel, _: SocketAddr) {
+        //
+    }
+
+    async fn accept_link_id(
+        &mut self,
+        addr: SocketAddr,
+        source: u16,
+        _destination: u16,
+    ) -> Result<AcceptConfig, Reject> {
+        tracing::info!("accepted from {addr:?}:{source}");
+        let mut decode_level = DecodeLevel::nothing();
+        decode_level.application = AppDecodeLevel::ObjectValues;
+        let config = AcceptConfig {
+            error_mode: LinkErrorMode::Close,
+            config: MasterChannelConfig {
+                master_address: EndpointAddress::try_new(1).unwrap(),
+                decode_level,
+                tx_buffer_size: Default::default(),
+                rx_buffer_size: Default::default(),
+            },
+        };
+        Ok(config)
+    }
+
+    async fn start_with_link_id(
+        &mut self,
+        mut channel: MasterChannel,
+        _addr: SocketAddr,
+        source: u16,
+        destination: u16,
+    ) {
+        tracing::info!("start with source = {source} dest = {destination}");
+
+        match Self::setup_channel(&mut channel, source).await {
+            Ok(_) => {
+                self.channels.insert(source, channel);
+            }
+            Err(err) => {
+                tracing::warn!("channel setup failed: {err}");
+            }
+        }
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
+    let _server = spawn_master_tcp_server(
+        "127.0.0.1:20000".parse()?,
+        NonZeroUsize::new(10).unwrap(),
+        PhysDecodeLevel::Data,
+        ConnectionHandler {
+            channels: Default::default(),
+        },
+    )
+    .await?;
+
+    let mut reader = FramedRead::new(tokio::io::stdin(), LinesCodec::new());
+
+    loop {
+        let cmd = reader.next().await.unwrap()?;
+        if cmd == "x" {
+            return Ok(());
+        }
+    }
+}

--- a/dnp3/src/app/attr.rs
+++ b/dnp3/src/app/attr.rs
@@ -892,10 +892,7 @@ impl<'a> Iterator for VariationListIter<'a> {
         let variation = *self.data.first()?;
         let prop = *self.data.get(1)?;
 
-        self.data = match self.data.get(2..) {
-            Some(x) => x,
-            None => &[],
-        };
+        self.data = self.data.get(2..).unwrap_or_default();
 
         Some(AttrItem {
             variation,

--- a/dnp3/src/app/timeout.rs
+++ b/dnp3/src/app/timeout.rs
@@ -1,14 +1,19 @@
 use std::time::Duration;
 
-/// A wrapper around a std::time::Duration
-/// that ensures values are in the range `[1ms .. 1hour]`
+/// A wrapper around a std::time::Duration that ensures values are in the range `[1ms .. 1hour]`
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
 #[cfg_attr(feature = "serialization", serde(try_from = "Duration"))]
-pub struct Timeout(pub(crate) Duration);
+pub struct Timeout(Duration);
+
+impl From<Timeout> for Duration {
+    fn from(value: Timeout) -> Self {
+        value.0
+    }
+}
 
 impl Default for Timeout {
     fn default() -> Self {

--- a/dnp3/src/app/timeout.rs
+++ b/dnp3/src/app/timeout.rs
@@ -44,6 +44,19 @@ impl Timeout {
     /// maximum allowed timeout value as a duration
     pub const MAX: Duration = Duration::from_secs(60 * 60); // one hour
 
+    /// construct from a duration, saturating at the minimum and maximum
+    pub fn saturating(value: Duration) -> Self {
+        if value < Self::MIN {
+            return Self(Self::MIN);
+        }
+
+        if value > Self::MAX {
+            return Self(Self::MAX);
+        }
+
+        Self(value)
+    }
+
     /// try to construct a `Timeout` from a count of seconds
     ///
     /// returns a `RangeError` is < `Timeout::MIN` or > `Timeout::MAX`

--- a/dnp3/src/app/timeout.rs
+++ b/dnp3/src/app/timeout.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
     derive(serde::Serialize, serde::Deserialize)
 )]
 #[cfg_attr(feature = "serialization", serde(try_from = "Duration"))]
-pub struct Timeout(Duration);
+pub struct Timeout(pub(crate) Duration);
 
 impl From<Timeout> for Duration {
     fn from(value: Timeout) -> Self {

--- a/dnp3/src/link/layer.rs
+++ b/dnp3/src/link/layer.rs
@@ -56,6 +56,10 @@ impl Layer {
         }
     }
 
+    pub(crate) fn seed(&mut self, seed_data: &[u8]) -> Result<(), scursor::WriteError> {
+        self.reader.seed(seed_data)
+    }
+
     pub(crate) fn reset(&mut self) {
         self.secondary_state = SecondaryState::NotReset;
         self.reader.reset();

--- a/dnp3/src/link/reader.rs
+++ b/dnp3/src/link/reader.rs
@@ -1,5 +1,3 @@
-use std::io::ErrorKind;
-
 use crate::decode::DecodeLevel;
 use crate::link::display::LinkDisplay;
 use crate::link::error::LinkError;
@@ -196,10 +194,6 @@ impl Reader {
 
         // now we can read more data
         let (count, addr) = io.read(self.buffer.writable(), level.physical).await?;
-
-        if count == 0 {
-            return Err(LinkError::Stdio(ErrorKind::UnexpectedEof));
-        }
 
         self.buffer.advance_write(count);
         Ok(addr)

--- a/dnp3/src/link/reader.rs
+++ b/dnp3/src/link/reader.rs
@@ -7,7 +7,7 @@ use crate::link::{LinkErrorMode, LinkReadMode};
 use crate::util::phys::{PhysAddr, PhysLayer};
 
 use crate::link;
-use scursor::ReadCursor;
+use scursor::{ReadCursor, WriteCursor};
 
 /// How many link frames might be required to transport this much application data?
 const fn num_link_frames(fragment_size: usize) -> usize {
@@ -138,6 +138,13 @@ impl Reader {
             parser: Parser::new(link_modes.error_mode),
             buffer: ReadBuffer::new(buffer_size),
         }
+    }
+
+    pub(crate) fn seed(&mut self, seed_data: &[u8]) -> Result<(), scursor::WriteError> {
+        let mut cursor = WriteCursor::new(self.buffer.writable());
+        cursor.write_bytes(seed_data)?;
+        self.buffer.advance_write(seed_data.len());
+        Ok(())
     }
 
     pub(crate) fn reset(&mut self) {

--- a/dnp3/src/master/task.rs
+++ b/dnp3/src/master/task.rs
@@ -52,6 +52,10 @@ impl MasterTask {
         }
     }
 
+    pub(crate) fn seed_link(&mut self, seed_data: &[u8]) -> Result<(), scursor::WriteError> {
+        self.reader.seed_link(seed_data)
+    }
+
     #[cfg(test)]
     pub(crate) fn set_rx_frame_info(&mut self, info: crate::link::header::FrameInfo) {
         self.reader.get_inner().set_rx_frame_info(info);

--- a/dnp3/src/outstation/control/select.rs
+++ b/dnp3/src/outstation/control/select.rs
@@ -68,7 +68,7 @@ impl SelectState {
                 return Err(CommandStatus::Timeout);
             }
             Some(elapsed) => {
-                if elapsed > timeout.0 {
+                if elapsed > timeout.into() {
                     tracing::warn!("received valid OPERATE after SELECT timeout");
                     return Err(CommandStatus::Timeout);
                 }

--- a/dnp3/src/outstation/database/details/event/buffer.rs
+++ b/dnp3/src/outstation/database/details/event/buffer.rs
@@ -682,7 +682,7 @@ impl EventBuffer {
             .events
             .iter()
             .filter(|(_, e)| e.state.get() == EventState::Unselected && selector(e))
-            .take(limit.unwrap_or(usize::max_value()))
+            .take(limit.unwrap_or(usize::MAX))
         {
             evt.state.set(EventState::Selected);
             count += 1;

--- a/dnp3/src/outstation/database/details/event/write_fn.rs
+++ b/dnp3/src/outstation/database/details/event/write_fn.rs
@@ -66,7 +66,7 @@ where
     let difference: u64 = time.timestamp().raw_value() - cto.timestamp().raw_value();
 
     // too big of a difference to encode
-    if difference > u16::max_value().into() {
+    if difference > u16::MAX.into() {
         return Ok(Continue::NewHeader);
     }
 

--- a/dnp3/src/tcp/master/mod.rs
+++ b/dnp3/src/tcp/master/mod.rs
@@ -1,2 +1,5 @@
 mod client;
+mod server;
+
 pub use client::*;
+pub use server::*;

--- a/dnp3/src/tcp/master/server.rs
+++ b/dnp3/src/tcp/master/server.rs
@@ -34,7 +34,7 @@ pub struct LinkIdConfig {
 }
 
 impl LinkIdConfig {
-    /// Initial with default values:
+    /// Initialize with default values:
     ///
     /// * max_tasks = 16
     /// * timeout = 5 seconds

--- a/dnp3/src/tcp/master/server.rs
+++ b/dnp3/src/tcp/master/server.rs
@@ -1,0 +1,131 @@
+use crate::app::Shutdown;
+use crate::link::reader::LinkModes;
+use crate::link::LinkErrorMode;
+use crate::master::task::MasterTask;
+use crate::master::{MasterChannel, MasterChannelConfig, MasterChannelType};
+use crate::util::phys::PhysLayer;
+use crate::util::session::{Enabled, Session};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tracing::Instrument;
+
+/// Spawn a TCP server that accept connections from outstations
+///
+///
+pub async fn spawn_master_tcp_server(
+    addr: SocketAddr,
+    handler: Box<dyn ConnectionHandler>,
+) -> std::io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+
+    let accept_task = AcceptTask {
+        conn_id: 0,
+        listener,
+        handler,
+    };
+
+    let task = async move {
+        let _ = accept_task
+            .run()
+            .instrument(tracing::info_span!("master-tcp-server", addr = ?addr))
+            .await;
+    };
+
+    tokio::spawn(task);
+
+    Ok(())
+}
+
+/// Determines what action will be taken when a TCP connection is accepted
+#[derive(Copy, Clone, Debug)]
+pub enum AcceptAction {
+    /// Reject the connection, the socket will be closed
+    Reject,
+    //WaitForLinkMessage(Timeout),
+    /// Accept the connection
+    Accept {
+        /// Configuration for the channel
+        config: MasterChannelConfig,
+        /// Link error mode that will be used
+        error_mode: LinkErrorMode,
+    },
+}
+
+/// Callbacks to user code that determine how the server processes connections
+pub trait ConnectionHandler: Send {
+    /// Filter the connection solely based on the remote address
+    fn accept(&mut self, addr: SocketAddr) -> AcceptAction;
+
+    /// Start a communication session that was previously accepted
+    ///
+    /// The user may add associations to the channel and then enable it
+    fn start(&mut self, channel: MasterChannel, addr: SocketAddr);
+}
+
+struct AcceptTask {
+    conn_id: u64,
+    listener: TcpListener,
+    handler: Box<dyn ConnectionHandler>,
+}
+
+impl AcceptTask {
+    async fn run(mut self) -> std::io::Result<()> {
+        loop {
+            self.accept_one().await?;
+        }
+    }
+
+    fn next_conn_id(&mut self) -> u64 {
+        let ret = self.conn_id;
+        self.conn_id += 1;
+        ret
+    }
+
+    async fn accept_one(&mut self) -> std::io::Result<()> {
+        let (stream, addr) = self.listener.accept().await?;
+
+        let (config, error_mode) = match self.handler.accept(addr) {
+            AcceptAction::Reject => {
+                tracing::info!("rejected connection from {addr}");
+                return Ok(());
+            }
+            AcceptAction::Accept { config, error_mode } => (config, error_mode),
+        };
+
+        let conn_id = self.next_conn_id();
+        let (tx, rx) = crate::util::channel::request_channel();
+        let task = MasterTask::new(Enabled::No, LinkModes::stream(error_mode), config, rx);
+
+        let task = SessionTask {
+            phys: PhysLayer::Tcp(stream),
+            session: Session::master(task),
+        };
+
+        let future = async move {
+            let _ = task.run().await;
+        }
+        .instrument(tracing::info_span!("master-session", remote = ?addr, conn = conn_id));
+
+        tokio::spawn(future);
+
+        let channel = MasterChannel::new(tx, MasterChannelType::Stream);
+
+        self.handler.start(channel, addr);
+
+        Ok(())
+    }
+}
+
+struct SessionTask {
+    phys: PhysLayer,
+    session: Session,
+}
+
+impl SessionTask {
+    async fn run(mut self) -> Result<(), Shutdown> {
+        self.session.wait_for_enabled().await?;
+        let err = self.session.run(&mut self.phys).await;
+        tracing::info!("closing: {err}");
+        Ok(())
+    }
+}

--- a/dnp3/src/tcp/master/server.rs
+++ b/dnp3/src/tcp/master/server.rs
@@ -221,6 +221,7 @@ impl<C: ConnectionHandler> AcceptTask<C> {
     async fn process_event(&mut self, event: TaskEvent) {
         match event {
             TaskEvent::Accept(stream, addr) => {
+                tracing::info!("accepted connection from {addr:?}");
                 self.handle_accept(stream, addr).await;
             }
             TaskEvent::LinkId(res) => {

--- a/dnp3/src/tcp/master/server.rs
+++ b/dnp3/src/tcp/master/server.rs
@@ -34,6 +34,19 @@ pub struct LinkIdConfig {
 }
 
 impl LinkIdConfig {
+    /// Initial with default values:
+    ///
+    /// * max_tasks = 16
+    /// * timeout = 5 seconds
+    /// * decode_level = Nothing
+    pub fn new() -> Self {
+        Self {
+            max_tasks: NonZeroUsize::new(16).unwrap(),
+            timeout: Timeout::from_secs(5).unwrap(),
+            decode_level: PhysDecodeLevel::Nothing,
+        }
+    }
+
     /// Set the maximum number of simultaneous tasks used to perform link identification
     ///
     /// New connections are until a task is available
@@ -57,11 +70,7 @@ impl LinkIdConfig {
 
 impl Default for LinkIdConfig {
     fn default() -> Self {
-        Self {
-            max_tasks: NonZeroUsize::new(16).unwrap(),
-            timeout: Timeout::from_secs(5).unwrap(),
-            decode_level: PhysDecodeLevel::Nothing,
-        }
+        Self::new()
     }
 }
 

--- a/dnp3/src/tcp/mod.rs
+++ b/dnp3/src/tcp/mod.rs
@@ -3,6 +3,7 @@ pub use endpoint_list::*;
 pub use master::*;
 pub use no_delay::*;
 pub use outstation::*;
+pub use server_handle::*;
 
 /// Entry points and types for TLS
 #[cfg(feature = "tls")]
@@ -13,6 +14,7 @@ mod endpoint_list;
 mod master;
 mod no_delay;
 mod outstation;
+mod server_handle;
 
 pub(crate) mod client;
 

--- a/dnp3/src/tcp/server_handle.rs
+++ b/dnp3/src/tcp/server_handle.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 /// Handle to a running TCP or TLS server. Dropping the handle shuts down the server.
 pub struct ServerHandle {
     pub(crate) addr: Option<SocketAddr>,
-    pub(crate) _tx: tokio::sync::oneshot::Sender<()>,
+    pub(crate) _token: crate::util::shutdown::ShutdownToken,
 }
 
 impl ServerHandle {

--- a/dnp3/src/tcp/server_handle.rs
+++ b/dnp3/src/tcp/server_handle.rs
@@ -1,0 +1,16 @@
+use std::net::SocketAddr;
+
+/// Handle to a running TCP or TLS server. Dropping the handle shuts down the server.
+pub struct ServerHandle {
+    pub(crate) addr: Option<SocketAddr>,
+    pub(crate) _tx: tokio::sync::oneshot::Sender<()>,
+}
+
+impl ServerHandle {
+    /// Returns the local address to which this server is bound.
+    ///
+    /// This can be useful, for example, when binding to port 0 to figure out which port was actually bound.
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.addr
+    }
+}

--- a/dnp3/src/transport/mock/reader.rs
+++ b/dnp3/src/transport/mock/reader.rs
@@ -50,6 +50,10 @@ impl MockReader {
 
     pub(crate) fn reset(&mut self) {}
 
+    pub(crate) fn seed_link(&mut self, _: &[u8]) -> Result<(), scursor::WriteError> {
+        unimplemented!()
+    }
+
     pub(crate) fn peek(&self) -> Option<TransportData> {
         Some(TransportData::Fragment(self.get(self.count)?))
     }

--- a/dnp3/src/transport/reader.rs
+++ b/dnp3/src/transport/reader.rs
@@ -79,6 +79,10 @@ impl TransportReader {
         &mut self.inner
     }
 
+    pub(crate) fn seed_link(&mut self, seed_data: &[u8]) -> Result<(), scursor::WriteError> {
+        self.inner.seed_link(seed_data)
+    }
+
     pub(crate) async fn read(
         &mut self,
         io: &mut PhysLayer,

--- a/dnp3/src/transport/real/reader.rs
+++ b/dnp3/src/transport/real/reader.rs
@@ -78,6 +78,10 @@ impl Reader {
         self.assembler.peek().map(TransportData::Fragment)
     }
 
+    pub(crate) fn seed_link(&mut self, seed_data: &[u8]) -> Result<(), scursor::WriteError> {
+        self.link.seed(seed_data)
+    }
+
     pub(crate) async fn read(
         &mut self,
         io: &mut PhysLayer,

--- a/dnp3/src/udp/task.rs
+++ b/dnp3/src/udp/task.rs
@@ -18,7 +18,7 @@ impl UdpTask {
         loop {
             self.session.wait_for_enabled().await?;
             if let Delay::Yes = self.run_one().await? {
-                if let Err(reason) = self.session.wait_for_retry(self.retry_delay.0).await {
+                if let Err(reason) = self.session.wait_for_retry(self.retry_delay.into()).await {
                     Self::handle_stop(reason)?;
                 }
             }

--- a/dnp3/src/util/future.rs
+++ b/dnp3/src/util/future.rs
@@ -1,15 +1,20 @@
+use std::marker::PhantomData;
 use std::task::Context;
 
-struct NeverReady;
+struct NeverReady<T> {
+    _phantom: PhantomData<T>,
+}
 
-impl std::future::Future for NeverReady {
-    type Output = ();
+impl<T> std::future::Future for NeverReady<T> {
+    type Output = T;
 
     fn poll(self: std::pin::Pin<&mut Self>, _: &mut Context<'_>) -> std::task::Poll<Self::Output> {
         std::task::Poll::Pending
     }
 }
 
-pub(crate) fn forever() -> impl std::future::Future<Output = ()> {
-    NeverReady {}
+pub(crate) fn forever<T>() -> impl std::future::Future<Output = T> {
+    NeverReady::<T> {
+        _phantom: Default::default(),
+    }
 }

--- a/dnp3/src/util/mod.rs
+++ b/dnp3/src/util/mod.rs
@@ -5,8 +5,8 @@ pub(crate) mod decode;
 pub(crate) mod future;
 pub(crate) mod phys;
 pub(crate) mod session;
+pub(crate) mod shutdown;
 pub(crate) mod slice_ext;
-
 pub(crate) struct Smallest<T>
 where
     T: Copy + PartialOrd,

--- a/dnp3/src/util/phys.rs
+++ b/dnp3/src/util/phys.rs
@@ -1,4 +1,5 @@
 use crate::decode::PhysDecodeLevel;
+use std::io::ErrorKind;
 use std::net::SocketAddr;
 
 use crate::udp::layer::UdpLayer;
@@ -69,6 +70,13 @@ impl PhysLayer {
                 (count, PhysAddr::None)
             }
         };
+
+        if length == 0 {
+            return Err(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "read return 0",
+            ));
+        }
 
         if level.enabled() {
             if let Some(x) = buffer.get(0..length) {

--- a/dnp3/src/util/session.rs
+++ b/dnp3/src/util/session.rs
@@ -21,6 +21,15 @@ pub(crate) enum StopReason {
     Shutdown,
 }
 
+impl std::fmt::Display for StopReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            StopReason::Disable => write!(f, "disabled"),
+            StopReason::Shutdown => write!(f, "shutdown"),
+        }
+    }
+}
+
 /// Communication sessions might terminate due to being explicitly stopped or because their was some I/O error
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum RunError {
@@ -28,6 +37,15 @@ pub(crate) enum RunError {
     Stop(StopReason),
     /// Error occurred due to underlying I/O or bad link data
     Link(LinkError),
+}
+
+impl std::fmt::Display for RunError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RunError::Stop(err) => write!(f, "{err}"),
+            RunError::Link(err) => write!(f, "{err}"),
+        }
+    }
 }
 
 impl From<Shutdown> for StopReason {

--- a/dnp3/src/util/shutdown.rs
+++ b/dnp3/src/util/shutdown.rs
@@ -1,0 +1,29 @@
+/// Create a shutdown token/listener pair
+pub(crate) fn shutdown_token() -> (ShutdownToken, ShutdownListener) {
+    let (tx, rx) = tokio::sync::watch::channel(());
+    (ShutdownToken { _inner: tx }, ShutdownListener { inner: rx })
+}
+
+/// An opaque token, that when dropped, causes every [`ShutdownListener`] to be notified
+pub(crate) struct ShutdownToken {
+    _inner: tokio::sync::watch::Sender<()>,
+}
+
+/// Component which can be used to asynchronously listen for shutdown
+#[derive(Clone)]
+pub(crate) struct ShutdownListener {
+    inner: tokio::sync::watch::Receiver<()>,
+}
+
+impl ShutdownListener {
+    /// Listen for the paired [`ShutdownToken`] to be dropped
+    pub(crate) async fn listen(&mut self) {
+        loop {
+            match self.inner.changed().await {
+                Ok(()) => {}
+                // indicates that the sender was dropped
+                Err(_) => return,
+            }
+        }
+    }
+}

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/MasterTcpServerExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/MasterTcpServerExample.java
@@ -1,0 +1,37 @@
+package io.stepfunc.dnp3.examples;
+
+import io.stepfunc.dnp3.*;
+import io.stepfunc.dnp3.Runtime;
+import org.joou.UShort;
+
+class ConnectionHandler implements io.stepfunc.dnp3.ConnectionHandler {
+
+    @Override
+    public void accept(String remoteAddr, AcceptHandler acceptor) {
+
+    }
+
+    @Override
+    public void start(String remoteAddr, MasterChannel channel) {
+
+    }
+
+    @Override
+    public void acceptWithLinkId(String remoteAddr, UShort source, UShort destination, IdentifiedLinkHandler acceptor) {
+
+    }
+
+    @Override
+    public void startWithLinkId(String remoteAddr, UShort source, UShort destination, MasterChannel channel) {
+
+    }
+}
+
+public class MasterTcpServerExample {
+    public static void main(String[] args) throws Exception {
+
+        Logging.configure(new LoggingConfig(), new ConsoleLogger());
+        final Runtime runtime = new Runtime(new RuntimeConfig());
+
+    }
+}

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/MasterTcpServerExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/dnp3/examples/MasterTcpServerExample.java
@@ -2,28 +2,63 @@ package io.stepfunc.dnp3.examples;
 
 import io.stepfunc.dnp3.*;
 import io.stepfunc.dnp3.Runtime;
+import org.joou.UByte;
 import org.joou.UShort;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+class StartRequest {
+    final MasterChannel channel;
+    final UShort destination;
+    final UShort source;
+
+    StartRequest(MasterChannel channel, UShort destination, UShort source) {
+        this.channel = channel;
+        this.destination = destination;
+        this.source = source;
+    }
+}
 
 class ConnectionHandler implements io.stepfunc.dnp3.ConnectionHandler {
 
+    final BlockingQueue<StartRequest> queue;
+
+    ConnectionHandler(BlockingQueue<StartRequest> queue) {
+        this.queue = queue;
+    }
+
     @Override
     public void accept(String remoteAddr, AcceptHandler acceptor) {
-
+        acceptor.getLinkIdentity();
     }
 
     @Override
     public void start(String remoteAddr, MasterChannel channel) {
-
+        // this should not be called since we always ask for the link identity
+        channel.shutdown();
     }
 
     @Override
     public void acceptWithLinkId(String remoteAddr, UShort source, UShort destination, IdentifiedLinkHandler acceptor) {
-
+        MasterChannelConfig config = new MasterChannelConfig(destination);
+        config.decodeLevel.application = AppDecodeLevel.OBJECT_VALUES;
+        acceptor.accept(LinkErrorMode.CLOSE, config);
     }
 
     @Override
     public void startWithLinkId(String remoteAddr, UShort source, UShort destination, MasterChannel channel) {
-
+        try {
+            //  We defer the handling of connections to the main loop...
+            //  We can't call any of the methods on channel like addAssociation b/c this callback is from Tokio
+            this.queue.put(new StartRequest(channel, destination, source));
+        }
+        catch (InterruptedException ignored) {
+            
+        }
     }
 }
 
@@ -32,6 +67,65 @@ public class MasterTcpServerExample {
 
         Logging.configure(new LoggingConfig(), new ConsoleLogger());
         final Runtime runtime = new Runtime(new RuntimeConfig());
+
+        final BlockingQueue<StartRequest> queue = new ArrayBlockingQueue<>(16);
+        final ConnectionHandler handler = new ConnectionHandler(queue);
+        final HashMap<UShort, MasterChannel> channels = new HashMap<>();
+
+        try (MasterServer server = MasterServer.createTcpServer(runtime, "127.0.0.1:20000", new LinkIdConfig(), handler)) {
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+            while(true) {
+                final StartRequest request = queue.take();
+                System.out.println("Accept with source == " + request.source + " destination == " + request.destination);
+                final MasterChannel previous = channels.put(request.source, request.channel);
+                if(previous != null) {
+                    previous.shutdown();
+                }
+                request.channel.addAssociation(
+                        request.source,
+                        new AssociationConfig(
+                                EventClasses.all(),
+                                EventClasses.all(),
+                                Classes.all(),
+                                EventClasses.none()
+                        ),
+                        new NullReadHandler(),
+                        new NullAssocHandler(),
+                        new NullAssocInfo()
+                );
+                request.channel.enable();
+            }
+        }
+
+    }
+}
+
+class NullReadHandler implements ReadHandler {}
+class NullAssocHandler implements AssociationHandler {
+    @Override
+    public UtcTimestamp getCurrentTime() {
+        return UtcTimestamp.invalid();
+    }
+}
+class NullAssocInfo implements AssociationInformation {
+
+    @Override
+    public void taskStart(TaskType taskType, FunctionCode functionCode, UByte seq) {
+
+    }
+
+    @Override
+    public void taskSuccess(TaskType taskType, FunctionCode functionCode, UByte seq) {
+
+    }
+
+    @Override
+    public void taskFail(TaskType taskType, TaskError error) {
+
+    }
+
+    @Override
+    public void unsolicitedResponse(boolean isDuplicate, UByte seq) {
 
     }
 }

--- a/ffi/dnp3-ffi/src/master/mod.rs
+++ b/ffi/dnp3-ffi/src/master/mod.rs
@@ -1,4 +1,6 @@
 mod functions;
 mod futures;
+mod server;
 
 pub use functions::*;
+pub use server::*;

--- a/ffi/dnp3-ffi/src/master/server.rs
+++ b/ffi/dnp3-ffi/src/master/server.rs
@@ -1,6 +1,15 @@
 use crate::ffi;
 use crate::ffi::ParamError;
-use dnp3::tcp::{AcceptAction, AcceptConfig};
+use dnp3::app::Timeout;
+use dnp3::master::MasterChannel;
+use dnp3::tcp::{AcceptAction, AcceptConfig, LinkIdConfig, Reject, ServerHandle};
+use std::ffi::{CStr, CString};
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+
+pub struct MasterServer {
+    _handle: ServerHandle,
+}
 
 pub struct AcceptHandler {
     action: Option<AcceptAction>,
@@ -8,6 +17,26 @@ pub struct AcceptHandler {
 
 pub struct IdentifiedLinkHandler {
     action: Option<AcceptConfig>,
+}
+
+pub(crate) unsafe fn master_server_destroy(instance: *mut MasterServer) {
+    if !instance.is_null() {
+        drop(Box::from_raw(instance));
+    }
+}
+
+pub(crate) unsafe fn create_master_tcp_server(
+    runtime: *mut crate::Runtime,
+    local_addr: &CStr,
+    link_id_config: ffi::LinkIdConfig,
+    connection_handler: ffi::ConnectionHandler,
+) -> Result<*mut MasterServer, ParamError> {
+    let runtime = runtime.as_ref().ok_or(ParamError::NullParameter)?;
+    let local_addr: SocketAddr = local_addr.to_str()?.parse()?;
+    let link_id_config: LinkIdConfig = link_id_config.into();
+    let future = dnp3::tcp::spawn_master_tcp_server(local_addr, link_id_config, connection_handler);
+    let handle = runtime.handle().block_on(future)??;
+    Ok(Box::into_raw(Box::new(MasterServer { _handle: handle })))
 }
 
 pub unsafe fn accept_handler_accept(
@@ -71,4 +100,86 @@ pub unsafe fn accept_handler_get_link_identity(instance: *mut AcceptHandler) -> 
     handler.action = Some(AcceptAction::GetLinkIdentity);
 
     ParamError::Ok
+}
+
+impl From<ffi::LinkIdConfig> for LinkIdConfig {
+    fn from(value: ffi::LinkIdConfig) -> Self {
+        LinkIdConfig::new()
+            .max_tasks(
+                NonZeroUsize::new(value.max_tasks.into()).unwrap_or(NonZeroUsize::new(1).unwrap()),
+            )
+            .timeout(Timeout::saturating(value.timeout()))
+            .decode_level(value.decode_level().into())
+    }
+}
+
+impl dnp3::tcp::ConnectionHandler for ffi::ConnectionHandler {
+    async fn accept(&mut self, addr: SocketAddr) -> Result<AcceptAction, Reject> {
+        let mut handler = AcceptHandler { action: None };
+        let addr = CString::new(addr.to_string()).map_err(|_| Reject)?;
+        Self::accept(self, &addr, &mut handler);
+        match handler.action {
+            None => Err(Reject),
+            Some(x) => Ok(x),
+        }
+    }
+
+    async fn start(&mut self, channel: MasterChannel, addr: SocketAddr) {
+        let addr = match CString::new(addr.to_string()) {
+            Ok(x) => x,
+            Err(_) => return,
+        };
+
+        let runtime = tokio::runtime::Handle::current();
+
+        let channel = crate::MasterChannel {
+            runtime: crate::RuntimeHandle::new(runtime),
+            handle: channel,
+        };
+
+        Self::start(self, &addr, Box::into_raw(Box::new(channel)));
+    }
+
+    async fn accept_link_id(
+        &mut self,
+        addr: SocketAddr,
+        source: u16,
+        destination: u16,
+    ) -> Result<AcceptConfig, Reject> {
+        let mut handler = IdentifiedLinkHandler { action: None };
+        let addr = CString::new(addr.to_string()).map_err(|_| Reject)?;
+        Self::accept_with_link_id(self, &addr, source, destination, &mut handler);
+        match handler.action {
+            None => Err(Reject),
+            Some(x) => Ok(x),
+        }
+    }
+
+    async fn start_with_link_id(
+        &mut self,
+        channel: MasterChannel,
+        addr: SocketAddr,
+        source: u16,
+        destination: u16,
+    ) {
+        let addr = match CString::new(addr.to_string()) {
+            Ok(x) => x,
+            Err(_) => return,
+        };
+
+        let runtime = tokio::runtime::Handle::current();
+
+        let channel = crate::MasterChannel {
+            runtime: crate::RuntimeHandle::new(runtime),
+            handle: channel,
+        };
+
+        Self::start_with_link_id(
+            self,
+            &addr,
+            source,
+            destination,
+            Box::into_raw(Box::new(channel)),
+        );
+    }
 }

--- a/ffi/dnp3-ffi/src/master/server.rs
+++ b/ffi/dnp3-ffi/src/master/server.rs
@@ -1,0 +1,74 @@
+use crate::ffi;
+use crate::ffi::ParamError;
+use dnp3::tcp::{AcceptAction, AcceptConfig};
+
+pub struct AcceptHandler {
+    action: Option<AcceptAction>,
+}
+
+pub struct IdentifiedLinkHandler {
+    action: Option<AcceptConfig>,
+}
+
+pub unsafe fn accept_handler_accept(
+    instance: *mut AcceptHandler,
+    error_mode: ffi::LinkErrorMode,
+    config: ffi::MasterChannelConfig,
+) -> ParamError {
+    unsafe fn inner(
+        instance: *mut AcceptHandler,
+        error_mode: ffi::LinkErrorMode,
+        config: ffi::MasterChannelConfig,
+    ) -> Result<(), ParamError> {
+        let handler = instance.as_mut().ok_or(ParamError::NullParameter)?;
+
+        handler.action = Some(AcceptAction::Accept(AcceptConfig {
+            error_mode: error_mode.into(),
+            config: config.try_into()?,
+        }));
+
+        Ok(())
+    }
+
+    match inner(instance, error_mode, config) {
+        Ok(()) => ParamError::Ok,
+        Err(err) => err,
+    }
+}
+
+pub unsafe fn identified_link_handler_accept(
+    instance: *mut IdentifiedLinkHandler,
+    error_mode: ffi::LinkErrorMode,
+    config: ffi::MasterChannelConfig,
+) -> ParamError {
+    unsafe fn inner(
+        instance: *mut IdentifiedLinkHandler,
+        error_mode: ffi::LinkErrorMode,
+        config: ffi::MasterChannelConfig,
+    ) -> Result<(), ParamError> {
+        let handler = instance.as_mut().ok_or(ParamError::NullParameter)?;
+
+        handler.action = Some(AcceptConfig {
+            error_mode: error_mode.into(),
+            config: config.try_into()?,
+        });
+
+        Ok(())
+    }
+
+    match inner(instance, error_mode, config) {
+        Ok(()) => ParamError::Ok,
+        Err(err) => err,
+    }
+}
+
+pub unsafe fn accept_handler_get_link_identity(instance: *mut AcceptHandler) -> ParamError {
+    let handler = match instance.as_mut() {
+        None => return ParamError::NullParameter,
+        Some(x) => x,
+    };
+
+    handler.action = Some(AcceptAction::GetLinkIdentity);
+
+    ParamError::Ok
+}

--- a/ffi/dnp3-schema/src/master/mod.rs
+++ b/ffi/dnp3-schema/src/master/mod.rs
@@ -14,13 +14,6 @@ pub(crate) fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Ba
 
     let master_channel_class = lib.declare_class("master_channel")?;
 
-    server::define_connection_handler(
-        lib,
-        shared,
-        master_channel_config.clone(),
-        master_channel_class.clone(),
-    )?;
-
     let write_dead_band_request = crate::master::write_dead_band_request::define(lib)?;
     let empty_response_callback = define_empty_response_callback(lib, shared.nothing.clone())?;
 
@@ -207,7 +200,7 @@ pub(crate) fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Ba
         )?
         .param(
             "config",
-            master_channel_config,
+            master_channel_config.clone(),
             "Generic configuration for the channel",
         )?
         .param(
@@ -734,7 +727,7 @@ pub(crate) fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Ba
         .doc("Asynchronously perform a link status check")?
         .build()?;
 
-    lib.define_class(&master_channel_class)?
+    let master_channel_class = lib.define_class(&master_channel_class)?
         .destructor(channel_destructor)?
         .static_method(master_channel_create_tcp_fn)?
         .static_method(master_channel_create_tcp_2_fn)?
@@ -777,6 +770,13 @@ pub(crate) fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Ba
                 .warning("The class methods that return a value (e.g. as {class:master_channel.add_association()}) cannot be called from within a callback.")
         )?
         .build()?;
+
+    server::define_connection_handler(
+        lib,
+        shared,
+        master_channel_config.clone(),
+        master_channel_class.declaration(),
+    )?;
 
     Ok(())
 }

--- a/ffi/dnp3-schema/src/master/mod.rs
+++ b/ffi/dnp3-schema/src/master/mod.rs
@@ -771,7 +771,7 @@ pub(crate) fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Ba
         )?
         .build()?;
 
-    server::define_connection_handler(
+    server::define_server_components(
         lib,
         shared,
         master_channel_config.clone(),

--- a/ffi/dnp3-schema/src/master/mod.rs
+++ b/ffi/dnp3-schema/src/master/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod read_handler;
 pub(crate) mod request;
+pub(crate) mod server;
 pub(crate) mod write_dead_band_request;
 
 use crate::shared::SharedDefinitions;
@@ -12,6 +13,13 @@ pub(crate) fn define(lib: &mut LibraryBuilder, shared: &SharedDefinitions) -> Ba
     let master_channel_config = define_master_channel_config(lib, shared)?;
 
     let master_channel_class = lib.declare_class("master_channel")?;
+
+    server::define_connection_handler(
+        lib,
+        shared,
+        master_channel_config.clone(),
+        master_channel_class.clone(),
+    )?;
 
     let write_dead_band_request = crate::master::write_dead_band_request::define(lib)?;
     let empty_response_callback = define_empty_response_callback(lib, shared.nothing.clone())?;
@@ -931,15 +939,15 @@ fn define_association_config(
 fn define_master_channel_config(
     lib: &mut LibraryBuilder,
     shared: &SharedDefinitions,
-) -> BackTraced<FunctionArgStructHandle> {
-    let config = lib.declare_function_argument_struct("master_channel_config")?;
+) -> BackTraced<UniversalStructHandle> {
+    let config = lib.declare_universal_struct("master_channel_config")?;
 
     let decode_level = Name::create("decode_level")?;
 
     let tx_buffer_size = Name::create("tx_buffer_size")?;
     let rx_buffer_size = Name::create("rx_buffer_size")?;
 
-    let config = lib.define_function_argument_struct(config)?
+    let config = lib.define_universal_struct(config)?
         .doc("Configuration for a MasterChannel that is independent of the physical layer")?
         .add("address", Primitive::U16, "Local DNP3 data-link address")?
         .add(decode_level.clone(), shared.decode_level.clone(), "Decoding level for this master. You can modify this later on with {class:master_channel.set_decode_level()}.")?

--- a/ffi/dnp3-schema/src/master/server.rs
+++ b/ffi/dnp3-schema/src/master/server.rs
@@ -1,7 +1,90 @@
 use crate::shared::SharedDefinitions;
 use oo_bindgen::model::*;
+use std::time::Duration;
 
-pub(crate) fn define_connection_handler(
+pub(crate) fn define_server_components(
+    lib: &mut LibraryBuilder,
+    shared: &SharedDefinitions,
+    master_channel_config: UniversalStructHandle,
+    master_channel: ClassDeclarationHandle,
+) -> BackTraced<()> {
+    let conn_handler =
+        define_connection_handler(lib, shared, master_channel_config, master_channel)?;
+
+    let master_server = lib.declare_class("master_server")?;
+    let link_id_config = define_link_id_config(lib, shared)?;
+
+    let destructor = lib.define_destructor(master_server.clone(), "Shutdown down the server")?;
+
+    let create_tcp_server = lib
+        .define_function("create_master_tcp_server")?
+        .doc(
+            doc("Spawn a TCP server that accepts connections from outstations")
+                .details("The behavior of each connection is controlled by callbacks to a user-defined implementation of a {interface:connection_handler}.")
+        )?
+        .param("runtime", shared.runtime_class.clone(), "Runtime on which to spawn the server")?
+        .param("local_addr", StringType, "Local address on which the server will accept connections")?
+        .param("link_id_config", link_id_config, "Configuration used when identifying outstations based on received link-frames")?
+        .param("connection_handler", conn_handler, " Callbacks used to accept and start communication sessions")?
+        .returns(master_server.clone(), "Handle to the running server that allows it to be shut down")?
+        .fails_with(shared.error_type.clone())?
+        .build_static("create_tcp_server")?;
+
+    let _master_server = lib
+        .define_class(&master_server)?
+        .destructor(destructor)?
+        .disposable_destroy()?
+        .doc("Class with methods used to spawn servers")?
+        .static_method(create_tcp_server)?
+        .build()?;
+
+    Ok(())
+}
+
+fn define_link_id_config(
+    lib: &mut LibraryBuilder,
+    shared: &SharedDefinitions,
+) -> BackTraced<UniversalStructHandle> {
+    let config = lib.declare_universal_struct("link_id_config")?;
+
+    let max_tasks = Name::create("max_tasks")?;
+    let timeout = Name::create("timeout")?;
+    let decode_level = Name::create("decode_level")?;
+
+    let config = lib
+        .define_universal_struct(config)?
+        .doc("Configuration that controls how the server performs remote link identification")?
+        .add(
+            max_tasks.clone(),
+            Primitive::U16,
+            "Set the maximum number of simultaneous tasks used to perform link identification",
+        )?
+        .add(
+            timeout.clone(),
+            DurationType::Milliseconds,
+            "Maximum time period to wait before receiving a link frame from the outstation",
+        )?
+        .add(
+            decode_level.clone(),
+            shared.levels.phys.clone(),
+            "Set the decode level to use when reading the link header used for identification",
+        )?
+        .end_fields()?
+        .begin_initializer(
+            "init",
+            InitializerType::Normal,
+            "Initialize to default values",
+        )?
+        .default(&max_tasks, NumberValue::U16(16))?
+        .default(&timeout, Duration::from_secs(5))?
+        .default_variant(&decode_level, "nothing")?
+        .end_initializer()?
+        .build()?;
+
+    Ok(config)
+}
+
+fn define_connection_handler(
     lib: &mut LibraryBuilder,
     shared: &SharedDefinitions,
     master_channel_config: UniversalStructHandle,
@@ -68,7 +151,7 @@ fn define_accept_method(
     Ok(accept)
 }
 
-pub(crate) fn define_accept_handler(
+fn define_accept_handler(
     lib: &mut LibraryBuilder,
     shared: &SharedDefinitions,
     master_channel_config: UniversalStructHandle,
@@ -96,7 +179,7 @@ pub(crate) fn define_accept_handler(
     Ok(handler)
 }
 
-pub(crate) fn define_identified_link_handler(
+fn define_identified_link_handler(
     lib: &mut LibraryBuilder,
     shared: &SharedDefinitions,
     master_channel_config: UniversalStructHandle,

--- a/ffi/dnp3-schema/src/master/server.rs
+++ b/ffi/dnp3-schema/src/master/server.rs
@@ -1,0 +1,115 @@
+use crate::shared::SharedDefinitions;
+use oo_bindgen::model::*;
+
+pub(crate) fn define_connection_handler(
+    lib: &mut LibraryBuilder,
+    shared: &SharedDefinitions,
+    master_channel_config: UniversalStructHandle,
+    master_channel: ClassDeclarationHandle,
+) -> BackTraced<AsynchronousInterface> {
+    let accept_handler = define_accept_handler(lib, shared, master_channel_config.clone())?;
+
+    let identify_link_handler =
+        define_identified_link_handler(lib, shared, master_channel_config.clone())?;
+
+    let handler = lib.define_interface(
+        "connection_handler",
+        "Callbacks to user code that determine how the server processes connections",
+    )?
+    // --- accept ---
+    .begin_callback("accept", "Filter the connection solely based on the remote address")?
+    .param("remote_addr", StringType, "Socket address of the remote outstation, e.g. 192.168.0.22:51532")?
+    .param("acceptor", accept_handler.declaration(), "Class used to handle the accept")?
+    .end_callback()?
+    // --- start ---
+    .begin_callback(
+        "start",
+        doc("Start a communication session that was previously accepted using only the socket address").warning("You must add associations and/or enable the channel from a different thread than this callback as those methods cannot be called on the Tokio runtime")
+    )?
+    .param("remote_addr", StringType, "Socket address of the remote outstation, e.g. 192.168.0.22:51532")?
+    .param("channel", master_channel.clone(), "Class used to control the channel")?
+    .end_callback()?
+     // --- accept_with_link_id ---
+    .begin_callback("accept_with_link_id", "Filter the connection based on the source and destination of the first link-layer frame")?
+    .param("remote_addr", StringType, "Socket address of the remote outstation, e.g. 192.168.0.22:51532")?
+    .param("source", Primitive::U16, "Source address from the frame")?
+    .param("destination", Primitive::U16, "Destination address from the frame")?
+    .param("acceptor", identify_link_handler.declaration(), "Class used to handle the accept")?
+    .end_callback()?
+    // --- start_with_link_id ---
+    .begin_callback(
+        "start_with_link_id",
+        doc("Start a communication session that was previously accepted using link identity information.").warning("You must add associations and/or enable the channel from a different thread than this callback as those methods cannot be called on the Tokio runtime")
+    )?
+    .param("remote_addr", StringType, "Socket address of the remote outstation, e.g. 192.168.0.22:51532")?
+    .param("source", Primitive::U16, "Source address from the frame")?
+    .param("destination", Primitive::U16, "Destination address from the frame")?
+    .param("channel", master_channel.clone(), "Class used to control the channel")?
+    .end_callback()?
+    .build_async()?;
+
+    Ok(handler)
+}
+
+fn define_accept_method(
+    lib: &mut LibraryBuilder,
+    class: ClassDeclarationHandle,
+    shared: &SharedDefinitions,
+    master_channel_config: UniversalStructHandle,
+) -> BackTraced<Method<Unvalidated>> {
+    let accept = lib
+        .define_method("accept", class.clone())?
+        .doc("Accept the connection and create a master channel")?
+        .param("error_mode", shared.link_error_mode.clone(), "Error mode to use for the link-layer. This should typically be {enum:link_error_mode.close}")?
+        .param("config", master_channel_config, "Configuration of the channel")?
+        .returns(shared.error_type.clone_enum(), "Enumeration describing the result of the operation")?
+        .build()?;
+
+    Ok(accept)
+}
+
+pub(crate) fn define_accept_handler(
+    lib: &mut LibraryBuilder,
+    shared: &SharedDefinitions,
+    master_channel_config: UniversalStructHandle,
+) -> BackTraced<ClassHandle> {
+    let handler = lib.declare_class("accept_handler")?;
+
+    let accept = define_accept_method(lib, handler.clone(), shared, master_channel_config.clone())?;
+
+    let get_link_identity = lib
+        .define_method("get_link_identity", handler.clone())?
+        .doc(
+            doc("Request that server attempt to identify the outstation by reading a link-layer header from the physical layer within a timeout.")
+                .details("This header is typically the beginning of an unsolicited fragment from the outstation.")
+        )?
+        .returns(shared.error_type.clone_enum(), "Enumeration describing the result of the operation")?
+        .build()?;
+
+    let handler = lib
+        .define_class(&handler)?
+        .doc("Class used to accept a connection, reject it, or defer it to link identification")?
+        .method(accept)?
+        .method(get_link_identity)?
+        .build()?;
+
+    Ok(handler)
+}
+
+pub(crate) fn define_identified_link_handler(
+    lib: &mut LibraryBuilder,
+    shared: &SharedDefinitions,
+    master_channel_config: UniversalStructHandle,
+) -> BackTraced<ClassHandle> {
+    let handler = lib.declare_class("identified_link_handler")?;
+
+    let accept = define_accept_method(lib, handler.clone(), shared, master_channel_config.clone())?;
+
+    let accept_handler = lib
+        .define_class(&handler)?
+        .doc("Class used to accept a connection, reject it, or defer it to link identification")?
+        .method(accept)?
+        .build()?;
+
+    Ok(accept_handler)
+}

--- a/ffi/dnp3-schema/src/shared.rs
+++ b/ffi/dnp3-schema/src/shared.rs
@@ -115,6 +115,10 @@ pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<SharedDefinitions> 
             "wrong_channel_type",
             "This operation cannot be performed on this channel type",
         )?
+        .add_error(
+            "consumed",
+            "This object is consumed and cannot be used again",
+        )?
         .doc("Error type used throughout the library")?
         .build()?;
 

--- a/ffi/dnp3-schema/src/shared.rs
+++ b/ffi/dnp3-schema/src/shared.rs
@@ -1,4 +1,5 @@
 use crate::attributes::DeviceAttrTypes;
+use crate::decoding::DecodeLevels;
 use crate::file::FileDefinitions;
 use crate::gv;
 use oo_bindgen::model::*;
@@ -15,6 +16,7 @@ pub(crate) struct SharedDefinitions {
     pub endpoint_list: ClassHandle,
     pub connect_strategy: FunctionArgStructHandle,
     pub tls_client_config: FunctionArgStructHandle,
+    pub levels: DecodeLevels,
     pub decode_level: UniversalStructHandle,
     pub serial_port_settings: FunctionArgStructHandle,
     pub link_error_mode: EnumHandle,
@@ -125,7 +127,8 @@ pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<SharedDefinitions> 
     let command_status = define_command_status(lib)?;
 
     crate::constants::define(lib)?;
-    let decode_level = crate::decoding::define(lib)?;
+    let levels = crate::decoding::define_levels(lib)?;
+    let decode_level = crate::decoding::define_decode_level_struct(lib, &levels)?;
     let runtime_class = sfio_tokio_ffi::define(lib, error_type.clone())?;
 
     let control_field_struct = lib.declare_callback_argument_struct("control_field")?;
@@ -322,6 +325,7 @@ pub(crate) fn define(lib: &mut LibraryBuilder) -> BackTraced<SharedDefinitions> 
         endpoint_list,
         connect_strategy,
         tls_client_config: tls.tls_client_config,
+        levels,
         decode_level,
         retry_strategy: define_retry_strategy(lib)?,
         serial_port_settings: define_serial_port_settings(lib)?,


### PR DESCRIPTION
Add support for masters acting as TCP servers. Outstation may be identified using either:

1) ip/port of remote host
2) first link-layer header received, typically an unsolicited message

Example code has only been added for Rust and Java ATM.