### PR TITLE
chore: Optimize CI workflow and prepare for 1.7.0-M2 milestone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 on:
   push:
-    branches:
-      - main
     tags:
       - "*"
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+### 1.7.0-M2 ###
+* :shield: Add security policy and automated supply chain scanning. See [#394](https://github.com/stepfunc/dnp3/pull/394).
+* :wrench: Add quality gate to prevent releases when tests fail. See [#393](https://github.com/stepfunc/dnp3/pull/393).
+* :bug: Fix Maven Central deployment issues for post-OSSRH era.
+* :wrench: Refactor release workflow into separate idempotent jobs for improved reliability.
+
 ### 1.7.0-M1 ###
 * :star: Add outstation ConnectionManager with fine-grained connection control for TCP and TLS clients. See [#381](https://github.com/stepfunc/dnp3/pull/381).
   * New Rust API: `spawn_outstation_tcp_client_2()` and `spawn_outstation_tls_client_2()` functions with `ClientConnectionHandler` trait

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # DNP3 Codebase Guidelines
 
+## Git Commit Guidelines
+- **Never take credit**: Do not add "Generated with Claude Code" or "Co-Authored-By: Claude" to commit messages
+- Keep commit messages professional and focused on the changes
+
 ## Build, Test, Lint Commands
 - Build: `cargo build [--features tls,serial,serialization]`
 - Run all tests: `cargo test`


### PR DESCRIPTION
## Summary
- Eliminate redundant CI runs by removing main branch from push triggers
- Update changelog for upcoming 1.7.0-M2 milestone release
- Add commit message guidelines to CLAUDE.md

## Details
With branch protection now enabled on main, all changes must go through PRs. This allows us to remove the main branch from CI push triggers, eliminating duplicate CI runs that occur when PRs are merged.

CI will now run only on:
- Pull requests (validates changes before merge)
- Tags (triggers release workflow)