### PR TITLE
[codex] Avoid ranged octet string index overflow

### DIFF
--- a/dnp3/src/app/parse/bytes.rs
+++ b/dnp3/src/app/parse/bytes.rs
@@ -140,7 +140,7 @@ impl<'a> Iterator for RangedBytesIterator<'a> {
         }
         let bytes = self.cursor.read_bytes(self.size).ok()?;
         let index = self.index;
-        self.index += 1;
+        self.index = self.index.saturating_add(1);
         self.remaining -= 1;
         Some((bytes, index))
     }

--- a/dnp3/src/app/parse/parser.rs
+++ b/dnp3/src/app/parse/parser.rs
@@ -1153,6 +1153,25 @@ mod test {
     }
 
     #[test]
+    fn parses_group110var1_at_max_index() {
+        let input = [0x6E, 0x01, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xAA];
+        let mut headers =
+            ObjectParser::parse(ParseOptions::default(), FunctionCode::Response, &input)
+                .unwrap()
+                .iter();
+
+        let bytes: Vec<(&[u8], u16)> = assert_matches!(
+            headers.next().unwrap().details,
+            HeaderDetails::TwoByteStartStop(0xFFFF, 0xFFFF, RangedVariation::Group110VarX(0x01, seq)) => {
+                seq.iter().collect()
+            }
+        );
+
+        assert_eq!(bytes, vec![([0xAA].as_slice(), 0xFFFF)]);
+        assert_matches!(headers.next(), None);
+    }
+
+    #[test]
     fn parses_group111var1_as_non_read() {
         let input = [
             0x6F, 0x01, 0x28, 0x02, 0x00, 0x01, 0x00, 0xAA, 0x02, 0x00, 0xBB,


### PR DESCRIPTION
## Summary

Avoid a debug-build integer overflow when iterating ranged octet string data whose final index is u16::MAX.

The iterator already captured the correct index before incrementing, so release builds wrapped after the last item and still produced the expected output. This change makes the increment explicit and consistent with the generic ranged iterator by using a saturating increment.

It is not a production (release) issue.