### PR TITLE
feat: Add support for reading Group 50 Var 1 (absolute time) in master

### DIFF
--- a/dnp3/src/master/extract.rs
+++ b/dnp3/src/master/extract.rs
@@ -1,4 +1,3 @@
-
 use crate::app::gen::count::CountVariation;
 use crate::app::measurement::*;
 use crate::app::parse::count::CountSequence;

--- a/dnp3/src/master/extract.rs
+++ b/dnp3/src/master/extract.rs
@@ -1,10 +1,12 @@
+
 use crate::app::gen::count::CountVariation;
 use crate::app::measurement::*;
+use crate::app::parse::count::CountSequence;
 use crate::app::parse::parser::{HeaderCollection, HeaderDetails, ObjectHeader};
 use crate::app::variations::*;
 use crate::app::ResponseHeader;
-use crate::master::ReadHandler;
 use crate::master::ReadType;
+use crate::master::{HeaderInfo, ReadHandler};
 
 /// Extract measurements from a HeaderCollection, sinking them into
 /// something that implements `MeasurementHandler`
@@ -33,6 +35,22 @@ pub(crate) fn extract_measurements_inner(
         item.map_or(prev, |x| Some(Time::Unsynchronized(x.time)))
     }
 
+    fn extract_g50v1(
+        seq: &CountSequence<Group50Var1>,
+        header: &ObjectHeader,
+        handler: &mut dyn ReadHandler,
+    ) -> bool {
+        if let Some(item) = seq.single() {
+            handler.handle_abs_time(
+                HeaderInfo::new(header.variation, header.details.qualifier(), false, false),
+                item.time,
+            );
+            true
+        } else {
+            false
+        }
+    }
+
     fn handle(
         cto: Option<Time>,
         header: ObjectHeader,
@@ -51,6 +69,13 @@ pub(crate) fn extract_measurements_inner(
             }
             HeaderDetails::TwoByteCount(1, CountVariation::Group51Var2(seq)) => {
                 return extract_cto_g51v2(cto, seq.single())
+            }
+            // handle g50v1 - absolute time (only count == 1 is valid)
+            HeaderDetails::OneByteCount(1, CountVariation::Group50Var1(seq)) => {
+                extract_g50v1(seq, &header, handler)
+            }
+            HeaderDetails::TwoByteCount(1, CountVariation::Group50Var1(seq)) => {
+                extract_g50v1(seq, &header, handler)
             }
             // everything else
             HeaderDetails::OneByteStartStop(_, _, var) => {
@@ -125,6 +150,7 @@ mod test {
         BinaryCommandEvent(Vec<(BinaryOutputCommandEvent, u16)>),
         AnalogCommandEvent(Vec<(AnalogOutputCommandEvent, u16)>),
         G102(Vec<(UnsignedInteger, u16)>),
+        AbsTime(Timestamp),
     }
 
     #[derive(Default)]
@@ -286,6 +312,10 @@ mod test {
                     self.received.push(Header::KnownAttr(known));
                 }
             }
+        }
+
+        fn handle_abs_time(&mut self, _info: HeaderInfo, time: Timestamp) {
+            self.received.push(Header::AbsTime(time));
         }
     }
 
@@ -628,5 +658,82 @@ mod test {
                 (UnsignedInteger { value: 0xCA }, 8)
             ])]
         );
+    }
+
+    #[test]
+    fn handles_g50v1_with_count_1() {
+        let mut handler = MockHandler::new();
+        let objects = HeaderCollection::parse(
+            ParseOptions::default(),
+            FunctionCode::Response,
+            // g50v1       count: 1   -------- time: 0x060504030201 ------------------
+            &[0x32, 0x01, 0x07, 0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
+        )
+        .unwrap();
+
+        extract_measurements_inner(objects, &mut handler);
+
+        assert_eq!(
+            &handler.pop(),
+            &[Header::AbsTime(Timestamp::new(0x060504030201))]
+        );
+    }
+
+    #[test]
+    fn handles_g50v1_with_two_byte_count() {
+        let mut handler = MockHandler::new();
+        let objects = HeaderCollection::parse(
+            ParseOptions::default(),
+            FunctionCode::Response,
+            // g50v1       count: 1 (two bytes)   -------- time: 0xAABBCCDDEEFF ------------------
+            &[
+                0x32, 0x01, 0x08, 0x01, 0x00, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA,
+            ],
+        )
+        .unwrap();
+
+        extract_measurements_inner(objects, &mut handler);
+
+        assert_eq!(
+            &handler.pop(),
+            &[Header::AbsTime(Timestamp::new(0xAABBCCDDEEFF))]
+        );
+    }
+
+    #[test]
+    fn ignores_g50v1_with_count_greater_than_1() {
+        let mut handler = MockHandler::new();
+        let objects = HeaderCollection::parse(
+            ParseOptions::default(),
+            FunctionCode::Response,
+            // g50v1       count: 2   -------- time1 ------ time2 ------
+            &[
+                0x32, 0x01, 0x07, 0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x11, 0x12, 0x13, 0x14,
+                0x15, 0x16,
+            ],
+        )
+        .unwrap();
+
+        extract_measurements_inner(objects, &mut handler);
+
+        // Should not receive any time values since count > 1
+        assert_eq!(&handler.pop(), &[]);
+    }
+
+    #[test]
+    fn handles_g50v1_with_count_0() {
+        let mut handler = MockHandler::new();
+        let objects = HeaderCollection::parse(
+            ParseOptions::default(),
+            FunctionCode::Response,
+            // g50v1       count: 0
+            &[0x32, 0x01, 0x07, 0x00],
+        )
+        .unwrap();
+
+        extract_measurements_inner(objects, &mut handler);
+
+        // Should not receive any time values since count == 0
+        assert_eq!(&handler.pop(), &[]);
     }
 }

