### PR TITLE
Make the HeaderInfo constructor public for mockability in tests

### DIFF
--- a/ffi/dnp3-schema/src/master/read_handler.rs
+++ b/ffi/dnp3-schema/src/master/read_handler.rs
@@ -66,6 +66,7 @@ pub(crate) fn define(
         )?
         .doc("Information about the object header and specific variation")?
         .end_fields()?
+        .add_full_initializer("init")?
         .build()?;
 
     let read_type = define_read_type_enum(lib)?;


### PR DESCRIPTION
This was referenced in #384
