### PR TITLE
update rustls-webpki to 0.103.13 to resolve RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` 0.103.12 → 0.103.13 to clear RUSTSEC-2026-0104 (reachable panic in CRL parsing).
- The vulnerable code path is not reached by this codebase — no CRLs are constructed or passed into webpki anywhere in `dnp3`, the FFI bindings, or `sfio-rustls-config`. No runtime exposure for consumers; lockfile-only update to clear the scheduled security audit.