### PR TITLE
prepare 1.7.0-RC4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 ### 1.7.0-RC4 ###
-* :lock: Fix inverted `MinTlsVersion` mapping. `MinTlsVersion::V13` previously enabled both TLS 1.2 and 1.3, so it did not exclude TLS 1.2 as documented, and `MinTlsVersion::V12` enabled TLS 1.2 only, disabling TLS 1.3. Both arms now match their documented meaning: `V12` allows TLS 1.2 and 1.3, `V13` allows only TLS 1.3. Affects 1.6.0 through 1.7.0-RC3. See [#437](https://github.com/stepfunc/dnp3/issues/437).
+* :shield: Fix inverted `MinTlsVersion` mapping. `MinTlsVersion::V13` previously enabled both TLS 1.2 and 1.3, so it did not exclude TLS 1.2 as documented, and `MinTlsVersion::V12` enabled TLS 1.2 only, disabling TLS 1.3. Both arms now match their documented meaning: `V12` allows TLS 1.2 and 1.3, `V13` allows only TLS 1.3. Affects 1.6.0 through 1.7.0-RC3. See [#437](https://github.com/stepfunc/dnp3/issues/437).
 * :bell: **Behavior change for existing TLS configurations.** Users who set `V13` were silently permitting TLS 1.2 and will now reject peers that do not support TLS 1.3. Users on the default `V12` (including all bindings users who never overrode it) will now negotiate TLS 1.3 where the peer supports it, rather than being pinned to TLS 1.2.
 
 ### 1.7.0-RC3 ###

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "dnp3"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "dnp3-bindings"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 dependencies = [
  "dnp3-schema",
  "oo-bindgen",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "dnp3-ffi"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 dependencies = [
  "dnp3",
  "dnp3-schema",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "dnp3-ffi-java"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 dependencies = [
  "dnp3-ffi",
  "dnp3-schema",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "dnp3-schema"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 dependencies = [
  "oo-bindgen",
  "sfio-tokio-ffi",

--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.13.4</scala.version>
-        <dnp3.version>1.7.0-RC3</dnp3.version>
+        <dnp3.version>1.7.0-RC4</dnp3.version>
         <dnp4s.version>0.1.0-SNAPSHOT</dnp4s.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
     </properties>

--- a/dnp3/Cargo.toml
+++ b/dnp3/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "dnp3"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 description = "Rust implementation of DNP3 (IEEE 1815) with idiomatic bindings for C, C++, .NET, and Java"

--- a/dnp3/codegen/pom.xml
+++ b/dnp3/codegen/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dev.gridio.dnp3</groupId>
     <artifactId>dnp3-model</artifactId>
-    <version>1.7.0-RC3</version>
+    <version>1.7.0-RC4</version>
     <packaging>jar</packaging>
 
     <name>dnp3-rs model</name>

--- a/ffi/bindings/c/CMakeLists.txt
+++ b/ffi/bindings/c/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(dnp3_c LANGUAGES C CXX)
 
-set(DNP3_BACKUP_VERSION 1.7.0-RC3)
+set(DNP3_BACKUP_VERSION 1.7.0-RC4)
 
 # Determine the architecture
 if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64" AND CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/ffi/bindings/dotnet/examples/master/Master.csproj
+++ b/ffi/bindings/dotnet/examples/master/Master.csproj
@@ -13,7 +13,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="dnp3" Version="1.7.0-RC3" />
+        <PackageReference Include="dnp3" Version="1.7.0-RC4" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/ffi/bindings/dotnet/examples/outstation/Outstation.csproj
+++ b/ffi/bindings/dotnet/examples/outstation/Outstation.csproj
@@ -13,7 +13,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="dnp3" Version="1.7.0-RC3" />
+        <PackageReference Include="dnp3" Version="1.7.0-RC4" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/ffi/bindings/java/examples/pom.xml
+++ b/ffi/bindings/java/examples/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.stepfunc.dnp3</groupId>
     <artifactId>examples</artifactId>
-    <version>1.7.0-RC3</version>
+    <version>1.7.0-RC4</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.stepfunc</groupId>
             <artifactId>dnp3</artifactId>
-            <version>1.7.0-RC3</version>
+            <version>1.7.0-RC4</version>
         </dependency>
     </dependencies>
 </project>

--- a/ffi/bindings/java/pom.xml
+++ b/ffi/bindings/java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.stepfunc</groupId>
     <artifactId>dnp3-parent</artifactId>
-    <version>1.7.0-RC3</version>
+    <version>1.7.0-RC4</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/ffi/dnp3-bindings/Cargo.toml
+++ b/ffi/dnp3-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnp3-bindings"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 
 # inherit from workspace
 rust-version.workspace = true

--- a/ffi/dnp3-ffi-java/Cargo.toml
+++ b/ffi/dnp3-ffi-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnp3-ffi-java"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 build = "build.rs"
 
 # inherit from workspace

--- a/ffi/dnp3-ffi/Cargo.toml
+++ b/ffi/dnp3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnp3-ffi"
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 
 # inherit from workspace
 rust-version.workspace = true

--- a/ffi/dnp3-schema/Cargo.toml
+++ b/ffi/dnp3-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dnp3-schema"
 # this version is what gets applied to the FFI libraries
-version = "1.7.0-RC3"
+version = "1.7.0-RC4"
 
 # inherit from workspace
 rust-version.workspace = true

--- a/guide/sitedata.json
+++ b/guide/sitedata.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.7.0-RC3",
+    "version": "1.7.0-RC4",
     "github_url": "https://github.com/stepfunc/dnp3"
 }


### PR DESCRIPTION
## Summary

Version bump to 1.7.0-RC4 via `./bump-version.sh`, plus one changelog correction.

The RC4 section carries the `MinTlsVersion` fix from #438. Its prefix was `:lock:` on merge; corrected to `:shield:` to match the convention documented in `RELEASE.md`.

No dependency changes — the `Cargo.lock` diff is workspace-internal versions only, consistent with the release policy that RCs after the first take security patches only.