--- a/dnp3/src/master/read_handler.rs
+++ b/dnp3/src/master/read_handler.rs
@@ -1,6 +1,6 @@
 use crate::app::attr::{AnyAttribute, Attribute};
 use crate::app::measurement::*;
-use crate::app::{MaybeAsync, QualifierCode, ResponseHeader, Variation};
+use crate::app::{MaybeAsync, QualifierCode, ResponseHeader, Timestamp, Variation};
 
 /// Trait used to process measurement data received from an outstation
 #[allow(unused_variables)]
@@ -128,6 +128,18 @@ pub trait ReadHandler: Send + Sync {
 
     /// Process a device attribute
     fn handle_device_attribute(&mut self, info: HeaderInfo, attr: AnyAttribute) {}
+
+    /// Process an absolute time value (g50v1)
+    ///
+    /// This method is called when the master receives a response containing
+    /// Group 50 Variation 1 (absolute time). The DNP3 specification defines
+    /// g50v1 as representing the current time of the outstation.
+    ///
+    /// Note: While the protocol structure allows for multiple time values,
+    /// semantically only a single absolute time value makes sense. If the
+    /// response contains a count != 1, a warning will be logged and this
+    /// callback will not be invoked.
+    fn handle_abs_time(&mut self, info: HeaderInfo, time: Timestamp) {}
 }
 
 pub(crate) fn handle_attribute(

--- a/ffi/bindings/dotnet/examples/master/Program.cs
+++ b/ffi/bindings/dotnet/examples/master/Program.cs
@@ -243,6 +243,13 @@ class MainClass
         }
 
         
+        public void HandleAbsTime(HeaderInfo info, Timestamp time)
+        {
+            Console.WriteLine("Absolute Time:");
+            Console.WriteLine("Qualifier: " + info.Qualifier);
+            Console.WriteLine("Variation: " + info.Variation);
+            Console.WriteLine($"Time: {time.Value} ({time.Quality})");
+        }
     }
     // ANCHOR_END: read_handler
 

--- a/ffi/dnp3-ffi/src/handler.rs
+++ b/ffi/dnp3-ffi/src/handler.rs
@@ -200,6 +200,14 @@ impl ReadHandler for ffi::ReadHandler {
         ffi::ReadHandler::handle_octet_string(self, info, &mut iterator);
     }
 
+    fn handle_abs_time(&mut self, info: HeaderInfo, time: Timestamp) {
+        let ffi_timestamp = ffi::Timestamp {
+            value: time.raw_value(),
+            quality: ffi::TimeQuality::SynchronizedTime.into(),
+        };
+        ffi::ReadHandler::handle_abs_time(self, info.into(), ffi_timestamp);
+    }
+
     fn handle_device_attribute(&mut self, info: HeaderInfo, attr: AnyAttribute) {
         let info: ffi::HeaderInfo = info.into();
         let (set, var, value) = FfiAttrValue::extract(attr);

--- a/ffi/dnp3-schema/src/master/read_handler.rs
+++ b/ffi/dnp3-schema/src/master/read_handler.rs
@@ -246,6 +246,15 @@ pub(crate) fn define(
         .param("values", shared_def.octet_string_it.clone(), iterator_doc)?
         .returns_nothing_by_default()?
         .end_callback()?
+        .begin_callback("handle_abs_time", "Handle an absolute time value (g50v1)")?
+        .param(
+            "info",
+            header_info.clone(),
+            "Group/variation and qualifier information",
+        )?
+        .param("time", shared_def.timestamp.clone(), "Absolute time value received from the outstation. The quality is always set to synchronized for g50v1.")?
+        .returns_nothing_by_default()?
+        .end_callback()?
         // group 0 callbacks
         .begin_callback("handle_string_attr", "Handle a known or unknown visible string device attribute")?
         .param(


### PR DESCRIPTION
## Summary
Closes #373

This PR adds support for masters to read Group 50 Variation 1 (absolute time) responses from outstations. Previously, while masters could construct requests for g50v1, there was no callback in the ReadHandler to process the response.

## Changes
- Added `handle_abs_time` method to the `ReadHandler` trait that receives a single `Timestamp` value
- Updated extraction logic in `extract.rs` to handle g50v1 responses:
  - Supports both one-byte and two-byte count qualifiers  
  - Only processes headers with count == 1 (semantically correct for absolute time)
  - Logs warnings and ignores headers with count != 1
- Added comprehensive test coverage for g50v1 handling
- Updated FFI bindings for C, .NET, and Java

## Breaking Changes
⚠️ **C# Users**: This is a breaking change. The `IReadHandler` interface now requires implementing the `HandleAbsTime` method. This is because .NET Standard 2.0 (which we target) does not support default interface methods.

C# implementations of `IReadHandler` must add:
```csharp
public void HandleAbsTime(HeaderInfo info, Timestamp time)
{
    // Handle absolute time value
}
```

## Testing
- Added unit tests for all g50v1 scenarios (count=0, count=1, count>1)
- All existing tests pass
- FFI bindings compile and test successfully